### PR TITLE
[Improvement] Replace color codes with colors.js

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,7 +1,8 @@
+var colors = require('colors');
 var format = require('util').format;
 
-var LEVELS = ['result', 'error', 'warn', 'info', 'debug'];
-var COLORS = [ 36,       31,      33,     36,     90];
+var LEVELS = ['result', 'error', 'warn',   'info', 'debug'];
+var COLORS = [ 'cyan',  'red',   'yellow', 'cyan',  'grey'];
 
 var globalConfig = {
   logLevel: 3,
@@ -27,7 +28,7 @@ var Logger = function(name, level) {
       var prefix = name ? type +  ' (' + name + '):' : type + ':';
 
       if (globalConfig.useColors) {
-        prefix = '\x1B[' + COLORS[index] + 'm' + prefix + '\x1B[39m';
+        prefix = prefix[COLORS[index]];
       }
 
       args[0] = prefix + ' ' + args[0];

--- a/lib/reporters/BaseColor.js
+++ b/lib/reporters/BaseColor.js
@@ -1,16 +1,18 @@
+var colors = require('colors');
+
 var BaseColorReporter = function() {
-  this.SPEC_FAILURE = '\x1B[31m%s %s FAILED\x1B[39m' + '\n';
-  this.SPEC_SLOW = '\x1B[33m%s SLOW %s:\x1B[39m %s\n';
-  this.ERROR = '\x1B[31m%s ERROR\x1B[39m\n';
+  this.SPEC_FAILURE = '%s %s FAILED'.red + '\n';
+  this.SPEC_SLOW = '%s SLOW %s: %s'.yellow + '\n';
+  this.ERROR = '%s ERROR'.red + '\n';
 
-  this.FINISHED_ERROR = ' \x1B[31mERROR\x1B[39m';
-  this.FINISHED_SUCCESS = ' \x1B[32mSUCCESS\x1B[39m';
-  this.FINISHED_DISCONNECTED = ' \x1B[31mDISCONNECTED\x1B[39m';
+  this.FINISHED_ERROR = ' ERROR'.red;
+  this.FINISHED_SUCCESS = ' SUCCESS'.green;
+  this.FINISHED_DISCONNECTED = ' DISCONNECTED'.red;
 
-  this.X_FAILED = ' \x1B[31m(%d FAILED)\x1B[39m';
+  this.X_FAILED = ' (%d FAILED)'.red;
 
-  this.TOTAL_SUCCESS = '\x1B[32mTOTAL: %d SUCCESS\x1B[39m\n';
-  this.TOTAL_FAILED = '\x1B[31mTOTAL: %d FAILED, %d SUCCESS\x1B[39m\n';
+  this.TOTAL_SUCCESS = 'TOTAL: %d SUCCESS'.green + '\n';
+  this.TOTAL_FAILED = 'TOTAL: %d FAILED, %d SUCCESS'.red + '\n';
 };
 
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "xmlbuilder": ">= 0.4.2",
     "rimraf": ">= 2.0.2",
     "q": ">= 0.8.9",
-    "LiveScript": ">= 1.0.1"
+    "LiveScript": ">= 1.0.1",
+    "colors": "~0.6.0-1"
   },
   "devDependencies": {
     "grunt-jasmine-node": "https://github.com/Dignifiedquire/grunt-jasmine-node/tarball/grunt-0.4",


### PR DESCRIPTION
As discussed in #106 I've replaced all color codes with function calls to [color.js](https://github.com/Marak/colors.js).
