### PR TITLE
Run tests on start

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,4 @@
-fvar io = require('socket.io');
+var io = require('socket.io');
 var net = require('net');
 var cfg = require('./config');
 var ws = require('./web-server');


### PR DESCRIPTION
made the change so that when a browser instance is registered and if autoWatch is enabled, call the tryExecution method so that tests will run ASAP.
