### PR TITLE
Update Ng-Scenario Adapter to correctly display total # of tests

### DIFF
--- a/adapter/angular-scenario.src.js
+++ b/adapter/angular-scenario.src.js
@@ -39,8 +39,8 @@ var registerResultListeners = function(model, tc) {
     return null;
   };
 
-  model.on('SpecBegin', function(spec) {
-    totalTests++;
+  model.on('RunnerBegin', function() {
+    totalTests = angular.scenario.Describe.specId;
     tc.info({total: totalTests});
   });
 

--- a/test/client/angular-scenario.spec.js
+++ b/test/client/angular-scenario.spec.js
@@ -26,14 +26,12 @@ describe('adapter angular-scenario', function() {
       registerResultListeners(model, tc);
     });
 
-    it('should update number of tests as it sees them', function() {
+    it('should update number of tests in the beginning', function() {
       spyOn(tc, 'info');
+      angular.scenario.Describe = {specId: 13};
 
-      model.emit('SpecBegin');
-      expect(tc.info).toHaveBeenCalledWith({total: 1});
-
-      model.emit('SpecBegin');
-      expect(tc.info).toHaveBeenCalledWith({total: 2});
+      model.emit('RunnerBegin');
+      expect(tc.info).toHaveBeenCalledWith({total: 13});
     });
 
     it('should handle passing tests', function() {


### PR DESCRIPTION
I am including the updated angular-scenario with this, but we should wait till the change in AngularJS is accepted first.
