### PR TITLE
[feature] Prefer local install over global install (Closes #170)

### DIFF
--- a/bin/testacular
+++ b/bin/testacular
@@ -1,17 +1,28 @@
 #!/usr/bin/env node
 
-var cli = require('../lib/cli');
+var path = require('path');
+var fs = require('fs');
+
+// Try to find a local install
+var dir = path.resolve(process.cwd(), 'node_modules', 'testacular', 'lib');
+
+// Check if the local install exists else we use the install we are in
+if (!fs.existsSync(dir)) {
+  dir = path.join('..', 'lib');
+}
+
+var cli = require(path.join(dir, 'cli'));
 
 var config = cli.process();
 
 switch (config.cmd) {
   case 'start':
-    require('../lib/server').start(config);
+    require(path.join(dir, 'server')).start(config);
     break;
   case 'run':
-    require('../lib/runner').run(config, process.exit);
+    require(path.join(dir, 'runner')).run(config, process.exit);
     break;
   case 'init':
-    require('../lib/init').init(config);
+    require(path.join(dir, 'init')).init(config);
     break;
 }


### PR DESCRIPTION
If testacular ist globally installed it checks the current working directory
to see if there is a version of testacular installed and if it finds one
it uses this version otherwise the global version is used.
