### PR TITLE
Add support for proxies in Testacular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 adapter/jasmine.js
 adapter/mocha.js
 static/testacular.js
+.idea/*
 tmp/*

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,7 +22,8 @@ var parseConfig = function(configFilePath, cliOptions) {
     autoWatch: false,
     reporter: 'progress',
     singleRun: false,
-    browsers: []
+    browsers: [],
+    proxies: {}
   };
 
   var ADAPTER_DIR = __dirname + '/../adapter';

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,7 +31,7 @@ exports.start = function(configFilePath, cliOptions) {
     watcher.watch(config.files, fileList);
   });
 
-  var webServer = ws.createWebServer(fileList, config.basePath);
+  var webServer = ws.createWebServer(fileList, config.basePath, config.proxies);
   var socketServer = io.listen(webServer, {
     logger: logger.create('socket.io', 0),
     transports: ['websocket', 'xhr-polling', 'jsonp-polling']

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -3,7 +3,9 @@ var fs = require('fs'),
     util = require('util'),
     u = require('./util'),
     path = require('path'),
-    log = require('./logger').create('web server');
+    log = require('./logger').create('web server'),
+    url = require('url'),
+    httpProxy = require('http-proxy');
 
 var SCRIPT_TAG = '<script type="text/javascript" src="%s"></script>';
 var MIME_TYPE = {
@@ -27,11 +29,27 @@ var setNoCacheHeaders = function(response) {
  * /absolute/... (files outside of basePath, absolute paths)
  * /adapter/... (testacular adapters)
  */
-var createHandler = function(fileList, staticFolder, adapterFolder, baseFolder) {
+var createHandler = function(fileList, staticFolder, adapterFolder, baseFolder, proxy, proxies) {
 
   return function(request, response) {
 
     var files = fileList.getFiles();
+
+    var getProxiedPath = function(requestUrl) {
+      var proxiedUrl;
+      if (proxies) {
+        var proxiesList = Object.keys(proxies);
+        proxiesList.sort();
+        proxiesList.reverse();
+        for (var i = 0; i < proxiesList.length; i++) {
+          if (requestUrl.indexOf(proxiesList[i]) == 0) {
+            proxiedUrl = url.parse(proxies[proxiesList[i]]);
+            break;
+          }
+        }
+      }
+      return proxiedUrl;
+    }
 
     // helper for serving static file
     var serveStaticFile = function(file, process) {
@@ -108,7 +126,15 @@ var createHandler = function(fileList, staticFolder, adapterFolder, baseFolder) 
       return file.path === requestedFilePath;
     };
 
-    // not in the file list - forbidden
+    // Check if proxied path, and if so, route it through proxy
+    var proxiedPath = getProxiedPath(request.url);
+    if (proxiedPath) {
+      proxiedPath.port = proxiedPath.port || '80';
+      return proxy.proxyRequest(request, response, {host: proxiedPath.hostname, port: proxiedPath.port});
+    }
+
+
+      // not in the file list - forbidden
     if (!files.some(equalsPath)) {
       response.writeHead(404);
       return response.end('NOT FOUND');
@@ -127,10 +153,12 @@ var createHandler = function(fileList, staticFolder, adapterFolder, baseFolder) 
   };
 };
 
-exports.createWebServer = function(fileList, baseFolder) {
+exports.createWebServer = function (fileList, baseFolder, proxies) {
   var staticFolder = path.normalize(__dirname + '/../static');
   var adapterFolder = path.normalize(__dirname + '/../adapter');
+  var proxy = new httpProxy.RoutingProxy();
 
   return http.createServer(createHandler(fileList, u.normalizeWinPath(staticFolder),
-                                         u.normalizeWinPath(adapterFolder), baseFolder));
+                                         u.normalizeWinPath(adapterFolder), baseFolder,
+                                         proxy, proxies));
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "socket.io": ">= 0.8.5",
     "chokidar": ">=0.3.0",
     "glob": ">=3.1.10",
+    "http-proxy": ">=0.8.2",
     "minimatch": ">=0.2.5",
     "optimist": ">= 0.3.1"
   },

--- a/test/unit/config.spec.coffee
+++ b/test/unit/config.spec.coffee
@@ -129,6 +129,8 @@ describe 'config', ->
       expect(config.singleRun).toBe false
       expect(config.browsers).toEqual []
 
+      expect(config.proxies).toEqual {}
+
       expect(config.LOG_DISABLE).toBeUndefined()
       expect(config.JASMINE).toBeUndefined()
       expect(config.console).toBeUndefined()


### PR DESCRIPTION
Base change which just adds support for multiple proxies in Testacular. Proxies of the form:

proxies: {'/static': 'http://gstatic.com', '/web': 'http://localhost:9000'}

Next change will try and move all testacular stuff into its own subfolder
