### PR TITLE
refactor: Move context setup into testactular.js

### DIFF
--- a/static/context.html
+++ b/static/context.html
@@ -15,24 +15,8 @@ Realoaded before every execution run.
        into it. If it is before body, then it fails to find the body and crashes and burns in an epic
        manner. -->
   <script type="text/javascript">
-    // TODO(vojta): extract this into context.js
-    window.__testacular__ = window.parent.testacular;
-
-    // This causes memory leak in Chrome (17.0.963.66)
-    window.onerror = function() {
-      return window.__testacular__.error.apply(window.__testacular__, arguments);
-    };
-
-    // patch the console
-    (function(window, tc) {
-      var console = window.console = window.console || {log: function() {}};
-      var browserConsoleLog = console.log;
-
-      console.log = function() {
-        tc.info({dump: Array.prototype.slice.call(arguments, 0)});
-        return browserConsoleLog.apply(console, arguments);
-      };
-    })(window, window.__testacular__);
+    // sets window.__testacular__ and overrides console and error handling
+    window.parent.testacular.setupContext(window);
 
     // All served files with the latest timestamps
     %MAPPINGS%

--- a/static/testacular.src.js
+++ b/static/testacular.src.js
@@ -42,6 +42,34 @@ var Testacular = function(socket, context, navigator, location) {
   var hasError = false;
   var store = {};
 
+  this.setupContext = function(contextWindow) {
+
+    var getConsole = function(currentWindow) {
+      return currentWindow.console || {
+          log: function() {},
+          warn: function() {},
+          error: function() {},
+          debug: function() {}
+        };
+    };
+
+    contextWindow.__testacular__ = this;
+
+    // This causes memory leak in Chrome (17.0.963.66)
+    contextWindow.onerror = function() {
+      return contextWindow.__testacular__.error.apply(contextWindow.__testacular__, arguments);
+    };
+
+    // patch the console
+    var localConsole = contextWindow.console = getConsole(contextWindow);
+    var browserConsoleLog = localConsole.log;
+
+    localConsole.log = function() {
+      contextWindow.__testacular__.info({dump: Array.prototype.slice.call(arguments, 0)});
+      return browserConsoleLog.apply(localConsole, arguments);
+    };
+  };
+
   var clearContext = function() {
     context.src = 'about:blank';
   };


### PR DESCRIPTION
Context doesn't need a separate js, it just needs a method in testacular.js to call.
