### PR TITLE
use bare false for CoffeeScript pre-compiler

### DIFF
--- a/lib/preprocessors/Coffee.js
+++ b/lib/preprocessors/Coffee.js
@@ -7,7 +7,7 @@ var Coffee = function(content, file, basePath, done) {
 
   var processed = null;
   try {
-    processed = coffee.compile(content, {bare: true});
+    processed = coffee.compile(content, {bare: false});
   } catch (e) {
     log.error('%s\n  at %s', e.message, file.originalPath);
   }


### PR DESCRIPTION
For real, most people use CoffeeScript with javascript wrapper support.

That allows us to define internal variables without needing to manual generate a scope to fun around our file.
I had issues and just noticed that was because Testacular compiling my CS code as bare (without a wrap).

Since I think most people use their CS compiled with bare:false, would be better to have it as default.
