### PR TITLE
angular-scenario adapter should limit output just to testacular

### DIFF
--- a/adapter/angular-scenario.src.js
+++ b/adapter/angular-scenario.src.js
@@ -13,7 +13,7 @@ var createNgScenarioStartFn = function(tc, scenarioSetupAndRun) {
   });
 
   return function(config) {
-    scenarioSetupAndRun();
+    scenarioSetupAndRun({scenario_output: 'testacular'});
   };
 };
 


### PR DESCRIPTION
In order to slightly speed up test runs, it's preferable to disable
the html output from the scenario runner.
