### PR TITLE
gh-pages: fixes for responsive design

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,9 @@
     <p>Spectacular Test Runner for JavaScript.</p>
     <p class="download-info">
       <span class="npm-install btn-large fake-btn">npm -g install testacular</span>
-      <a href="https://github.com/vojtajina/testacular/" class="btn btn-primary btn-large">View project on GitHub</a>
+      <a href="https://github.com/vojtajina/testacular/" class="btn btn-primary btn-large">
+        View project on GitHub
+      </a>
     </p>
   </div>
 
@@ -122,9 +124,7 @@
   <!-- <p class="marketing-byline">To be done. Record a screen cast describing whole workflow...</p> -->
 
   <div class="yt-video-container">
-    <div class="yt-video fake-btn">
-      <iframe width="853" height="480" src="http://www.youtube.com/embed/MVw8N3hTfCI" frameborder="0" allowfullscreen></iframe>
-    </div>
+    <iframe width="853" height="480" src="http://www.youtube.com/embed/MVw8N3hTfCI" frameborder="0" allowfullscreen></iframe>
   </div>
 
 </div><!-- /.marketing -->

--- a/testacular.css
+++ b/testacular.css
@@ -40,15 +40,26 @@ hr.soften {
   border: 0;
 }
 
-
-.yt-video {
-  margin: 0 auto;
-  padding: 20px;
-}
+/* responsive youtube embed by
+ * http://avexdesigns.com/responsive-youtube-embed/
+ */
 
 .yt-video-container {
-  width: 100%;
-  text-align: center;
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 30px;
+  height: 0;
+  overflow: hidden;
+}
+
+.yt-video-container iframe,
+.yt-video-container object,
+.yt-video-container embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
 }
 
 
@@ -79,6 +90,7 @@ hr.soften {
 .jumbotron .npm-install {
   font-family: 'Bitstream Vera Sans Mono','Courier',monospace;
   font-weight: bold;
+  padding: 15px 24px;
 }
 
 .fake-btn {
@@ -130,6 +142,9 @@ hr.soften {
   line-height: 36px;
 }
 
+.download-info {
+
+}
 
 /* Quick links
 -------------------------------------------------- */
@@ -251,6 +266,9 @@ hr.soften {
     font-size: 18px;
     padding: 10px 14px;
     margin: 0 auto 10px;
+  },
+  .jumbotron .btn-fake {
+    display: block;
   }
   /* Masthead (home page jumbotron) */
   .masthead {
@@ -286,7 +304,7 @@ hr.soften {
   }
 
   /* Jumbotron buttons */
-  .jumbotron .btn {
+  .jumbotron .btn-large {
     margin-bottom: 10px;
   }
 


### PR DESCRIPTION
I've fixed some responsive design errors for the homepage 
- Youtube embed scales accordingly to window size
- `margin-bottom` in smaller screen sizes is now correct for the `.jumbotron` buttons
