### PR TITLE
Allow multiple output 'type's for code coverage

### DIFF
--- a/docs/user/coverage.rst
+++ b/docs/user/coverage.rst
@@ -66,7 +66,7 @@ The reporter defaults to the following values.
 .. code-block:: javascript
 
   coverageReporter = {
-    type : 'html',
+    type : ['html'],
     dir : 'coverage/'
   }
 
@@ -83,18 +83,33 @@ If you want to configure it yourself, these are the options you have.
   * ``text-summary``
   * ``cobertura`` (xml format supported by Jenkins)
 
-  If you set ``type`` to ``text`` or ``text-summary``, you may set the ``file`` option, like this.
+  If you include ``text`` or ``text-summary`` in ``type``, you may set the ``file`` option, like this.
 
   .. code-block:: javascript
 
     coverageReporter = {
-      type : 'text',
+      type : ['text'],
       dir : 'coverage/',
       file : 'coverage.txt'
     }
 
     If no filename is given, it will write the output to the console.
 
+  Multiple output formats may be given, for instance
+
+  .. code-block:: javascript
+
+    coverageReporter = {
+      type : ['html', 'cobertura', 'text'],
+      dir : 'coverage/',
+      file : 'coverage.txt'
+    }
+
+  Note that only the text reporter will write to the file ``coverage.txt``,
+  while ``html`` and ``cobertura`` will write to their default filenames.
+
+  At this time, specifying ``text`` and ``text-summary`` will only write
+  one file if the ``file`` option is specified.
 
 .. object:: dir (String)
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -127,7 +127,7 @@ var parseConfig = function(configFilePath, cliOptions) {
       suite: ''
     },
     coverageReporter: {
-      type: 'html',
+      type: ['html'],
       dir: 'coverage/'
     }
   };

--- a/lib/reporters/Coverage.js
+++ b/lib/reporters/Coverage.js
@@ -87,18 +87,26 @@ var CoverageReporter = function(rootConfig, emitter) {
         pendingFileWritings++;
         var out = path.resolve(outDir, browser.name);
         helper.mkdirIfNotExists(out, function() {
-          var options = helper.merge({}, config, {
-            dir : out,
-            sourceStore : new BasePathStore({
-              basePath : basePath
-            })
+          type.forEach(function(t) {
+            var options = helper.merge({}, config, {
+              dir : out,
+              sourceStore : new BasePathStore({
+                basePath : basePath
+              })
+            });
+
+            if (t !== 'text' && t !== 'text-summary')
+            {
+              delete options.file;
+            }
+
+            var reporter = istanbul.Report.create(t, options);
+            try {
+              reporter.writeReport(collector, true);
+            } catch (e) {
+              log.error(e);
+            }
           });
-          var reporter = istanbul.Report.create(type, options);
-          try {
-            reporter.writeReport(collector, true);
-          } catch (e) {
-            log.error(e);
-          }
           collector.dispose();
           writeEnd();
         });

--- a/test/e2e/coverage/testacular.conf.js
+++ b/test/e2e/coverage/testacular.conf.js
@@ -28,6 +28,6 @@ preprocessors = {
 //- cobertura (xml format supported by Jenkins)
 coverageReporter = {
     // cf. http://gotwarlost.github.com/istanbul/public/apidocs/
-    type : 'html',
+    type : ['html'],
     dir : 'coverage/'
 };


### PR DESCRIPTION
The coverage should be reworked to treat `type` as an array of report output formats...

So that at this point in the code, multiple output formats can be written.
https://github.com/vojtajina/testacular/blob/master/lib/reporters/Coverage.js#L96

I haven't looked too closely at how reports are generated, but as I understand it, all the collection has completed, and reports are simply the way to format the output.  I also verified that Istanbul doesn't allow arrays for `type`, just a string:
https://github.com/gotwarlost/istanbul/blob/master/lib/util/factory.js#L41

Should be a straightforward change to check the param type and either generate one or many reports I think.

/cc @taichi 
