### PR TITLE
Fix for #114 - test depends on global install

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -42,9 +42,14 @@ module.exports = function(grunt) {
     },
 
     test: {
-      unit: 'test/unit',
+      unit: '',
       client: 'test/client/testacular.conf.js',
       e2e: 'test/e2e/*/testacular.conf.js'
+    },
+    jasmine_node: {
+      projectRoot: 'test/unit',
+      isVerbose: true,
+      extensions: 'js|coffee'
     },
 
     // JSHint options
@@ -89,6 +94,7 @@ module.exports = function(grunt) {
   });
 
   grunt.loadTasks('tasks');
+  grunt.loadNpmTasks('grunt-jasmine-node');
   grunt.registerTask('default', 'build lint test');
   grunt.registerTask('release', 'Build, bump and publish to NPM.', function(type) {
     grunt.task.run('build bump:' + (type || 'patch') + ' npm-publish');

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "LiveScript": ">= 1.0.1"
   },
   "devDependencies": {
-    "jasmine-node": ">= 1.0.11",
+    "grunt-jasmine-node": "0.0.2",
+    "jasmine-node": "~1.0.26",
     "mocks": ">= 0.0.5",
     "grunt": ">= 0.3.11",
     "which": ">= 1.0.5"

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -86,13 +86,10 @@ module.exports = function(grunt) {
 
       return next();
     }
-
-
-    // UNIT tests
     else if (this.target === 'unit') {
-      exec(which('jasmine-node'), ['--coffee', this.data], 'Unit tests failed.');
+      grunt.task.run(['jasmine_node']);
+      specDone();
     }
-
 
     // CLIENT unit tests
     else if (this.target === 'client') {


### PR DESCRIPTION
This fixes #114. 
I've done the following
- install [grunt-jasmine-node](https://github.com/jasmine-contrib/grunt-jasmine-node) task
- setup `jasmine_node` to run the unit tests
- rename the old `test` task to `tests` and remove the unit part from it
- setup new `test` taks that runs `jasmine_node tests`
