### PR TITLE
chore: Make Travis.ci run the default 'grunt' command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_script:
   - sh -e /etc/init.d/xvfb start
   - npm link
   - npm install -g grunt-cli
-  - grunt build
 
 script:
-  - grunt test
+  - grunt


### PR DESCRIPTION
The default grunt command should always pass, so Travis.ci should run that instead of a custom task list.

Depends on [#301](https://github.com/vojtajina/testacular/pull/301) to get jshint passing first.
