### PR TITLE
Added support for more mime-types on served static files

### DIFF
--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -5,17 +5,13 @@ var util = require('util');
 var querystring = require('querystring');
 var httpProxy = require('http-proxy');
 var pause = require('pause');
+var mime = require('mime');
 
 var helper = require('./helper');
 var proxy = require('./proxy');
 var log = require('./logger').create('web server');
 
 var SCRIPT_TAG = '<script type="text/javascript" src="%s"></script>';
-var MIME_TYPE = {
-  txt: 'text/plain',
-  html: 'text/html',
-  js: 'application/javascript'
-};
 
 
 var setNoCacheHeaders = function(response) {
@@ -34,7 +30,7 @@ var serveStaticFile = function(file, response, process) {
     }
 
     // set content type
-    response.setHeader('Content-Type', MIME_TYPE[file.split('.').pop()] || MIME_TYPE.txt);
+    response.setHeader('Content-Type', mime.lookup(file, 'text/plain'));
 
     // call custom process fn to transform the data
     var responseData = process && process(data.toString(), response) || data;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "istanbul": "0.1.22",
     "lodash": "~0.9.1",
     "growly": "~1.1.0",
-    "pause": ">= 0.0.1"
+    "pause": ">= 0.0.1",
+    "mime": ">= 1.2.7"
   },
   "devDependencies": {
     "grunt": ">= 0.4.0rc1",


### PR DESCRIPTION
I added this to be able to serve other files too in addition to the 3 file-types (txt, html, js) that are supported now. This fix will add support for all 600+ types and 800+ extensions defined by the Apache project.
