### PR TITLE
[fix] Handle uncaught exceptions

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -215,4 +215,11 @@ exports.start = function(cliOptions) {
     // Windows doesn't support signals yet, so they simply don't get this handling.
     // https://github.com/joyent/node/issues/1553
   }
+  
+  // Handle all unhandled exceptions, so we don't just exit but 
+  // disconnect the browsers before exiting.
+  process.on('uncaughtException', function(error) {
+    log.error(error);
+    disconnectBrowsers(1);
+  });
 };


### PR DESCRIPTION
This handles all uncaught exceptions with the following behaviour
1. Print the error message via the standard logger
2. Disconnect the browsers and
3. Kill the process with code 1.

This fixes #94.
