### PR TITLE
Added notification center support for osx systems

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -72,6 +72,11 @@ var parseConfig = function(configFilePath, cliOptions) {
     files: [],
     exclude: [],
     logLevel: constant.LOG_INFO,
+    osxNotifications: {
+      notify: false,
+      host: "localhost",
+      port: 1337
+    },
     colors: true,
     autoWatch: false,
     reporters: ['progress'],

--- a/lib/osx-notifier.js
+++ b/lib/osx-notifier.js
@@ -1,0 +1,57 @@
+//Manage notification center in osx
+//Based on https://npmjs.org/package/node-osx-notifier
+//Configuration sample:
+// osxNotifications = {
+//   notify: true,
+//   host: "localhost",  //Defaults to localhost
+//   port: 1337 //defaults to 1337
+// };
+var log = require('./logger').create('osx-notifier');
+var spawn = require('child_process').spawn;
+var path = require('path');
+var http = require('http');
+var root = path.dirname(__dirname);
+var osxNotifier = {};
+
+var TITLE = "Testacular results";
+
+osxNotifier.spawn = function(config_osx, globalEmitter) {
+    var center = spawn(path.join(root, "/node_modules/node-osx-notifier/lib/node-osx-notifier.js"), [config_osx.port, config_osx.host]);
+
+    log.debug("Notification center started..");
+    center.on('exit', function(code) {
+        log.info('node-osx-notifier exited with code ' + code);
+    });
+
+    globalEmitter.on('run_complete', function(browsers, results) {
+        notify(results, config_osx);
+    });
+
+};
+
+var notify = function(results, config_osx) {
+      var isFailed  = ( results.exitCode !== 0 );
+      var str_request = isFailed ? 'fail' : 'pass';
+      var message = "Passed: " + results.success + "\nFailed: " + results.failed;
+      var uri = '/' + str_request + "?title=" + encodeURIComponent(TITLE) + "&message=" + encodeURIComponent(message);
+
+      var options = {
+        host: config_osx.host,
+        port: config_osx.port,
+        path: uri,
+        method: 'GET'
+      };
+
+      log.debug("Sending request to osx notification center.");
+
+      var req = http.request(options, null);
+
+      req.on('error', function(err) {
+        log.error('error: ' + err.message);
+      });
+      
+      req.end();
+
+    };
+
+exports.osxNotifier = osxNotifier;

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,6 +12,7 @@ var Launcher = require('./launcher').Launcher;
 var FileList = require('./file-list').List;
 var watcher = require('./watcher');
 var preprocessor = require('./preprocessor');
+var osxNotifier = require('./osx-notifier').osxNotifier;
 
 
 // TODO(vojta): get this whole mess under test
@@ -58,6 +59,11 @@ exports.start = function(cliOptions) {
     if (config.browsers && config.browsers.length) {
       launcher.launch(config.browsers, config.port, config.urlRoot, config.captureTimeout, 3);
     }
+
+    if (config.osxNotifications && config.osxNotifications.notify){
+      osxNotifier.spawn(config.osxNotifications, globalEmitter);
+    };
+
   });
 
   var resultReporter = reporter.createReporters(config.reporters, config);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "http-proxy": ">=0.8.2",
     "optimist": ">= 0.3.4",
     "coffee-script": ">= 1.3.3",
-    "xmlbuilder": ">= 0.4.2"
+    "xmlbuilder": ">= 0.4.2",
+    "node-osx-notifier": ">= 0.1.0"
   },
   "devDependencies": {
     "jasmine-node": ">= 1.0.11",


### PR DESCRIPTION
Open for any suggestion on improving the code, I am not sure I have full understanding of where things should be placed...

This is in reference to:
https://github.com/vojtajina/testacular/blob/stable/TODO.md

>  growl notifications ?

I basically added a simple notification of the results of testing, I can now see totals and Green/Red on osx.

this is not based on growl, instead it is based on a node module that does a similar job:
node-osx-notifier

Hope it helps :)
