### PR TITLE
launcher.js support for IE

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -232,6 +232,23 @@ PhantomJSBrowser.prototype = {
 };
 
 
+var IEBrowser = function() {
+    Browser.apply(this, arguments);
+
+    this._getOptions = function(url) {
+        return [url];
+    };
+};
+
+IEBrowser.prototype = {
+    name: 'IE',
+
+    DEFAULT_CMD: {
+        win32: 'C:\\Program Files\\Internet Explorer\\iexplore.exe'
+    }
+};
+
+
 var Launcher = function() {
   var browsers = [];
 
@@ -304,3 +321,4 @@ exports.FirefoxBrowser = FirefoxBrowser;
 exports.OperaBrowser = OperaBrowser;
 exports.SafariBrowser = SafariBrowser;
 exports.PhantomJSBrowser = PhantomJSBrowser;
+exports.IEBrowser = IEBrowser;


### PR DESCRIPTION
Only win32 platform support obviously, defaulting to "C:\Program
Files\Internet Explorer\iexplore.exe". Only tested in IE10.
