### PR TITLE
e2e tests do not run when urlRoot config is set

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
     test: {
       unit: 'test/unit',
       client: 'test/client/config.js',
-      e2e: 'test/e2e/*/testacular.conf.js'
+      e2e: 'test/e2e/*/testacular*.conf.js'
     },
 
     // JSHint options

--- a/test/e2e/angular-scenario/e2eSpec.js
+++ b/test/e2e/angular-scenario/e2eSpec.js
@@ -4,7 +4,7 @@
 describe('My Sample App', function() {
 
   it('should let Angular do its work', function() {
-    browser().navigateTo('/index.html');
+    browser().navigateTo('index.html');
     input('yourName').enter('A Pirate!');
     expect(element('.ng-binding').text()).toEqual('Hello A Pirate!!');
   });

--- a/test/e2e/angular-scenario/testacular.e2eWithUrlRoot.conf.js
+++ b/test/e2e/angular-scenario/testacular.e2eWithUrlRoot.conf.js
@@ -11,5 +11,5 @@ files = [
 autoWatch = true;
 
 proxies = {
-  '/': 'http://localhost:8000/test/e2e/angular-scenario/'
+  '/prefixPath/': 'http://localhost:8000/test/e2e/angular-scenario/'
 };


### PR DESCRIPTION
testacular.js was not determining the correct socket.io endpoint when the urlRoot config option was in use.

This solution requires that you set up your proxies to match the urlRoot configuration:

``` javascript
urlRoot = '/pathPrefix/';

proxies = {
  '/pathPrefix/': 'http://localhost:8000/'
};

```

``` javascript
browser().navigateTo('index.html');
```

or that you navigate using absolute paths in your spec (at least for the first navigation):

``` javascript
urlRoot = '/pathPrefix/';

proxies = {
  '/': 'http://localhost:8000/'
};
```

``` javascript
  browser().navigateTo('/index.html');
```
