### PR TITLE
Support running testacular on a custom hostname

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -108,6 +108,7 @@ var parseConfig = function(configFilePath, cliOptions) {
   var config = {
     port: constant.DEFAULT_PORT,
     runnerPort: constant.DEFAULT_RUNNER_PORT,
+    hostname: constant.DEFAULT_HOSTNAME,
     basePath: '',
     files: [],
     exclude: [],

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -6,6 +6,7 @@ exports.VERSION = pkg.version;
 
 exports.DEFAULT_PORT = 9876;
 exports.DEFAULT_RUNNER_PORT = 9100;
+exports.DEFAULT_HOSTNAME = 'localhost';
 
 // log levels
 exports.LOG_DISABLE = 'OFF';

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -17,8 +17,8 @@ var Launcher = function(emitter) {
   var browsers = [];
 
 
-  this.launch = function(names, port, urlRoot, timeout, retryLimit) {
-    var url = 'http://localhost:' + port + urlRoot;
+  this.launch = function(names, hostname, port, urlRoot, timeout, retryLimit) {
+    var url = 'http://' + hostname + ':' + port + urlRoot;
     var Cls, browser;
 
     names.forEach(function(name) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -60,10 +60,10 @@ exports.start = function(cliOptions, done) {
   });
 
   webServer.listen(config.port, function() {
-    log.info('Testacular server started at http://localhost:' + config.port + config.urlRoot);
+    log.info('Testacular server started at http://' + config.hostname + ':' + config.port + config.urlRoot);
 
     if (config.browsers && config.browsers.length) {
-      launcher.launch(config.browsers, config.port, config.urlRoot, config.captureTimeout, 3);
+      launcher.launch(config.browsers, config.hostname, config.port, config.urlRoot, config.captureTimeout, 3);
     }
   });
 
@@ -98,7 +98,7 @@ exports.start = function(cliOptions, done) {
     var nonReady = [];
 
     if (!capturedBrowsers.length) {
-      log.warn('No captured browser, open http://localhost:' + config.port + config.urlRoot);
+      log.warn('No captured browser, open http://' + config.hostname + ':' + config.port + config.urlRoot);
       return false;
     } else if (capturedBrowsers.areAllReady(nonReady)) {
       log.debug('All browsers are ready, executing');
@@ -150,8 +150,8 @@ exports.start = function(cliOptions, done) {
     log.debug('Execution (fired by runner)');
 
     if (!capturedBrowsers.length) {
-      log.warn('No captured browser, open http://localhost:' + config.port + config.urlRoot);
-      socket.end('No captured browser, open http://localhost:' + config.port + config.urlRoot + '\n');
+      log.warn('No captured browser, open http://' + config.hostname + ':' + config.port + config.urlRoot);
+      socket.end('No captured browser, open http://' + config.hostname + ':' + config.port + config.urlRoot + '\n');
       return;
     }
 

--- a/test/unit/launcher.spec.coffee
+++ b/test/unit/launcher.spec.coffee
@@ -66,7 +66,7 @@ describe 'launcher', ->
     describe 'launch', ->
 
       it 'should start all browsers', ->
-        l.launch ['Chrome', 'ChromeCanary'], 1234
+        l.launch ['Chrome', 'ChromeCanary'], 'localhost', 1234
 
         expect(mockSpawn).to.have.been.calledTwice
         expect(mockSpawn.getCall(0).args[0]).to.equal 'google-chrome'
@@ -74,9 +74,13 @@ describe 'launcher', ->
 
 
       it 'should allow launching a script', ->
-        l.launch ['/usr/local/bin/special-browser'], 1234, '/'
+        l.launch ['/usr/local/bin/special-browser'], 'localhost', 1234, '/'
         expect(mockSpawn).to.have.been.calledWith '/usr/local/bin/special-browser', ['http://localhost:1234/?id=1']
 
+
+      it 'should use the non default host', ->
+        l.launch ['/usr/local/bin/special-browser'], '127.0.0.1', 1234, '/'
+        expect(mockSpawn).to.have.been.calledWith '/usr/local/bin/special-browser', ['http://127.0.0.1:1234/?id=1']
 
 
     describe 'kill', ->
@@ -86,7 +90,7 @@ describe 'launcher', ->
         exitSpy = sinon.spy()
 
       it 'should kill all running processe', ->
-        l.launch ['Chrome', 'ChromeCanary'], 1234
+        l.launch ['Chrome', 'ChromeCanary'], 'localhost', 1234
         l.kill()
 
         expect(mockSpawn._processes.length).to.equal 2
@@ -95,7 +99,7 @@ describe 'launcher', ->
 
 
       it 'should call callback when all processes killed', ->
-        l.launch ['Chrome', 'ChromeCanary'], 1234
+        l.launch ['Chrome', 'ChromeCanary'], 'localhost', 1234
         l.kill exitSpy
 
         expect(exitSpy).not.to.have.been.called
@@ -112,7 +116,7 @@ describe 'launcher', ->
 
 
       it 'should call callback even if a process had already been killed', (done) ->
-        l.launch ['Chrome', 'ChromeCanary'], 1234, '/', 0, 1 # disable retry
+        l.launch ['Chrome', 'ChromeCanary'], 'localhost', 1234, '/', 0, 1 # disable retry
         mockSpawn._processes[0].emit 'close', 1
         mockSpawn._processes[1].emit 'close', 1
 
@@ -126,7 +130,7 @@ describe 'launcher', ->
     describe 'areAllCaptured', ->
 
       it 'should return true if only if all browsers captured', ->
-        l.launch ['Chrome', 'ChromeCanary'], 1234
+        l.launch ['Chrome', 'ChromeCanary'], 'localhost', 1234
 
         expect(l.areAllCaptured()).to.equal  false
 
@@ -140,7 +144,7 @@ describe 'launcher', ->
     describe 'onExit', ->
 
       it 'should kill all browsers', (done) ->
-        l.launch ['Chrome', 'ChromeCanary'], 1234, '/', 0, 1
+        l.launch ['Chrome', 'ChromeCanary'], 'localhost', 1234, '/', 0, 1
 
         emitter.emitAsync('exit').then done
 


### PR DESCRIPTION
Add an optional 'host' parameter to the configuration
Usecase:
- application requires a virtual host naming pattern.
- map the hostname on /etc/hosts
- make testacular run on that hostname and launches
  the test browsers on that hostname.
