### PR TITLE
Change default urlRoot to '/__testacular/'

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -120,7 +120,7 @@ var parseConfig = function(configFilePath, cliOptions) {
     captureTimeout: 60000,
     proxies: {},
     preprocessors: {'**/*.coffee': 'coffee'},
-    urlRoot: '/',
+    urlRoot: '/__testacular/',
     reportSlowerThan: 0,
     junitReporter: {
       outputFile: 'test-results.xml',


### PR DESCRIPTION
Reopening vojtajina/testacular#268 against the master branch instead of stable.

Looking through issues & google groups, there's a pain point when testacular captures the root path for itself.

I don't see any use case where the default urlRoot _should_ be '/' -- and quite the opposite is true; every application will have _something_ bound to '/' -- so, it seems more logical to bind the test runner to something that won't collide with the code under test.
