### PR TITLE
chore: Update package.json to use a specific commit of node-di

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "Fred Sauer <fredsa@google.com>"
   ],
   "dependencies": {
-    "di": "git://github.com/vojtajina/node-di.git",
+    "di": "git://github.com/vojtajina/node-di.git#db32a5f1",
     "socket.io": "0.9.13",
     "chokidar": "0.5.3",
     "glob": "3.1.20",


### PR DESCRIPTION
Other dependencies are locked to specific versions. di should be as well.
