### PR TITLE
Disable auto-update in Opera

### DIFF
--- a/lib/launchers/Opera.js
+++ b/lib/launchers/Opera.js
@@ -28,7 +28,7 @@ var PREFS =
     'Ask For Usage Stats Percentage=0\n' +
     'Enable Usage Statistics=0\n' +
     'Disable Opera Package AutoUpdate=1\n' +
-    'Browser JavaScript=0\n\n' + // site-patches by Opera delivred through uto-update
+    'Browser JavaScript=0\n\n' + // site-patches by Opera delivred through auto-update
     '[Install]\n' +
     'Newest Used Version=1.00.0000\n\n' +
     '[State]\n' +


### PR DESCRIPTION
Disable binary update of the Opera installation.

Note: also disables all auto-update related UI.

(In response to Opera bug report DSK-375423.)
