### PR TITLE
[feature] Integrate log4js as logger basis. (Closes #106)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test/e2e/coverage/coverage
 test/e2e/coverageQunit/coverage
 test/e2e/coverageRequirejs/coverage
 test-results.xml
+test/unit/test.log

--- a/lib/config.js
+++ b/lib/config.js
@@ -129,7 +129,8 @@ var parseConfig = function(configFilePath, cliOptions) {
     coverageReporter: {
       type: 'html',
       dir: 'coverage/'
-    }
+    },
+    loggers: [ constant.CONSOLE_APPENDER ]
   };
 
   var ADAPTER_DIR = __dirname + '/../adapter';

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -8,11 +8,23 @@ exports.DEFAULT_PORT = 9876;
 exports.DEFAULT_RUNNER_PORT = 9100;
 
 // log levels
-exports.LOG_DISABLE = -1;
-exports.LOG_ERROR   =  1;
-exports.LOG_WARN    =  2;
-exports.LOG_INFO    =  3;
-exports.LOG_DEBUG   =  4;
+exports.LOG_DISABLE = 'OFF';
+exports.LOG_ERROR   = 'ERROR';
+exports.LOG_WARN    = 'WARN';
+exports.LOG_INFO    = 'INFO';
+exports.LOG_DEBUG   = 'DEBUG';
 
+// Default patterns for the pattern layout.
+exports.COLOR_PATTERN = '%[%p [%c]: %]%m';
+exports.NO_COLOR_PATTERN = '%p [%c]: %m';
+
+// Default console appender
+exports.CONSOLE_APPENDER = {
+  type: 'console',
+  layout: {
+    type: 'pattern',
+    pattern: exports.COLOR_PATTERN
+  }
+};
 
 exports.EXIT_CODE_0 = '\x1FEXIT0';

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,56 +1,79 @@
-var util = require('util');
-var colors = require('colors');
+// This is the **logger** module for *Testacular*. It uses
+// [log4js](https://github.com/nomiddlename/log4js-node) to handle and
+// configure all logging that happens inside of *Testacular*.
 
 
-var LEVELS = ['result', 'error', 'warn',   'info', 'debug'];
-var COLORS = [ 'cyan',  'red',   'yellow', 'cyan',  'grey'];
+// ### Helpers and Setup
 
-var globalConfig = {
-  logLevel: 3,
-  useColors: true
+var log4js = require('log4js');
+var helper = require('./helper');
+var constant = require('./constants');
+
+// Special Wrapper for Socket.io :(
+var LogWrapper = function(name, level) {
+  this.logger = log4js.getLogger(name);
+  this.logger.setLevel(level);
 };
-
-var isDefined = function(value) {
-  return typeof value !== 'undefined';
-};
-
-var Logger = function(name, level) {
-  var createMethod = function(type) {
-    return function() {
-      var currentLevel =  isDefined(level) ? level : globalConfig.logLevel;
-      var index = LEVELS.indexOf(type);
-
-      // ignore
-      if (index > currentLevel) {
-        return;
-      }
-
-      var args = Array.prototype.slice.call(arguments);
-      var prefix = name ? type +  ' (' + name + '):' : type + ':';
-
-      if (globalConfig.useColors) {
-        prefix = prefix[COLORS[index]];
-      }
-
-      args[0] = prefix + ' ' + args[0];
-      console.log(util.format.apply(null, args));
-    };
+['error', 'warn', 'info', 'debug'].forEach(function(level) {
+  LogWrapper.prototype[level] = function() {
+    this.logger[level].apply(this.logger, arguments);
   };
+});
 
-  // define public methods: error, warn, info, debug
-  LEVELS.forEach(function(level) {
-    this[level] = createMethod(level);
-  }, this);
+// #### Public Functions
+
+// Setup the logger by passing in the configuration options. It needs
+// three argumentes:
+//
+//     setup(logLevel, colors, appenders)
+//
+// * `logLevel`: *String* Defines the global log level.
+// * `colors`: *Boolean* Use colors in the stdout or not.
+// * `appenders`: *Array* This will be passed as appenders to log4js
+//   to allow for fine grained configuration of log4js. For more information
+//   see https://github.com/nomiddlename/log4js-node.
+var setup = function(level, colors, appenders) {
+  // Turn color on/off on the console appenders with pattern layout
+  var pattern = colors ? constant.COLOR_PATTERN : constant.NO_COLOR_PATTERN;
+
+  // If there are no appenders use the default one
+  appenders = helper.isDefined(appenders) ? appenders : [constant.CONSOLE_APPENDER];
+
+  appenders = appenders.map(function(appender) {
+    if(appender.type === 'console') {
+      if (helper.isDefined(appender.layout) && appender.layout.type === 'pattern') {
+        appender.layout.pattern = pattern;
+      }
+    }
+    return appender;
+  });
+
+  // Pass the values to log4js
+  log4js.setGlobalLogLevel(level);
+  log4js.configure({
+    appenders: appenders
+  });
 };
 
-exports.create = function(name, level) {
-  return new Logger(name, level);
+// Create a new logger. There are two optional arguments
+// * `name`, which defaults to `testacular` and
+//   If the `name = 'socket.io'` this will create a special wrapper
+//   to be used as a logger for socket.io.
+// * `level`, which defaults to the global level.
+var create = function(name, level) {
+  if (name === 'socket.io') {
+    return new LogWrapper('socket.io', level);
+  } else {
+    var logger = log4js.getLogger(name || 'testacular');
+    if (helper.isDefined(level)) {
+      logger.setLevel(level);
+    }
+    return logger;
+  }
 };
 
-exports.setLevel = function(level) {
-  globalConfig.logLevel = level;
-};
 
-exports.useColors = function(use) {
-  globalConfig.useColors = !!use;
-};
+// #### Publish
+
+exports.create = create;
+exports.setup = setup;

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,9 +22,8 @@ exports.start = function(cliOptions, done) {
   if (! helper.isFunction(done)) {
     done = process.exit;
   }
-
-  logger.setLevel(config.logLevel);
-  logger.useColors(config.colors);
+  
+  logger.setup(config.logLevel, config.colors, config.loggers);
 
   var log = logger.create();
   var globalEmitter = new events.EventEmitter();
@@ -43,7 +42,7 @@ exports.start = function(cliOptions, done) {
 
   var webServer = ws.createWebServer(config.basePath, config.proxies, config.urlRoot);
   var socketServer = io.listen(webServer, {
-    logger: logger.create('socket.io', 0),
+    logger: logger.create('socket.io', constant.LOG_ERROR),
     resource: config.urlRoot + 'socket.io',
     transports: ['websocket', 'flashsocket', 'xhr-polling', 'jsonp-polling']
   });

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "lodash": "~0.9.1",
     "growly": "~1.1.0",
     "pause": ">= 0.0.1",
-    "mime": ">= 1.2.7"
+    "mime": ">= 1.2.7",
+    "log4js": "~0.5.6"
   },
   "devDependencies": {
     "grunt": "0.4.0rc4",

--- a/test/unit/config.spec.coffee
+++ b/test/unit/config.spec.coffee
@@ -64,11 +64,13 @@ describe 'config', ->
   # Should parse configuration file and do some basic processing as well
   #============================================================================
   describe 'parseConfig', ->
-
+    logSpy = sinon.spy()
+      
     beforeEach ->
-      logger = require '../../lib/logger'
-      logger.setLevel 1 # enable errors
-      logger.useColors false
+      logger = require '../../lib/logger.js'
+      logger.setup 'ERROR', false
+
+      logger.create('config').on 'log', logSpy
 
 
 
@@ -101,22 +103,34 @@ describe 'config', ->
 
     it 'should log error and exit if file does not exist', ->
       e.parseConfig '/conf/not-exist.js', {}
-      expect(console.log).to.have.been.calledWith 'error (config): Config file does not exist!'
+
+      expect(logSpy).to.have.been.called
+      event = logSpy.lastCall.args[0]
+      expect(event.level.toString()).to.be.equal 'ERROR'
+      expect(event.data).to.be.deep.equal ['Config file does not exist!']
       expect(mocks.process.exit).to.have.been.calledWith 1
+
 
 
     it 'should log error and exit if it is a directory', ->
       e.parseConfig '/conf', {}
-      expect(console.log).to.have.been.calledWith 'error (config): Config file does not exist!'
+
+      expect(logSpy).to.have.been.called
+      event = logSpy.lastCall.args[0]
+      expect(event.level.toString()).to.be.equal 'ERROR'
+      expect(event.data).to.be.deep.equal ['Config file does not exist!']
       expect(mocks.process.exit).to.have.been.calledWith 1
 
 
     it 'should throw and log error if invalid file', ->
       e.parseConfig '/conf/invalid.js', {}
-      expect(console.log).to.have.been.calledWith 'error (config): Syntax error in config file!\n' +
-        'Unexpected token ='
-      expect(mocks.process.exit).to.have.been.calledWith 1
 
+      expect(logSpy).to.have.been.called
+      event = logSpy.lastCall.args[0]
+      expect(event.level.toString()).to.be.equal 'ERROR'
+      expect(event.data).to.be.deep.equal ['Syntax error in config file!\nUnexpected token =']
+      expect(mocks.process.exit).to.have.been.calledWith 1
+      
 
     it 'should override config with given cli options', ->
       config = e.parseConfig '/home/config4.js', {port: 456, autoWatch: false}

--- a/test/unit/launcher.spec.coffee
+++ b/test/unit/launcher.spec.coffee
@@ -50,7 +50,7 @@ describe 'launcher', ->
       ++lastGeneratedId
 
     # disable logger
-    logger.setLevel -1
+    logger.setup 'OFF'
 
 
   #============================================================================


### PR DESCRIPTION
This commit rewrites the logger to use [log4js](https://github.com/nomiddlename/log4js-node). There are multiple things that change.
- For the end user, the standard configurations still work but there is now an option `logger` where  one can add any arguments that can be added to `log4js.configure()`. This adds the ability to log to a file and stuff like that.
- Internally I've changed the tests to use the log event emitted by the logger when testing for console output.
- Because of the way log4js works global configuration of the log level no takes precedence over the local definition. 
- The tests have now the ugly side effect of printing the log messages. I don't know how to mock `console.log` to remove that. If anyone knows how to do that please let me know.

This pull isn't finished by any means. Please discuss and ideas, opinions and improvements. The aim is to get a future proof logger, so go ahead take it apart.
