### PR TITLE
[fix] QUnit adapter should use QUnit.log

### DIFF
--- a/adapter/qunit.src.js
+++ b/adapter/qunit.src.js
@@ -1,19 +1,9 @@
-var formatErrorQUnit = function () {
-	var errorMessages = [];
-	var messages = QUnit.config.current.assertions;
-	for (var i = 0, l = messages.length; i < l; i++) {
-		if (messages[i].message.indexOf("<pre>") > 0) {
-			errorMessages.push(messages[i].message.replace(/^(.*?)<pre>/, '').replace(/<\/pre>(.*?)$/, ''));
-		}
-	}
-	return errorMessages;
-};
-
 var createQUnitStartFn = function (tc) {
 	return function (runner) {
 		(function (tc, runner) {
 			var totalNumberOfTest = 0;
 			var timer = null;
+      var testResult = {};
 
 			runner.done(function () {
 				tc.info({ total: totalNumberOfTest });
@@ -23,14 +13,22 @@ var createQUnitStartFn = function (tc) {
 			runner.testStart(function (test) {
 				totalNumberOfTest += 1;
 				timer = new Date().getTime();
+        testResult = { success: true, errors: [] };
 			});
+      
+      runner.log(function (details) {
+        if (!details.result) {
+          testResult.success = false;
+          testResult.errors.push(details.message + (details.source ? ('\n' + details.source) : ''));
+        }
+      });
 
 			runner.testDone(function (test) {
 				var result = {
 					description: test.name,
 					suite: [test.module] || [],
-					success: test.failed === 0,
-					log: formatErrorQUnit() || [],
+					success: testResult.success,
+					log: testResult.errors || [],
 					time: new Date().getTime() - timer
 				};
 

--- a/test/client/mocks.js
+++ b/test/client/mocks.js
@@ -25,6 +25,10 @@ var Emitter = function() {
   this.testDone = function(fn) {
     this.on("testDone", fn);
   };
+  
+  this.log = function(fn) {
+    this.on("log", fn);
+  };
 
   this.emit = function(event) {
     var eventListeners = listeners[event];

--- a/test/client/qunit.spec.js
+++ b/test/client/qunit.spec.js
@@ -10,8 +10,6 @@ describe('adapter qunit', function() {
     beforeEach(function() {
       tc = new Testacular(new MockSocket(), {});
       runner = new Emitter();
-      //hack to mock QUnit config singleton
-      runner.config = {current: {assertions: []}}
       window.QUnit = runner;
       reporter = new (createQUnitStartFn(tc))();
     });
@@ -38,14 +36,14 @@ describe('adapter qunit', function() {
           expect(result.log instanceof Array).toBe(true);
         });
 
-        var mockMochaResult = {
+        var mockQUnitResult = {
           name: 'should do something',
           module: 'desc1',
           failed: 0
         };
 
-        runner.emit('testStart', mockMochaResult);
-        runner.emit('testDone', mockMochaResult);
+        runner.emit('testStart', mockQUnitResult);
+        runner.emit('testDone', mockQUnitResult);
 
         expect(tc.result).toHaveBeenCalled();
       });
@@ -56,18 +54,22 @@ describe('adapter qunit', function() {
           expect(result.log).toEqual(['Big trouble.']);
         });
 
-        window.QUnit.config.current.assertions = [{ message : '<span><pre>Big trouble.</pre></span>'}];
-        var mockMochaResult = {
+        var mockQUnitResult = {
           module: 'desc1',
           failed: 1,
           name: 'should do something'
         };
+        
+        var mockQUnitLog = {
+          result: false,
+          message: 'Big trouble.',
+        };
 
-        runner.emit('testStart', mockMochaResult);
-        runner.emit('testDone', mockMochaResult);
+        runner.emit('testStart', mockQUnitResult);
+        runner.emit('log', mockQUnitLog);
+        runner.emit('testDone', mockQUnitResult);
 
         expect(tc.result).toHaveBeenCalled();
-        window.QUnit.config.current.assertions = [];
       });
     });
   });


### PR DESCRIPTION
Currently QUnit adapter is using internal QUnit.config.current.assertions function to get error messages for tests. This change is to make it use QUnit.log event instead. QUnit.log is fired on each assertion, so I have to collect all the messages per given test and then output them as a single message.
