### PR TITLE
Added the ability to use coffeescript for the configuration file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,7 @@
 var fs = require('fs');
 var path = require('path');
 var vm = require('vm');
+var coffee = require('coffee-script');
 var log = require('./logger').create('config');
 var util = require('./util');
 var constant = require('./constants');
@@ -110,7 +111,14 @@ var parseConfig = function(configFilePath, cliOptions) {
   };
 
   try {
-    vm.runInNewContext(fs.readFileSync(configFilePath), configEnv);
+    var configSrc = fs.readFileSync(configFilePath);
+
+    // if the configuration file is coffeescript compile it
+    if (path.extname(configFilePath) === '.coffee') {
+      configSrc = coffee.compile(configSrc.toString(), {bare: true});
+    }
+
+    vm.runInNewContext(configSrc, configEnv);
   } catch(e) {
     if (e.name === 'SyntaxError') {
       log.error('Syntax error in config file!\n' + e.message);

--- a/test/unit/config.spec.coffee
+++ b/test/unit/config.spec.coffee
@@ -35,7 +35,7 @@ describe 'config', ->
         'exclude.js': fsMock.file 0, 'exclude = ["one.js", "sub/two.js"];'
         'absolute.js': fsMock.file 0, 'files = ["http://some.com", "https://more.org/file.js"];'
         'both.js': fsMock.file 0, 'files = ["one.js", "two.js"]; exclude = ["third.js"]'
-
+        'coffee.coffee': fsMock.file 0, 'files = [ "one.js"\n  "two.js"]'
     # load file under test
     m = loadFile __dirname + '/../../lib/config.js', mocks, {process: mocks.process}
     e = m.exports
@@ -169,3 +169,12 @@ describe 'config', ->
     it 'should normalize reporters to an array', ->
       config = m.parseConfig '/home/config6.js', {}
       expect(config.reporters).toEqual ['junit']
+
+    it 'should compile coffeescript config', ->
+      config = e.parseConfig '/conf/coffee.coffee', {}
+      expect(config.files).toEqual ['/conf/one.js', '/conf/two.js']
+
+    it 'should set defaults with coffeescript', ->
+      config = e.parseConfig '/conf/coffee.coffee', {}
+      expect(config.autoWatch).toBe false
+


### PR DESCRIPTION
Well the title says it all. If the file extension of the configuration file is `.coffee` it compiles the file before evaluating it.
