### PR TITLE
Try TMP, TMPDIR and TEMP before defaulting to /tmp for temp files.

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -37,7 +37,7 @@ var Browser = function(id) {
     return [url];
   };
 
-  this._tempDir = env.TMPDIR + id;
+  this._tempDir = ( process.env.TMP || process.env.TMPDIR || process.env.TEMP || '/tmp' ) + '/testacular-'+id;
 
   try {
     fs.mkdirSync(this._tempDir);


### PR DESCRIPTION
PhantomJS failed on Ubuntu since environment variable TMPDIR was not set.
