### PR TITLE
feat (reporter.stream): Add a reporter suitable for capture to a file

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -59,8 +59,10 @@ var createReporters = function(names, config, emitter) {
 // PUBLISH
 exports.Dots = require('./reporters/Dots');
 exports.Progress = require('./reporters/Progress');
+exports.Stream = require('./reporters/Stream');
 exports.DotsColor = require('./reporters/DotsColor');
 exports.ProgressColor = require('./reporters/ProgressColor');
+exports.StreamColor = require('./reporters/StreamColor');
 exports.JUnit = require('./reporters/JUnit');
 exports.Coverage = require('./reporters/Coverage');
 exports.Growl = require('./reporters/Growl');

--- a/lib/reporters/Stream.js
+++ b/lib/reporters/Stream.js
@@ -1,0 +1,28 @@
+var util = require('util');
+var BaseReporter = require('./Base');
+
+
+var StreamReporter = function(formatError, reportSlow) {
+  BaseReporter.call(this, formatError, reportSlow);
+
+  this.specSuccess = function(browser) {
+    this.write(this._render());
+  };
+
+  this.onBrowserComplete = function(browser) {
+    this.write(this._render());
+  };
+
+
+  this.onRunStart = function(browsers) {
+    this._browsers = browsers;
+  };
+
+  this._render = function() {
+    return this._browsers.map(this.renderBrowser).join('\n') + '\n';
+  };
+};
+
+
+// PUBLISH
+module.exports = StreamReporter;

--- a/lib/reporters/StreamColor.js
+++ b/lib/reporters/StreamColor.js
@@ -1,0 +1,12 @@
+var StreamReporter = require('./Stream');
+var BaseColorReporter = require('./BaseColor');
+
+
+var StreamColorReporter = function(formatError, reportSlow) {
+  StreamReporter.call(this, formatError, reportSlow);
+  BaseColorReporter.call(this);
+};
+
+
+// PUBLISH
+module.exports = StreamColorReporter;


### PR DESCRIPTION
The project is moving to log4js for logging but while tests are running
as part of an ant build can can be useful to have a reporter that just
streams the output to the console.  Progress is okay at this, but also
spew navigation characters.  If you're looking the output from a text file,
it is very ugly.

The Stream reporter is a stripped down thin wrapper around Base. I'm not
sure it makes sense for it to have a color option, but I've included it
for now.
