### PR TITLE
fix(web-server): Socket.write TypeError in 0.10.0

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -166,7 +166,7 @@ exports.start = function(cliOptions, done) {
       // clean up, close runner socket
       globalEmitter.once('run_complete', function(browsers, results) {
         resultReporter.removeAdapter(socketWrite);
-        socket.end(!results.exitCode && constant.EXIT_CODE_0);
+        socket.end(results.exitCode ? void 0 : constant.EXIT_CODE_0);
       });
     });
 


### PR DESCRIPTION
### Commit

Stop 'run_complete' handler from passing boolean false to socket.end()
when the run results' exit code is non-zero.

Prevent the boolean from propagating to Socket.write and triggering
'invalid data' in 0.10.0.
### Details
#### Versions
- os: OSX 10.8 + Ubuntu 12.04.2 (VMware Fusion)
- node: v0.10.0-linux-x64
- chrome: 27.0.1440.0 canary
- testacular: 0.6.0
- mocha: 1.8.2
#### test.js

``` js
describe('really short example', function() {
  it('should throw', function() {
    throw new Error('end the world');
  });
});
```
#### testacular.conf.js

``` js
basePath = '';
files = [
  MOCHA,
  MOCHA_ADAPTER,
  'test.js'
];
reporters = ['progress'];
port = 9876;
runnerPort = 9100;
colors = true;
logLevel = LOG_WARN;
autoWatch = false;
browsers = [];
captureTimeout = 60000;
singleRun = false;
```
#### `testacular run` output, 1 run (unpatched)

```
Chrome 27.0 (Mac) really short example should throw FAILED
    Error: end the world
        at Context.<anonymous> (/var/dev/testacular-mocha-example/test.js:3:11)
Chrome 27.0 (Mac): Executed 1 of 1 (1 FAILED) (0.067 secs / NaN secs)
```
#### `testacular start` output, 1 run (unpatched)

```
Chrome 27.0 (Mac) really short example should throw FAILED
    Error: end the world
        at Context.<anonymous> (/var/dev/testacular-mocha-example/test.js:3:11)
Chrome 27.0 (Mac): Executed 1 of 1 (1 FAILED) (0.067 secs / NaN secs)
ERROR [testacular]: [TypeError: invalid data]
TypeError: invalid data
    at Socket.write (net.js:580:11)
    at Socket.Writable.end (_stream_writable.js:322:10)
    at Socket.end (net.js:380:31)
    at null.<anonymous> (/var/dev/testacular-mocha-example/node_modules/testacular/lib/server.js:169:16)
    at g (events.js:175:14)
    at EventEmitter.emit (events.js:117:20)
    at null.<anonymous> (/var/dev/testacular-mocha-example/node_modules/testacular/lib/server.js:124:21)
    at EventEmitter.emit (events.js:117:20)
    at onComplete (/var/dev/testacular-mocha-example/node_modules/testacular/lib/browser.js:76:13)
    at Socket.EventEmitter.emit [as $emit] (events.js:95:17)
```

[net.js:580](https://github.com/joyent/node/blob/v0.10.0/lib/net.js#L580)
#### `testacular start` output, 3 runs (patched)

```
Chrome 27.0 (Mac) really short example should throw FAILED
    Error: end the world
        at Context.<anonymous> (/var/dev/testacular-mocha-example/test.js:3:11)
Chrome 27.0 (Mac): Executed 1 of 1 (1 FAILED) (0.056 secs / NaN secs)
Chrome 27.0 (Mac) really short example should throw FAILED
    Error: end the world
        at Context.<anonymous> (/var/dev/testacular-mocha-example/test.js:3:11)
Chrome 27.0 (Mac): Executed 1 of 1 (1 FAILED) (0.032 secs / NaN secs)
Chrome 27.0 (Mac) really short example should throw FAILED
    Error: end the world
        at Context.<anonymous> (/var/dev/testacular-mocha-example/test.js:3:11)
Chrome 27.0 (Mac): Executed 1 of 1 (1 FAILED) (0.029 secs / NaN secs
```
