### PR TITLE
[readme] Removes `sudo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ First, you need to install [Node.js]. [There are installers](http://nodejs.org/d
 Macintosh and Windows. On Linux, we recommend using [NVM].
 
 ````bash
-sudo npm install -g testacular
-
-# or install in a local folder (you have to create symlinks to binaries on your own)
-npm install testacular
+npm install -g testacular
 ````
 
 You can install Testacular even without NPM, just get the latest package and create symlinks:


### PR DESCRIPTION
Here is a sample .npmrc file:

```
unsafe-perm = true
loglevel = info
root = /usr/local/lib/node
prefix = ~/.local
```

prefix is the important thing here, it will set where things get installed
