### PR TITLE
FIxes Windows problem - in the case where there are files on multiple different drives

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -8,6 +8,7 @@ var log = require('./logger').create('watcher');
 var createWinGlob = function(realGlob) {
   return function(pattern, options, done) {
     var drive = pattern.substr(0, 3);
+    options = util.merge(options, { cwd: drive });
     realGlob(pattern.substr(3), options, function(err, results) {
       done(err, results.map(function(path) {
         return drive + path;


### PR DESCRIPTION
If you try to load files from a number of different files (i.e. C:, D:, etc.) then the glob fails to pick up those that are not in the current drive.  This simple fix solves that.
This is actually quite a common problem on Windows, where testacular is installed to C:\Users... and so the JASMINE and JASMINE_ADAPTOR are pulled from the C: but the developer is keeping their code on another drive, say D:\dev...
