### PR TITLE
fix broken build windows

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
     var wrapper = src.replace('src.js', 'wrapper');
 
     grunt.file.copy(wrapper, dest, {process: function(content) {
-      var wrappers = content.split('%CONTENT%\n');
+      var wrappers = content.split(/%CONTENT%\r?\n/);
       return wrappers[0] + grunt.file.read(src) + wrappers[1];
     }});
 


### PR DESCRIPTION
Changed the expression that replaces %CONTENT% in the wrapper to include eventual \r
