### PR TITLE
Allow functions to be used for preprocessors

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var crypto = require('crypto');
 var util = require('util');
 var mm = require('minimatch');
+var path = require('path');
 
 var helper = require('./helper');
 var log = require('./logger').create('preprocess');
@@ -23,8 +24,25 @@ var createPreprocessor = function(config, basePath) {
 
     for (var i = 0; i < patterns.length; i++) {
       if (mm(file.originalPath, patterns[i])) {
-        var processorName = helper.ucFirst(config[patterns[i]]);
-        processor = exports[processorName];
+        var processorName = config[patterns[i]];
+
+        if (typeof processorName === 'function') {
+          processor = function(content, file, basePath, done) {
+            try {
+              processorName(content, file, function (result) {
+                var ext = result.ext || 'js';
+                file.path = file.path + '.' + ext;
+                done(result.content);
+              });
+            } catch (error) {
+              log.error('%s\n  at %s', error.message, file.originalPath);
+              done();
+            }
+          };
+        } else {
+          processor = exports[helper.ucFirst(processorName)];
+        }
+
         if (processor) {
           break;
         } else {
@@ -37,7 +55,7 @@ var createPreprocessor = function(config, basePath) {
       return fs.readFile(file.originalPath, function(err, buffer) {
         // TODO(vojta): extract get/create temp dir somewhere else (use the same for launchers etc)
         var env = process.env;
-        file.contentPath = (env.TMPDIR || env.TMP || env.TEMP || '/tmp') + '/'  + sha1(file.originalPath) + '.js';
+        file.contentPath = path.resolve((env.TMPDIR || env.TMP || env.TEMP || '/tmp'), sha1(file.originalPath) + '.js');
 
         processor(buffer.toString(), file, basePath, function(processed) {
           fs.writeFile(file.contentPath, processed, function(err) {

--- a/test/unit/preprocessor.spec.coffee
+++ b/test/unit/preprocessor.spec.coffee
@@ -4,8 +4,9 @@
 describe 'preprocessor', ->
   util = require '../test-util'
   mocks = require 'mocks'
+  path = require 'path'
 
-  m = pp = mockFs = doneSpy = fakePreprocessor = null
+  m = pp = mockFs = doneSpy = fakePreprocessor = xyzPreprocessor = null
 
   waitsForDoneAnd = (resume) ->
     waitsFor (-> doneSpy.callCount), 'done callback'
@@ -13,12 +14,39 @@ describe 'preprocessor', ->
 
   beforeEach util.disableLogger
 
+  addPath = (dirs, absPath) ->
+    components = (comp for comp in (absPath.split(path.sep)) when comp != '')
+
+    buildPath = (components) ->
+      if components.length > 0
+        dir = {}
+        dir[components[0]] = buildPath(components.slice(1))
+        dir
+      else
+        {}
+
+    dirs[components[0]] = buildPath(components.slice(1))
+
+  addTempDirs = (dirs) ->
+    addIfPresent = (tmpDir) ->
+      addPath(dirs, process.env[tmpDir]) if process.env[tmpDir]
+
+    addIfPresent 'TMPDIR'
+    addIfPresent 'TMP'
+    addIfPresent 'TEMP'
+
   beforeEach ->
-    mockFs = mocks.fs.create
+    dirs =
       some:
-        'a.js': mocks.fs.file 0, 'originalContent'
+        'a.coffee': mocks.fs.file 0, 'coffee!'
+        'a.xyz': mocks.fs.file 0, 'x|y|z'
+
+    addTempDirs(dirs)
+
+    mockFs = mocks.fs.create(dirs)
 
     fakePreprocessor = jasmine.createSpy 'fake preprocessor'
+    xyzPreprocessor = jasmine.createSpy 'fake preprocessor'
     mocks_ =
       fs: mockFs
       minimatch: require 'minimatch'
@@ -27,7 +55,10 @@ describe 'preprocessor', ->
     m = mocks.loadFile __dirname + '/../../lib/preprocessor.js', mocks_
     doneSpy = jasmine.createSpy 'done'
 
-    pp = m.createPreprocessor {'**/*.js': 'coffee'}, null
+    pp = m.createPreprocessor {
+        '**/*.coffee': 'coffee'
+        '**/*.xyz': xyzPreprocessor
+    }, null
 
   it 'should preprocess matching file', ->
     fakePreprocessor.andCallFake (content, file, basePath, done) ->
@@ -35,13 +66,25 @@ describe 'preprocessor', ->
       file.contentPath = '/some/new.js'
       done 'new-content'
 
-    file = {originalPath: '/some/a.js', path: 'path'}
+    file = {originalPath: '/some/a.coffee', path: 'path'}
 
     pp file, doneSpy
     waitsForDoneAnd ->
       expect(fakePreprocessor).toHaveBeenCalled()
       expect(file.path).toBe 'path-preprocessed'
       expect(mockFs.readFileSync('/some/new.js').toString()).toBe 'new-content'
+
+  it 'should preprocess matching file with function', ->
+    xyzPreprocessor.andCallFake (content, file, done) ->
+      done {ext: 'xyzjs', content: 'return "' + content + '";'}
+
+    file = {originalPath: '/some/a.xyz', path: 'a.xyz'}
+
+    pp file, doneSpy
+    waitsForDoneAnd ->
+      expect(xyzPreprocessor).toHaveBeenCalled()
+      expect(file.path).toBe 'a.xyz.xyzjs'
+      expect(mockFs.readFileSync(file.contentPath).toString()).toBe 'return "x|y|z";'
 
   it 'should ignore not matching file', ->
     fakePreprocessor.andCallFake (content, file, basePath, done) ->
@@ -53,3 +96,4 @@ describe 'preprocessor', ->
 
     waitsForDoneAnd ->
       expect(fakePreprocessor).not.toHaveBeenCalled()
+      expect(xyzPreprocessor).not.toHaveBeenCalled()


### PR DESCRIPTION
Allow functions to be used instead of strings. Better for extending testacular with new preprocessors:

```
var pogo = require('pogo');

preprocessors = {
  '**/*.coffee': 'coffee',
  '**/*.pogo': function (content, filename, done) {
    done({content: pogo.compile(content, {filename: filename})});
  }
};
```

Let me know if there's a better way to do this... Cheers.

Tim.
