### PR TITLE
Disable usage statistics dialog in Opera

### DIFF
--- a/lib/launchers/Opera.js
+++ b/lib/launchers/Opera.js
@@ -25,6 +25,7 @@ var PREFS =
     'Show E-mail Client=0\n' +
     'Show Mail Header Toolbar=0\n' +
     'Show Setupdialog On Start=0\n' +
+    'Ask For Usage Stats Percentage=0\n'
     'Enable Usage Statistics=0\n' +
     '[Install]\n' +
     'Newest Used Version=1.00.0000\n' +


### PR DESCRIPTION
When set to 0, the dialog prompting for participation in usage statistics should never appear.

(In response to Opera bug report DSK-375137.)
