### PR TITLE
[api] Add done callback to server.start method.

### DIFF
--- a/bin/testacular
+++ b/bin/testacular
@@ -17,7 +17,7 @@ var config = cli.process();
 
 switch (config.cmd) {
   case 'start':
-    require(path.join(dir, 'server')).start(config);
+    require(path.join(dir, 'server')).start(config, process.exit);
     break;
   case 'run':
     require(path.join(dir, 'runner')).run(config, process.exit);

--- a/lib/server.js
+++ b/lib/server.js
@@ -15,7 +15,7 @@ var FileList = require('./file-list').List;
 
 
 // TODO(vojta): get this whole mess under test
-exports.start = function(cliOptions) {
+exports.start = function(cliOptions, done) {
   var config = cfg.parseConfig(cliOptions.configFile, cliOptions);
 
 
@@ -196,7 +196,7 @@ exports.start = function(cliOptions) {
     });
 
     globalEmitter.emitAsync('exit').then(function() {
-      process.exit(code || 0);
+      done(code || 0);
     });
   };
 


### PR DESCRIPTION
This improves the api of `server.start()` so that it's consistent with the api of `runner.run()` and allows for a callback other than `process.exit` to be executed when the tests are finished.

I need this for Dignifiedquire/grunt-testacular#5.
