### PR TITLE
[improvement] Construct ignore function for chokidar

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -37,7 +37,7 @@ exports.start = function(cliOptions, done) {
 
   if (config.autoWatch) {
     filesPromise.then(function() {
-      watcher.watch(config.files, fileList);
+      watcher.watch(config.files, config.exclude, fileList);
     });
   }
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,4 +1,5 @@
 var chokidar = require('chokidar');
+var mm = require('minimatch');
 
 var helper = require('./helper');
 var log = require('./logger').create('watcher');
@@ -39,12 +40,27 @@ var watchPatterns = function(patterns, watcher) {
   });
 };
 
-exports.watch = function(patterns, fileList) {
-  // TODO(vojta): pass ignored function to not watch unnecessary files
+// Function to test if an item is on the exclude list
+// and therefore should not be watched by chokidar
+var createIgnore = function(excludes){
+  return function(item) {
+    log.debug('Testing %s', item);
+
+    var matchExclude = function(pattern) {
+      log.debug('Excluding %s', pattern);
+      return mm(item, pattern, {dot: true});
+    };
+    return excludes.some(matchExclude);
+  };
+};
+
+exports.watch = function(patterns, excludes, fileList) {
   var options = {
-    ignorePermissionErrors: true
+    ignorePermissionErrors: true,
+    ignored: createIgnore(excludes)
   };
   var chokidarWatcher = new chokidar.FSWatcher(options);
+
   watchPatterns(patterns, chokidarWatcher);
 
   var bind = function(fn) {

--- a/test/unit/watcher.spec.coffee
+++ b/test/unit/watcher.spec.coffee
@@ -17,7 +17,6 @@ describe 'watcher', ->
     mocks_ = chokidar: mocks.chokidar
     m = mocks.loadFile __dirname + '/../../lib/watcher.js', mocks_
 
-
   #============================================================================
   # baseDirFromPattern() [PRIVATE]
   #============================================================================
@@ -73,3 +72,21 @@ describe 'watcher', ->
       ], chokidarWatcher
 
       expect(chokidarWatcher.watchedPaths_).toEqual ['/some/sub']
+
+  #============================================================================
+  # ignore() [PRIVATE]
+  #============================================================================
+  describe 'ignore', ->
+    it 'should ignore all files', ->
+      ignore = m.createIgnore ['**/*']
+      expect(ignore '/some/files/deep/nested.js').toBeTruthy()
+      expect(ignore '/some/files').toBeTruthy()
+
+    it 'should ignore .# files', ->
+      ignore = m.createIgnore ['**/.#*']
+      expect(ignore '/some/files/deep/nested.js').toBeFalsy()
+      expect(ignore '/some/files').toBeFalsy()
+      expect(ignore '/some/files/deep/.npm').toBeFalsy()
+      expect(ignore '.#files.js').toBeTruthy()
+      expect(ignore '/some/files/deeper/nested/.#files.js').toBeTruthy()
+    


### PR DESCRIPTION
In response to #65 all files in the `exclude` list now get ignored by the chokidar watcher.
For use with emacs one can now use the following in the configuration file:

``` js
exclude = [
  '**/.#*'
];
```
