### PR TITLE
add grunt-contrib-jshint to devDependencies,

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -85,6 +85,7 @@ module.exports = (grunt) ->
 
   grunt.loadTasks 'tasks'
   grunt.loadNpmTasks 'grunt-jasmine-node'
+  grunt.loadNpmTasks 'grunt-contrib-jshint'
 
   grunt.registerTask 'default', ['build', 'jshint', 'test']
   grunt.registerTask 'release', 'Build, bump and publish to NPM.', (type) ->

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "colors": "~0.6.0-1"
   },
   "devDependencies": {
+    "grunt-contrib-jshint": ">= 0.1.0",
     "grunt-jasmine-node": "https://github.com/Dignifiedquire/grunt-jasmine-node/tarball/grunt-0.4",
     "jasmine-node": "~1.0.26",
     "mocks": ">= 0.0.5",


### PR DESCRIPTION
because grunt doesn't support default tasks at this commit.
gruntjs/grunt@76038272992575e84fab38a86907e05ab7299b56
