### PR TITLE
make lint happy.

### DIFF
--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -42,7 +42,7 @@ var createHandler = function(fileList, staticFolder, adapterFolder, baseFolder, 
         proxiesList.sort();
         proxiesList.reverse();
         for (var i = 0; i < proxiesList.length; i++) {
-          if (requestUrl.indexOf(proxiesList[i]) == 0) {
+          if (requestUrl.indexOf(proxiesList[i]) === 0) {
             proxiedUrl = url.parse(proxies[proxiesList[i]]);
             break;
           }


### PR DESCRIPTION
The command `grunt lint` fails without this.
