### PR TITLE
fix(runner) Added meta tags for utf-8 encoding.

### DIFF
--- a/static/debug.html
+++ b/static/debug.html
@@ -9,6 +9,7 @@ just for immediate execution, without reporting to Testacular server.
   <title>Testacular DEBUG RUNNER</title>
   <!-- TOOD(vojta): create simple favicon and cache it -->
   <link href="data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQEAYAAABPYyMiAAAABmJLR0T///////8JWPfcAAAACXBIWXMAAABIAAAASABGyWs+AAAAF0lEQVRIx2NgGAWjYBSMglEwCkbBSAcACBAAAeaR9cIAAAAASUVORK5CYII=" rel="icon" type="image/x-icon" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>
   <!-- The scripts need to be at the end of body, so that some test running frameworks

--- a/static/safari.html
+++ b/static/safari.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Safari REDIRECTS to Testacular</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <script type="text/javascript">
     window.location = '%URL%';
   </script>


### PR DESCRIPTION
Lack of charset specification in the document casuses the testrunners to fail when including scripts that use utf8 encodings, such as [d3js does here](https://github.com/mbostock/d3/blob/master/d3.js#L17).
