### PR TITLE
chore(deps): Use socket.io@0.9.13 

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "Igor Minar <igor@angularjs.org>"
   ],
   "dependencies": {
-    "socket.io": "0.9.0",
+    "socket.io": "0.9.13",
     "chokidar": "0.5.3",
     "glob": "3.1.14",
     "minimatch": "0.2.5",


### PR DESCRIPTION
Testacular 0.5.9 npm install fails during ws@0.4.0 preinstall on CentOS configuration

Socket.io@0.9.0 depends on ws@0.4.0, which appears had a bug in it.  Update to latest socket.io to fix this.  Testacular@0.5.7, which installed socket.io@0.9.13, worked just fine.

Related error output:  

```
 npm http GET https://registry.npmjs.org/amdefine
 
 > ws@0.4.0 preinstall /data/build/jenkins/workspace/webr-master-chrome/Webr/node_modules/testacular/node_modules/socket.io/node_modules/socket.io-client/node_modules/ws
 > make
 
 node-waf configure build
 make: node-waf: Command not found
 make: *** [all] Error 127
 npm ERR! error rolling back Error: ENOTEMPTY, rmdir '/data/build/jenkins/workspace/webr-master-chrome/Webr/node_modules/testacular/node_modules/socket.io/node_modules/socket.io-client/node_modules/uglify-js/test/unit/compress/test'
 npm ERR! error rolling back  socket.io-client@0.9.0 { [Error: ENOTEMPTY, rmdir '/data/build/jenkins/workspace/webr-master-chrome/Webr/node_modules/testacular/node_modules/socket.io/node_modules/socket.io-client/node_modules/uglify-js/test/unit/compress/test']
 npm ERR! error rolling back   errno: 53,
 npm ERR! error rolling back   code: 'ENOTEMPTY',
 npm ERR! error rolling back   path: '/data/build/jenkins/workspace/webr-master-chrome/Webr/node_modules/testacular/node_modules/socket.io/node_modules/socket.io-client/node_modules/uglify-js/test/unit/compress/test' }




 npm ERR! ws@0.4.0 preinstall: `make`
 npm ERR! `sh "-c" "make"` failed with 2
 npm ERR! 
 npm ERR! Failed at the ws@0.4.0 preinstall script.
 npm ERR! This is most likely a problem with the ws package,
 npm ERR! not with npm itself.
 npm ERR! Tell the author that this fails on your system:
 npm ERR!     make
 npm ERR! You can get their info via:
 npm ERR!     npm owner ls ws
 npm ERR! There is likely additional logging output above.
 
 npm ERR! System Linux 2.6.32-279.14.1.el6.centos.plus.x86_64
 npm ERR! command "/usr/bin/node" "/usr/bin/npm" "install"
 npm ERR! cwd /data/build/jenkins/workspace/webr-master-chrome/Webr/epubrender
 npm ERR! node -v v0.8.14
 npm ERR! npm -v 1.1.65
 npm ERR! code ELIFECYCLE
 npm http 304 https://registry.npmjs.org/amdefine
 npm ERR! Error: ENOENT, lstat '/data/build/jenkins/workspace/webr-master-chrome/Webr/node_modules/testacular/node_modules/socket.io/node_modules/socket.io-client/node_modules/uglify-js/tmp/app.js'
 npm ERR! If you need help, you may report this log at:
 npm ERR!     <http://github.com/isaacs/npm/issues>
 npm ERR! or email it to:
 npm ERR!     <npm-@googlegroups.com>
 
 npm ERR! System Linux 2.6.32-279.14.1.el6.centos.plus.x86_64
 npm ERR! command "/usr/bin/node" "/usr/bin/npm" "install"
 npm ERR! cwd /data/build/jenkins/workspace/webr-master-chrome/Webr/epubrender
 npm ERR! node -v v0.8.14
 npm ERR! npm -v 1.1.65
 npm ERR! path /data/build/jenkins/workspace/webr-master-chrome/Webr/node_modules/testacular/node_modules/socket.io/node_modules/socket.io-client/node_modules/uglify-js/tmp/app.js
 npm ERR! fstream_path /data/build/jenkins/workspace/webr-master-chrome/Webr/node_modules/testacular/node_modules/socket.io/node_modules/socket.io-client/node_modules/uglify-js/tmp/app.js
 npm ERR! fstream_type File
 npm ERR! fstream_class FileWriter
 npm ERR! code ENOENT
 npm ERR! errno 34
 npm ERR! fstream_stack Writer._finish.er.fstream_finish_call (/usr/local/nodejs/node-v0.8.14-linux-x64/lib/node_modules/npm/node_modules/fstream/lib/writer.js:284:26)
 npm ERR! fstream_stack Object.oncomplete (fs.js:297:15)
 npm http GET https://registry.npmjs.org/cli
 npm http 304 https://registry.npmjs.org/cli
 npm ERR! 
 npm ERR! Additional logging details can be found in:
 npm ERR!     /data/build/jenkins/workspace/webr-master-chrome/Webr/epubrender/npm-debug.log
 npm ERR! not ok code 0
```
