### PR TITLE
Crash in repoter.js for Mocha - when result.log is null

### DIFF
--- a/adapter/mocha.src.js
+++ b/adapter/mocha.src.js
@@ -57,9 +57,9 @@ var createMochaReporterConstructor = function(tc) {
         description: test.title,
         suite: [],
         success: test.state === 'passed',
-        skipped: false,
+        skipped: test.pending === true,
         time: test.duration,
-        log: test.$errors
+        log: test.$errors || []
       };
 
       var pointer = test.parent;


### PR DESCRIPTION
Investigating this for a cause... but here is the log.

Environment - Node 0.8.11, Testacular Canary 0.3.8, Canary 24.0.1284.0, PhantomJS 1.7, Mocha 1.5, Chai 1.3 - on Windows 7 x64

Because your code does a lot of msg passing, I'm not sure if this is somehow being caused by a bad test run or what.  Will add some debug code to try and track it down. 

For now, wanted to get the ball rolling...

```
C:\Source\AngularCoffeeLessDemo\node_modules\testacular\lib\reporter.js:126
    result.log.forEach(function(log) {
               ^
TypeError: Cannot call method 'forEach' of undefined
    at BaseReporter.specFailure (C:\Source\AngularCoffeeLessDemo\node_modules\testacular\lib\reporter.js:126:16)
    at BaseReporter.onSpecComplete (C:\Source\AngularCoffeeLessDemo\node_modules\testacular\lib\reporter.js:107:12)
    at EventEmitter.emit (events.js:96:17)
    at Browser.onResult (C:\Source\AngularCoffeeLessDemo\node_modules\testacular\lib\browser.js:105:13)
    at Socket.EventEmitter.emit [as $emit] (events.js:93:17)
    at SocketNamespace.handlePacket (C:\Source\AngularCoffeeLessDemo\node_modules\testacular\node_modules\socket.io\lib\namespace.js:335:22)
    at Manager.onClientMessage (C:\Source\AngularCoffeeLessDemo\node_modules\testacular\node_modules\socket.io\lib\manager.js:487:38)
    at WebSocket.Transport.onMessage (C:\Source\AngularCoffeeLessDemo\node_modules\testacular\node_modules\socket.io\lib\transport.js:387:20)
    at Parser.<anonymous> (C:\Source\AngularCoffeeLessDemo\node_modules\testacular\node_modules\socket.io\lib\transports\websocket\hybi-16.js:39:10)
    at Parser.EventEmitter.emit (events.js:93:17)
```
