### PR TITLE
bug with load order of JS files?

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -32,11 +32,6 @@ var resolveSinglePattern = function(pattern, done) {
   var finish = function() {
     waiting--;
     if (!waiting) {
-      // sort the results by path,
-      // as the async fs callbacks might return in unpredictable order
-        //results.sort(function(a, b) {
-        //return a.path > b.path;
-    //});
       done(null, results);
     }
   };
@@ -49,16 +44,13 @@ var resolveSinglePattern = function(pattern, done) {
    */
   var processPath = function(path, pointer) {
       waiting++;
-      console.log( "Checking: " + path + " " + pointer );
       var stat = null;
       try {
           stat = fs.statSync(path); //, function(err, stat) {
       } catch(err) {
-          console.log( "Stat failed" );
           finish();
       }
       if( stat ) {
-          console.log( "Stat'ed oK." );
           if (stat.isDirectory()) {
               // end of pattern, we don't want directory...
               if (pointer === parts.length) return finish();
@@ -85,9 +77,6 @@ var resolveSinglePattern = function(pattern, done) {
               if (pointer === parts.length) results.push({path: path, mtime: stat.mtime, isUrl: false});
               return finish();
           }
-      }
-      else {
-          console.log( "Stat undefined" );
       }
   };
 


### PR DESCRIPTION
I think I have identified a bug in testacular.

lib/config.js loads files listed in the config.  The entire final list of files _could_ come back sorted because async callbacks for reading files from a directory can return out of order.

This works if you are using a single directory because the end result is that the file list is sorted alphabetically, which is how we expect a directory listing to return.

However, if you have files which need to be loaded in a specific order, and they are in different directories, it does not always work.

For example, if the testacular.conf config file specifies paths like this:

b/first.js
a/last.js

And, you need to load b/first.js first, and then load a/last.js next, the current implementation of testacular _can_ fail (though might not fail).  It is unfortunately non-deterministic, because the loading of b/first.js could return first, and then sorting does not occur.  But, you could get a situation where the list of files gets returned as [ 'a/last.js', 'b/first.js' ].  If you have defined something in b/first.js that a/last.js depends on, errors occur.

I've forked the repo, and I think the solution is simply to remove the sorting function and load files synchronously.

https://github.com/xrd/testacular
https://github.com/xrd/testacular/blob/master/lib/config.js

I tried to create a repository which shows the failure and uses my patch to show the problem, but since this bug is not guaranteed to occur, it was difficult to isolate in my test example.  But, the repository is here:

https://github.com/xrd/testacular-load-order
(with-patch.js checks out fixed version, runs npm install, and then runs the test and without-patch.js checks out old version (unpatched testacular), npm installs, and runs test...)

Chris
