### PR TITLE
Don't display netTime if it isn't present

### DIFF
--- a/lib/reporters/Base.js
+++ b/lib/reporters/Base.js
@@ -28,8 +28,11 @@ var BaseReporter = function(formatError, reportSlow, adapter) {
         msg += this.FINISHED_SUCCESS;
       }
 
-      msg += util.format(' (%s / %s)', u.formatTimeInterval(results.totalTime),
-                                       u.formatTimeInterval(results.netTime));
+      if(results.netTime)
+        msg += util.format(' (%s / %s)', u.formatTimeInterval(results.totalTime),
+                                         u.formatTimeInterval(results.netTime));
+      else
+        msg += util.format(' (%s)', u.formatTimeInterval(results.totalTime));
     }
 
     return msg;


### PR DESCRIPTION
The test base reporter displays `NaN` if `netTime` isn't present:

```
SUCCESS (0.288 secs / NaN secs)
```

This makes sure that it isn't displayed:

```
SUCCESS (0.288 secs)
```

Note that I'm using Mocha and not Jasmine.
