### PR TITLE
Add --disable-web-security flag to Chrome launcher.

### DIFF
--- a/lib/launchers/Chrome.js
+++ b/lib/launchers/Chrome.js
@@ -13,6 +13,7 @@ var ChromeBrowser = function() {
       '--no-first-run',
       '--disable-default-apps',
       '--start-maximized',
+      '--disable-web-security',
       url
     ];
   };


### PR DESCRIPTION
Adding the disable-web-security flag to Chrome (and likely safari) no longer forces the tests to run through a proxy, eliminating the headaches seen in #86, #90, #179, and others. When using ANGULAR_SCENARIO, tests can now do things like

```
browser().navigateTo("http://www.nytimes.com/")
expect(element('.story').count()).toBeGreaterThan 0
```

The entire suite becomes, in a stroke, much more powerful and easy to use than Selenium.

Major drawbacks: I haven't been able to find similar flags for Firefox or IE.
