### PR TITLE
[feature] Add benchmark task.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -88,9 +88,20 @@ module.exports = (grunt) ->
         boss: true
       globals: {}
 
+    benchmark:
+      options:
+        times: 1
+      unit:
+        src: ['benchmarks/unit.js']
+      client:
+        src: ['benchmarks/client.js']
+      e2e:
+        src: ['benchmarks/e2e.js']
+
   grunt.loadTasks 'tasks'
   grunt.loadNpmTasks 'grunt-jasmine-node'
   grunt.loadNpmTasks 'grunt-contrib-jshint'
+  grunt.loadNpmTasks 'grunt-benchmark'
 
   grunt.registerTask 'default', ['build', 'jshint', 'test']
   grunt.registerTask 'release', 'Build, bump and publish to NPM.', (type) ->

--- a/benchmarks/client.js
+++ b/benchmarks/client.js
@@ -1,0 +1,30 @@
+// benchmarks/client.js
+var path = require('path');
+
+var basePath = path.resolve(__dirname, '..');
+// Create a spawnable test task. Doesnt actually spawn until called.
+var clientTask = require('grunt-benchmark').spawnTask('test:client', {
+
+  // Text trigger to look for to know when to run the next step or exit
+  trigger: 'Done, without errors.',
+
+  // Base folder and Gruntfile
+  // You'll want to setup a fixture base folder and Gruntfile.js
+  // to ensure your Grunt'ing appropriately
+  base: basePath,
+  gruntfile: path.resolve(basePath, 'Gruntfile.coffee')
+
+  // Additional Grunt options can be specified here
+
+});
+
+// Our actual benchmark
+module.exports = {
+  'client tests': function(done) {
+    // start the watch task
+    clientTask(function() {}, function(result) {
+      // All done, do something more with the output result or finish up the benchmark
+      done();
+    });
+  }
+};

--- a/benchmarks/e2e.js
+++ b/benchmarks/e2e.js
@@ -1,0 +1,30 @@
+// benchmarks/e2e.js
+var path = require('path');
+
+var basePath = path.resolve(__dirname, '..');
+// Create a spawnable test task. Doesnt actually spawn until called.
+var e2eTask = require('grunt-benchmark').spawnTask('test:e2e', {
+
+  // Text trigger to look for to know when to run the next step or exit
+  trigger: 'Done, without errors.',
+
+  // Base folder and Gruntfile
+  // You'll want to setup a fixture base folder and Gruntfile.js
+  // to ensure your Grunt'ing appropriately
+  base: basePath,
+  gruntfile: path.resolve(basePath, 'Gruntfile.coffee')
+
+  // Additional Grunt options can be specified here
+
+});
+
+// Our actual benchmark
+module.exports = {
+  'e2e tests': function(done) {
+    // start the watch task
+    e2eTask(function() {}, function(result) {
+      // All done, do something more with the output result or finish up the benchmark
+      done();
+    });
+  }
+};

--- a/benchmarks/unit.js
+++ b/benchmarks/unit.js
@@ -1,0 +1,30 @@
+// benchmarks/unit.js
+var path = require('path');
+
+var basePath = path.resolve(__dirname, '..');
+// Create a spawnable test task. Doesnt actually spawn until called.
+var unitTask = require('grunt-benchmark').spawnTask('test:unit', {
+
+  // Text trigger to look for to know when to run the next step or exit
+  trigger: 'Done, without errors.',
+
+  // Base folder and Gruntfile
+  // You'll want to setup a fixture base folder and Gruntfile.js
+  // to ensure your Grunt'ing appropriately
+  base: basePath,
+  gruntfile: path.resolve(basePath, 'Gruntfile.coffee')
+
+  // Additional Grunt options can be specified here
+
+});
+
+// Our actual benchmark
+module.exports = {
+  'unit tests': function(done) {
+    // start the watch task
+    unitTask(function() {}, function(result) {
+      // All done, do something more with the output result or finish up the benchmark
+      done();
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "grunt-jasmine-node": ">= 0.0.4",
     "mocks": ">= 0.0.5",
     "grunt-cli": ">= 0.1.0",
-    "which": ">= 1.0.5"
+    "which": ">= 1.0.5",
+    "grunt-benchmark": "https://github.com/shama/grunt-benchmark/tarball/master"
   },
   "preferGlobal": true,
   "repository": {


### PR DESCRIPTION
Using grunt-benchmark one can now benchmark the complete testsuite as discussed in #129
Three tasks are available
- `grunt benchmark:unit`
- `grunt benchmark:client`
- `grunt benchmark:e2e`

which respectively benchmark the tests. 
Running `grunt benchmark` runs all the benchmarks. Right now I've set the repeat option to 1 but that is just because the e2e tests take such a long time. I would suggest that for every major change to the code base the benchmarks should be run before and afterwards and that they should be included in pull requests so we can see the performance consequences are immediately visible.

Right now I get the following values:

``` bash
Running "benchmark:unit" (benchmark) task
Benchmarking "unit tests" [benchmarks/unit.js] x1...
>> 3890 ms per iteration

Running "benchmark:client" (benchmark) task
Benchmarking "client tests" [benchmarks/client.js] x1...
>> 3580 ms per iteration

Running "benchmark:e2e" (benchmark) task
Benchmarking "e2e tests" [benchmarks/e2e.js] x1...
>> 21723 ms per iteration
```
