### PR TITLE
autoStart option

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -92,6 +92,15 @@ it again. After three attempts to capture it, Testacular will give up.
 See [config/files] for more information.
 
 
+## autoStart
+**Type:** Boolean
+
+**Default:** `true`
+
+**Description** If false, the tests will not start automatically. A file in the files array config
+needs to call `__testacular__.start()`.
+
+
 ## hostname
 **Type:** String
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -209,7 +209,8 @@ var parseConfig = function(configFilePath, cliOptions) {
       'testacular-chrome-launcher',
       'testacular-firefox-launcher',
       'testacular-phantomjs-launcher'
-    ]
+    ],
+    autoStart: true
   };
 
   // merge the config from config file and cliOptions (precendense)

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -43,7 +43,7 @@ var serveStaticFile = function(file, response, process) {
 
 
 var createTestacularSourceHandler = function(promiseContainer, staticFolder, adapterFolder,
-    baseFolder, urlRoot) {
+    baseFolder, urlRoot, autoStart) {
   return function(request, response, next) {
     var requestUrl = request.url.replace(/\?.*/, '');
 
@@ -117,7 +117,11 @@ var createTestacularSourceHandler = function(promiseContainer, staticFolder, ada
 
           mappings = 'window.__testacular__.files = {\n' + mappings.join(',\n') + '\n};\n';
 
-          return data.replace('%SCRIPTS%', scriptTags.join('\n')).replace('%MAPPINGS%', mappings);
+          autoStart = autoStart ? '' : 'window.__testacular__.autoStart = false;';
+
+          return data.replace('%SCRIPTS%', scriptTags.join('\n'))
+                     .replace('%MAPPINGS%', mappings)
+                     .replace('%AUTOSTART%', autoStart);
         });
       });
     }
@@ -173,9 +177,9 @@ var createSourceFileHandler = function(promiseContainer, adapterFolder, baseFold
 
 
 var createHandler = function(promiseContainer, staticFolder, adapterFolder, baseFolder, proxyFn,
-    proxies, urlRoot) {
+    proxies, urlRoot, autoStart) {
   var testacularSrcHandler = createTestacularSourceHandler(promiseContainer, staticFolder,
-      adapterFolder, baseFolder, urlRoot);
+      adapterFolder, baseFolder, urlRoot, autoStart);
   var proxiedPathsHandler = proxy.createProxyHandler(proxyFn, proxies);
   var sourceFileHandler = createSourceFileHandler(promiseContainer, adapterFolder, baseFolder);
 
@@ -192,7 +196,7 @@ var createHandler = function(promiseContainer, staticFolder, adapterFolder, base
 };
 
 
-exports.createWebServer = function (baseFolder, proxies, urlRoot) {
+exports.createWebServer = function (baseFolder, proxies, urlRoot, autoStart) {
   var staticFolder = path.normalize(__dirname + '/../static');
   var adapterFolder = path.normalize(__dirname + '/../adapter');
 
@@ -202,7 +206,7 @@ exports.createWebServer = function (baseFolder, proxies, urlRoot) {
 
   var server = http.createServer(createHandler(promiseContainer,
       helper.normalizeWinPath(staticFolder), helper.normalizeWinPath(adapterFolder), baseFolder,
-      new httpProxy.RoutingProxy({changeOrigin: true}), proxies, urlRoot));
+      new httpProxy.RoutingProxy({changeOrigin: true}), proxies, urlRoot, autoStart));
 
   server.updateFilesPromise = function(promise) {
     promiseContainer.promise = promise;
@@ -211,4 +215,10 @@ exports.createWebServer = function (baseFolder, proxies, urlRoot) {
   return server;
 };
 
-exports.createWebServer.$inject = ['config.basePath', 'config.proxies', 'config.urlRoot'];
+exports.createWebServer.$inject = [
+  'config.basePath',
+  'config.proxies',
+  'config.urlRoot',
+  'config.autoStart'
+];
+

--- a/static/context.html
+++ b/static/context.html
@@ -24,6 +24,7 @@ Realoaded before every execution run.
   <!-- Dynamically replaced with <script> tags -->
   %SCRIPTS%
   <script type="text/javascript">
+    %AUTOSTART%
     window.__testacular__.loaded();
   </script>
 </body>

--- a/static/testacular.src.js
+++ b/static/testacular.src.js
@@ -100,6 +100,11 @@ var Testacular = function(socket, context, navigator, location) {
 
   // all files loaded, let's start the execution
   this.loaded = function() {
+
+    // let a userfile call start manually
+    if (this.autoStart === false) {
+      return;
+    }
     // has error -> cancel
     if (!hasError) {
       this.start(config);

--- a/test/client/testacular.spec.js
+++ b/test/client/testacular.spec.js
@@ -33,6 +33,13 @@ describe('testacular', function() {
     expect(spyStart).not.toHaveBeenCalled();
   });
 
+  it('should not start execution if autoStart is false', function() {
+    tc.autoStart = false;
+    tc.loaded();
+
+    expect(spyStart).not.toHaveBeenCalled();
+  });
+
 
   it('should remove reference to start even after syntax error', function() {
     tc.error('syntax error', '/some/file.js', 11);


### PR DESCRIPTION
closes #375

Can prevent tests from being run automatically
for scenarios that require an application to
do some initialization work before starting tests