### PR TITLE
fix (init): fix for failing "testacular init" on Windows

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -135,7 +135,7 @@ var StateMachine = function(rli) {
       this.suggestNextOption();
     }
 
-    if (!key.ctrl && !key.meta && key.name !== 'enter') {
+    if (!key.ctrl && !key.meta && key.name !== 'enter' && key.name !== 'return') {
       key.name = 'escape';
     }
   };


### PR DESCRIPTION
fix (init): fix for failing "testacular init" on Windows

Change the testacular init so it can succeed on Windows where key.name is "return", not "enter"
