### PR TITLE
Added  --files option to cli 

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -43,6 +43,10 @@ var processArgs = function(argv, options) {
     options.browsers = options.browsers.split(',');
   }
 
+  if (util.isString(options.files)) {
+    options.files = options.files.split(',');
+  }
+  
   if (options.reportSlowerThan === false) {
     options.reportSlowerThan = 0;
   }
@@ -99,6 +103,7 @@ var describeStart = function() {
     .describe('log-level', '<disable | error | warn | info | debug> Level of logging.')
     .describe('colors', 'Use colors when reporting and printing logs.')
     .describe('no-colors', 'Do not use colors when reporting or printing logs.')
+    .describe('files', 'Overrides the file list (use #ADAPTER to include the standard adapters)')
     .describe('reporters', 'List of reporters (available: dots, progress, junit).')
     .describe('browsers', 'List of browsers to start (eg. --browsers Chrome,ChromeCanary,Firefox).')
     .describe('capture-timeout', '<integer> Kill browser if does not capture in given time [ms].')

--- a/lib/config.js
+++ b/lib/config.js
@@ -113,6 +113,19 @@ var parseConfig = function(configFilePath, cliOptions) {
     __dirname: path.dirname(configFilePath)
   };
 
+  // resolve adapter injections
+  if (cliOptions && cliOptions.files) {
+    cliOptions.files = cliOptions.files.map(function(file){
+      if (file.match(/^#/)) {
+        var adapter = file.replace(/^#/, '');
+        return configEnv[adapter.toUpperCase()];
+      }
+      else {
+        return file;
+      }
+    });
+  }
+
   try {
     var configSrc = fs.readFileSync(configFilePath);
 

--- a/test/unit/cli.spec.coffee
+++ b/test/unit/cli.spec.coffee
@@ -80,3 +80,9 @@ describe 'cli', ->
 
       options = processArgs ['--reporters', 'dots']
       expect(options.reporters).toEqual ['dots']
+
+    it 'should cast files to array', ->
+      options = processArgs ['--files', 'file1,file2']
+      expect(options.files).toEqual ['file1', 'file2']
+
+      

--- a/test/unit/config.spec.coffee
+++ b/test/unit/config.spec.coffee
@@ -2,6 +2,7 @@
 # lib/config.js module
 #==============================================================================
 describe 'config', ->
+  path = require 'path'
   fsMock = require('mocks').fs
   loadFile = require('mocks').loadFile
   mocks = m = e = null
@@ -41,6 +42,7 @@ describe 'config', ->
         'config4.js': fsMock.file 0, 'port = 123; autoWatch = true; basePath = "/abs/base"'
         'config5.js': fsMock.file 0, 'port = {f: __filename, d: __dirname}' # piggyback on port prop
         'config6.js': fsMock.file 0, 'reporters = "junit";'
+        'config7.js': fsMock.file 0, 'files = ["a.js", "b.js", "#MOCHA"];'        
       conf:
         'invalid.js': fsMock.file 0, '={function'
         'exclude.js': fsMock.file 0, 'exclude = ["one.js", "sub/two.js"];'
@@ -50,6 +52,7 @@ describe 'config', ->
     # load file under test
     m = loadFile __dirname + '/../../lib/config.js', mocks, {process: mocks.process}
     e = m.exports
+
 
 
   #============================================================================
@@ -194,6 +197,11 @@ describe 'config', ->
       config = e.parseConfig '/conf/coffee.coffee', {}
       expect(config.autoWatch).toBe false
 
+    it 'should resolve adapters', ->
+      config = m.parseConfig '/home/config7.js', {files: ['a.js','b.js','#MOCHA']}
+      adapterPath = path.resolve "#{__dirname}/../../adapter/lib/mocha.js"
+      expect(config.files).toEqual ['/home/a.js', '/home/b.js', adapterPath]
+
 
   describe 'normalizeConfig', ->
     it 'should resolve junitReporter.outputFile to basePath and CWD', ->
@@ -201,4 +209,7 @@ describe 'config', ->
         basePath: '/some/base'
         junitReporter: {outputFile: 'file.xml'}
       expect(config.junitReporter.outputFile).toBe '/some/base/file.xml'
+
+
+
 


### PR DESCRIPTION
and the ability to pass adapters via `"#ADAPTER"`.
For example you can do now

``` bash
$ testacular start --files "#JASMINE,file1.js,file2.js" testacular.conf.js
```
