### PR TITLE
fix: global error handler should propagate errors

### DIFF
--- a/static/karma.src.js
+++ b/static/karma.src.js
@@ -86,7 +86,7 @@ var Karma = function(socket, context, navigator, location) {
     hasError = true;
     socket.emit('error', msg + '\nat ' + url + ':' + line);
     this.complete();
-    return true;
+    return false;
   };
 
   this.result = function(result) {


### PR DESCRIPTION
Does anybody remember why it was returning true ? I really don't remember why I did it.

Closes #368
