### PR TITLE
Fix gh-pages rendering: MarkDotto framing issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,12 +51,6 @@
     <li><a href="https://github.com/vojtajina/testacular/blob/master/CHANGELOG.md">Changelog</a></li>
     <li><a href="https://github.com/vojtajina/testacular/blob/master/README.md">Readme</a></li>
     <li class="divider">&middot;</li>
-    <li>
-      <iframe class="github-btn" src="http://markdotto.github.com/github-buttons/github-btn.html?user=vojtajina&repo=testacular&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
-    </li>
-    <li>
-      <iframe class="github-btn" src="http://markdotto.github.com/github-buttons/github-btn.html?user=vojtajina&repo=testacular&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
-    </li>
     <li class="divider">&middot;</li>
     <li class="follow-btn">
       <a href="https://twitter.com/vojtajina" class="twitter-follow-button" data-width="200px" data-link-color="#0069D6" data-show-count="true">Follow @vojtajina</a>


### PR DESCRIPTION
For some reason, the MarkDotto Github buttons have disappeared. This means that whenever someone visits the gh-pages branch they're redirected to a 404 page by framebusting code. I've just removed the Github buttons to fix the issue.
