### PR TITLE
Added --start-maximized option for MS WIN "hidden windows" issue

### DIFF
--- a/lib/launchers/Chrome.js
+++ b/lib/launchers/Chrome.js
@@ -12,6 +12,7 @@ var ChromeBrowser = function() {
       '--no-default-browser-check',
       '--no-first-run',
       '--disable-default-apps',
+      '--start-maximized',
       url
     ];
   };


### PR DESCRIPTION
This commit adds a command line option which should prevent chrome from opening in a hidden window as described in http://code.google.com/p/chromium/issues/detail?id=151836 .
