### PR TITLE
[mocha] add ability to fail beforeEach/afterEach hooks

### DIFF
--- a/adapter/mocha.src.js
+++ b/adapter/mocha.src.js
@@ -43,7 +43,12 @@ var createMochaReporterConstructor = function(tc) {
     });
 
     runner.on('fail', function(test, error) {
-      test.$errors.push(formatError(error));
+      if ('hook' == test.type || error.uncaught) {
+        test.$errors = [formatError(error)];
+        runner.emit('test end', test);
+      } else {
+        test.$errors.push(formatError(error));
+      }
     });
 
     runner.on('test end', function(test) {

--- a/test/client/mocha.spec.js
+++ b/test/client/mocha.spec.js
@@ -103,5 +103,26 @@ describe('adapter mocha', function() {
         expect(tc.result).toHaveBeenCalled();
       });
     });
+
+    describe('fail', function() {
+      it('should end test on hook failure', function() {
+        spyOn(tc, 'result').andCallFake(function(result) {
+          expect(result.success).toBe(false);
+          expect(result.skipped).toBe(false);
+          expect(result.log).toEqual(['hook failed']);
+        });
+
+        var mockMochaHook = {
+          type: 'hook',
+          title: 'scenario "before each" hook',
+          parent: {title: 'desc1', root: true}
+        };
+
+        runner.emit('hook', mockMochaHook);
+        runner.emit('fail', mockMochaHook, {message: 'hook failed'});
+
+        expect(tc.result).toHaveBeenCalled();
+      })
+    })
   });
 });


### PR DESCRIPTION
hook failure handling similar to https://github.com/visionmedia/mocha/blob/master/lib/reporters/html.js#L112
