### PR TITLE
Crash when proxied request is hung up by browser.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -61,7 +61,7 @@ var createProxyHandler = function(proxy, proxyConfig) {
     };
   }
   proxy.on('proxyError', function(err, req, resp) {
-    if (err.code === 'ECONNRESET' && resp.socket.destroyed) {
+    if (err.code === 'ECONNRESET' && req.socket.destroyed) {
       log.debug('failed to proxy %s (browser hang up the socket)', req.url);
     } else {
       log.warn('failed to proxy %s (%s)', req.url, err);


### PR DESCRIPTION
When the browser hangs up socket and the proxied server didn't manage to start responding, it seems that resp parameter in 'proxyError' event is not filled out.

```
Sample resp: { domain: null,
  _events: { finish: [Function] },
  _maxListeners: 10,
  output: [],
  outputEncodings: [],
  writable: true,
  _last: false,
  chunkedEncoding: false,
  shouldKeepAlive: true,
  useChunkedEncodingByDefault: true,
  sendDate: true,
  _hasBody: true,
  _trailer: '',
  finished: false }
```

As we see, it doesn't have a .socket object and crashes the process:

```
ERROR [testacular]: [TypeError: Cannot read property 'destroyed' of undefined]
TypeError: Cannot read property 'destroyed' of undefined
    at i (/usr/lib/node_modules/testacular/lib/proxy.js:67:49)
    at EventEmitter.emit (events.js:126:20)
    at EventEmitter.emit (events.js:106:17)
    at ClientRequest.proxyError (/usr/lib/node_modules/testacular/node_modules/http-proxy/lib/node-http-proxy/http-proxy.js:186:14)
    at ClientRequest.g (events.js:192:14)
    at ClientRequest.EventEmitter.emit (events.js:96:17)
    at Socket.socketCloseListener (http.js:1378:9)
    at Socket.EventEmitter.emit (events.js:126:20)
    at Socket._destroy.destroyed (net.js:358:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```

So, to fix it, we use req, which is guaranteed to be filled out and .socket.destroyed is set to true in this case.
