### PR TITLE
docs: update links to point to new karma repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@
 
 #### Bug Fixes
 
-* **adapter.requirejs:** do not configure baseUrl automatically ([63f3f409](https://github.com/testacular/testacular/commit/63f3f409ae85a5137396a7ed6537bedfe4437cb3), closes [#291](https://github.com/testacular/testacular/issues/291))
-* **init:** add missing browsers (Opera, IE) ([f39e5645](https://github.com/testacular/testacular/commit/f39e5645ec561c2681d907f7c1611f01911ee8fd))
-* **reporter.junit:** Add browser log output to JUnit.xml ([f108799a](https://github.com/testacular/testacular/commit/f108799a4d8fd95b8c0250ee83c23ada25d026b9), closes [#302](https://github.com/testacular/testacular/issues/302))
+* **adapter.requirejs:** do not configure baseUrl automatically ([63f3f409](https://github.com/karma-runner/karma/commit/63f3f409ae85a5137396a7ed6537bedfe4437cb3), closes [#291](https://github.com/karma-runner/karma/issues/291))
+* **init:** add missing browsers (Opera, IE) ([f39e5645](https://github.com/karma-runner/karma/commit/f39e5645ec561c2681d907f7c1611f01911ee8fd))
+* **reporter.junit:** Add browser log output to JUnit.xml ([f108799a](https://github.com/karma-runner/karma/commit/f108799a4d8fd95b8c0250ee83c23ada25d026b9), closes [#302](https://github.com/karma-runner/karma/issues/302))
 
 
 #### Features
 
-* add Teamcity reporter ([03e700ae](https://github.com/testacular/testacular/commit/03e700ae2234ca7ddb8f9235343e3b0c80868bbd))
-* **adapter.jasmine:** remove only last failed specs anti-feature ([435bf72c](https://github.com/testacular/testacular/commit/435bf72cb12112462940c8114fbaa19f9de38531), closes [#148](https://github.com/testacular/testacular/issues/148))
-* **config:** allow empty config file when called programmatically ([f3d77424](https://github.com/testacular/testacular/commit/f3d77424009f621e1fb9d60eeec7f052ebb3c585), closes [#358](https://github.com/testacular/testacular/issues/358))
+* add Teamcity reporter ([03e700ae](https://github.com/karma-runner/karma/commit/03e700ae2234ca7ddb8f9235343e3b0c80868bbd))
+* **adapter.jasmine:** remove only last failed specs anti-feature ([435bf72c](https://github.com/karma-runner/karma/commit/435bf72cb12112462940c8114fbaa19f9de38531), closes [#148](https://github.com/karma-runner/karma/issues/148))
+* **config:** allow empty config file when called programmatically ([f3d77424](https://github.com/karma-runner/karma/commit/f3d77424009f621e1fb9d60eeec7f052ebb3c585), closes [#358](https://github.com/karma-runner/karma/issues/358))
 
 <a name="v0.5.10"></a>
 ### v0.5.10 (2013-02-14)
@@ -24,15 +24,15 @@
 
 #### Bug Fixes
 
-* **init:** fix the logger configuration ([481dc3fd](https://github.com/testacular/testacular/commit/481dc3fd75f45a0efa8aabdb1c71e8234b9e8a06), closes [#340](https://github.com/testacular/testacular/issues/340))
-* **proxy:** fix crashing proxy when browser hangs connection ([1c78a01a](https://github.com/testacular/testacular/commit/1c78a01a19411accb86f0bde9e040e5088752575))
+* **init:** fix the logger configuration ([481dc3fd](https://github.com/karma-runner/karma/commit/481dc3fd75f45a0efa8aabdb1c71e8234b9e8a06), closes [#340](https://github.com/karma-runner/karma/issues/340))
+* **proxy:** fix crashing proxy when browser hangs connection ([1c78a01a](https://github.com/karma-runner/karma/commit/1c78a01a19411accb86f0bde9e040e5088752575))
 
 
 #### Features
 
-* set urlRoot to /__testacular__/ when proxying the root ([8b4fd64d](https://github.com/testacular/testacular/commit/8b4fd64df6b7d07b5479e43dcd8cd2aa5e1efc9c))
-* **adapter.requirejs:** normalize paths before appending timestamp ([94889e7d](https://github.com/testacular/testacular/commit/94889e7d2de701c67a2612e3fc6a51bfae891d36))
-* update dependencies to the latest ([93f96278](https://github.com/testacular/testacular/commit/93f9627817f2d5d9446de9935930ca85cfa7df7f), [e34d8834](https://github.com/testacular/testacular/commit/e34d8834d69ec4e022fcd6e1be4055add96d693c))
+* set urlRoot to /__testacular__/ when proxying the root ([8b4fd64d](https://github.com/karma-runner/karma/commit/8b4fd64df6b7d07b5479e43dcd8cd2aa5e1efc9c))
+* **adapter.requirejs:** normalize paths before appending timestamp ([94889e7d](https://github.com/karma-runner/karma/commit/94889e7d2de701c67a2612e3fc6a51bfae891d36))
+* update dependencies to the latest ([93f96278](https://github.com/karma-runner/karma/commit/93f9627817f2d5d9446de9935930ca85cfa7df7f), [e34d8834](https://github.com/karma-runner/karma/commit/e34d8834d69ec4e022fcd6e1be4055add96d693c))
 
 
 <a name="v0.5.9"></a>
@@ -41,16 +41,16 @@
 
 #### Bug Fixes
 
-* **adapter.requirejs:** show error if no timestamp defined for a file ([59dbdbd1](https://github.com/testacular/testacular/commit/59dbdbd136baa87467b9b9a4cb6ce226ae87bbef))
-* **init:** fix logger configuration ([557922d7](https://github.com/testacular/testacular/commit/557922d71941e0929f9cdc0d3794424a1f27b311))
-* **reporter:** remove newline from base reporter browser dump ([dfae18b6](https://github.com/testacular/testacular/commit/dfae18b63b413a1e6240d00b9dc0521ac0386ec5), closes [#297](https://github.com/testacular/testacular/issues/297))
-* **reporter.dots:** only add newline to message when needed ([dbe1155c](https://github.com/testacular/testacular/commit/dbe1155cb57fc4caa792f83f45288238db0fc7e0)
+* **adapter.requirejs:** show error if no timestamp defined for a file ([59dbdbd1](https://github.com/karma-runner/karma/commit/59dbdbd136baa87467b9b9a4cb6ce226ae87bbef))
+* **init:** fix logger configuration ([557922d7](https://github.com/karma-runner/karma/commit/557922d71941e0929f9cdc0d3794424a1f27b311))
+* **reporter:** remove newline from base reporter browser dump ([dfae18b6](https://github.com/karma-runner/karma/commit/dfae18b63b413a1e6240d00b9dc0521ac0386ec5), closes [#297](https://github.com/karma-runner/karma/issues/297))
+* **reporter.dots:** only add newline to message when needed ([dbe1155c](https://github.com/karma-runner/karma/commit/dbe1155cb57fc4caa792f83f45288238db0fc7e0)
 
 #### Features
 
-* add "debug" button to easily open debugging window ([da85aab9](https://github.com/testacular/testacular/commit/da85aab927edd1614e4e05b136dee834344aa3cb))
-* **config:** support running on a custom hostname ([b8c5fe85](https://github.com/testacular/testacular/commit/b8c5fe8533b13fd59cbf48972d2021069a84ae5b))
-* **reporter.junit:** add a 'skipped' tag for skipped testcases ([6286406e](https://github.com/testacular/testacular/commit/6286406e0a36a61125ea16d6f49be07030164cb0), closes [#321](https://github.com/testacular/testacular/issues/321))
+* add "debug" button to easily open debugging window ([da85aab9](https://github.com/karma-runner/karma/commit/da85aab927edd1614e4e05b136dee834344aa3cb))
+* **config:** support running on a custom hostname ([b8c5fe85](https://github.com/karma-runner/karma/commit/b8c5fe8533b13fd59cbf48972d2021069a84ae5b))
+* **reporter.junit:** add a 'skipped' tag for skipped testcases ([6286406e](https://github.com/karma-runner/karma/commit/6286406e0a36a61125ea16d6f49be07030164cb0), closes [#321](https://github.com/karma-runner/karma/issues/321))
 
 
 ### v0.5.8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ are some tips to get you started.
 ## Getting Started
 
 * Make sure you have a [GitHub account](https://github.com/signup/free)
-* Consider [submiting a ticket](https://github.com/vojtajina/testacular/issues/new) for your issue,
+* Consider [submiting a ticket](https://github.com/karma-runner/karma/issues/new) for your issue,
   assuming one does not already exist.
   * Clearly describe the issue including steps to reproduce when it is a bug.
   * Make sure you fill in the earliest version that you know has the issue.
@@ -97,8 +97,8 @@ $ grunt test:client
 * [GitHub pull request documentation]
 * [@TestacularJS]
 
-[Testacular - Git Commit Msg Format Conventions]: http://testacular.github.com/0.6.0/dev/git-commit-msg.html
-[Issue tracker]: https://github.com/vojtajina/testacular/issues
+[Testacular - Git Commit Msg Format Conventions]: http://karma-runner.github.com/0.6.0/dev/git-commit-msg.html
+[Issue tracker]: https://github.com/karma-runner/karma/issues
 [Mailing List]: https://groups.google.com/forum/#!forum/testacular
 [General GitHub documentation]: http://help.github.com/
 [GitHub pull request documentation]: http://help.github.com/send-pull-requests/

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ just a simple JavaScript or CoffeeScript file that tells Testacular
 where all the awesomeness of your project are.
 
 You can find a simple example in
-[test/client/testacular.conf.js](https://github.com/testacular/testacular/blob/master/test/client/testacular.conf.js)
+[test/client/testacular.conf.js](https://github.com/karma-runner/karma/blob/master/test/client/testacular.conf.js)
 which contains most of the options.
 
 To create your own from scratch there is the `init` command, which
@@ -124,7 +124,7 @@ use the awesome [Socket.io] library and [Node.js].
 ## This is so great. I want to help.
 
 See
-[Contributing.md](https://github.com/vojtajina/testacular/blob/master/CONTRIBUTING.md)
+[Contributing.md](https://github.com/karma-runner/karma/blob/master/CONTRIBUTING.md)
 or the [docs] for more information.
 
 
@@ -167,14 +167,14 @@ or the [docs] for more information.
 [here]: http://www.youtube.com/watch?v=MVw8N3hTfCI
 [installers]: http://nodejs.org/download/
 [Mailing List]: https://groups.google.com/forum/#!forum/testacular
-[Issuetracker]: https://github.com/testacular/testacular/issues
+[Issuetracker]: https://github.com/karma-runner/karma/issues
 [@TestacularJS]: http://twitter.com/TestacularJS
 [RequireJS]: http://requirejs.org/
 [Istanbul]: https://github.com/gotwarlost/istanbul
 
-[Browsers]: http://testacular.github.com/0.6.0/config/browsers.html
-[Versioning]: http://testacular.github.com/0.6.0/about/versioning.html
-[Configuration File Overview]: http://testacular.github.com/0.6.0/config/configuration-file.html
-[docs]: http://testacular.github.com
-[Docs]: http://testacular.github.com
-[website]: http://testacular.github.com
+[Browsers]: http://karma-runner.github.com/0.6.0/config/browsers.html
+[Versioning]: http://karma-runner.github.com/0.6.0/about/versioning.html
+[Configuration File Overview]: http://karma-runner.github.com/0.6.0/config/configuration-file.html
+[docs]: http://karma-runner.github.com
+[Docs]: http://karma-runner.github.com
+[website]: http://karma-runner.github.com

--- a/docs/about/01-changelog.md
+++ b/docs/about/01-changelog.md
@@ -4,15 +4,15 @@
 
 #### Bug Fixes
 
-* **init:** fix the logger configuration ([481dc3fd](https://github.com/testacular/testacular/commit/481dc3fd75f45a0efa8aabdb1c71e8234b9e8a06), closes [#340](https://github.com/testacular/testacular/issues/340))
-* **proxy:** fix crashing proxy when browser hangs connection ([1c78a01a](https://github.com/testacular/testacular/commit/1c78a01a19411accb86f0bde9e040e5088752575))
+* **init:** fix the logger configuration ([481dc3fd](https://github.com/karma-runner/karma/commit/481dc3fd75f45a0efa8aabdb1c71e8234b9e8a06), closes [#340](https://github.com/karma-runner/karma/issues/340))
+* **proxy:** fix crashing proxy when browser hangs connection ([1c78a01a](https://github.com/karma-runner/karma/commit/1c78a01a19411accb86f0bde9e040e5088752575))
 
 
 #### Features
 
-* set urlRoot to /__testacular__/ when proxying the root ([8b4fd64d](https://github.com/testacular/testacular/commit/8b4fd64df6b7d07b5479e43dcd8cd2aa5e1efc9c))
-* **adapter.requirejs:** normalize paths before appending timestamp ([94889e7d](https://github.com/testacular/testacular/commit/94889e7d2de701c67a2612e3fc6a51bfae891d36))
-* update dependencies to the latest ([93f96278](https://github.com/testacular/testacular/commit/93f9627817f2d5d9446de9935930ca85cfa7df7f), [e34d8834](https://github.com/testacular/testacular/commit/e34d8834d69ec4e022fcd6e1be4055add96d693c))
+* set urlRoot to /__testacular__/ when proxying the root ([8b4fd64d](https://github.com/karma-runner/karma/commit/8b4fd64df6b7d07b5479e43dcd8cd2aa5e1efc9c))
+* **adapter.requirejs:** normalize paths before appending timestamp ([94889e7d](https://github.com/karma-runner/karma/commit/94889e7d2de701c67a2612e3fc6a51bfae891d36))
+* update dependencies to the latest ([93f96278](https://github.com/karma-runner/karma/commit/93f9627817f2d5d9446de9935930ca85cfa7df7f), [e34d8834](https://github.com/karma-runner/karma/commit/e34d8834d69ec4e022fcd6e1be4055add96d693c))
 
 
 <a name="v0.5.9"></a>
@@ -21,16 +21,16 @@
 
 #### Bug Fixes
 
-* **adapter.requirejs:** show error if no timestamp defined for a file ([59dbdbd1](https://github.com/testacular/testacular/commit/59dbdbd136baa87467b9b9a4cb6ce226ae87bbef))
-* **init:** fix logger configuration ([557922d7](https://github.com/testacular/testacular/commit/557922d71941e0929f9cdc0d3794424a1f27b311))
-* **reporter:** remove newline from base reporter browser dump ([dfae18b6](https://github.com/testacular/testacular/commit/dfae18b63b413a1e6240d00b9dc0521ac0386ec5), closes [#297](https://github.com/testacular/testacular/issues/297))
-* **reporter.dots:** only add newline to message when needed ([dbe1155c](https://github.com/testacular/testacular/commit/dbe1155cb57fc4caa792f83f45288238db0fc7e0)
+* **adapter.requirejs:** show error if no timestamp defined for a file ([59dbdbd1](https://github.com/karma-runner/karma/commit/59dbdbd136baa87467b9b9a4cb6ce226ae87bbef))
+* **init:** fix logger configuration ([557922d7](https://github.com/karma-runner/karma/commit/557922d71941e0929f9cdc0d3794424a1f27b311))
+* **reporter:** remove newline from base reporter browser dump ([dfae18b6](https://github.com/karma-runner/karma/commit/dfae18b63b413a1e6240d00b9dc0521ac0386ec5), closes [#297](https://github.com/karma-runner/karma/issues/297))
+* **reporter.dots:** only add newline to message when needed ([dbe1155c](https://github.com/karma-runner/karma/commit/dbe1155cb57fc4caa792f83f45288238db0fc7e0)
 
 #### Features
 
-* add "debug" button to easily open debugging window ([da85aab9](https://github.com/testacular/testacular/commit/da85aab927edd1614e4e05b136dee834344aa3cb))
-* **config:** support running on a custom hostname ([b8c5fe85](https://github.com/testacular/testacular/commit/b8c5fe8533b13fd59cbf48972d2021069a84ae5b))
-* **reporter.junit:** add a 'skipped' tag for skipped testcases ([6286406e](https://github.com/testacular/testacular/commit/6286406e0a36a61125ea16d6f49be07030164cb0), closes [#321](https://github.com/testacular/testacular/issues/321))
+* add "debug" button to easily open debugging window ([da85aab9](https://github.com/karma-runner/karma/commit/da85aab927edd1614e4e05b136dee834344aa3cb))
+* **config:** support running on a custom hostname ([b8c5fe85](https://github.com/karma-runner/karma/commit/b8c5fe8533b13fd59cbf48972d2021069a84ae5b))
+* **reporter.junit:** add a 'skipped' tag for skipped testcases ([6286406e](https://github.com/karma-runner/karma/commit/6286406e0a36a61125ea16d6f49be07030164cb0), closes [#321](https://github.com/karma-runner/karma/issues/321))
 
 
 ### v0.5.8

--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -223,7 +223,7 @@ sometimes you might want to proxy a url that is already taken by Testacular.
 
 
 
-[test/client/testacular.conf.js]: https://github.com/testacular/testacular/blob/master/test/client/testacular.conf.js
+[test/client/testacular.conf.js]: https://github.com/karma-runner/karma/blob/master/test/client/testacular.conf.js
 [config/files]: files.html
 [config/browsers]: browsers.html
 [config/preprocessors]: preprocessors.html

--- a/docs/config/03-browsers.md
+++ b/docs/config/03-browsers.md
@@ -63,4 +63,4 @@ parameter to be used to connect to the server. The supplied id is used
 by the server to determine when the specific browser is captured.
 
 
-[launchers]: https://github.com/testacular/testacular/blob/master/lib/launchers
+[launchers]: https://github.com/karma-runner/karma/blob/master/lib/launchers

--- a/docs/config/04-preprocessors.md
+++ b/docs/config/04-preprocessors.md
@@ -34,7 +34,7 @@ return `false` and the preprocessor would not be executed on the CoffeeScript fi
 
 [files]: files.html
 [minimatch]: https://github.com/isaacs/minimatch
-[coffee]: https://github.com/testacular/testacular/blob/v0.5.8/lib/preprocessors/Coffee.js
-[live]: https://github.com/testacular/testacular/blob/v0.5.8/lib/preprocessors/Live.js
-[html2js]: https://github.com/testacular/testacular/blob/v0.5.8/lib/preprocessors/Html2js.js
-[coverage]: https://github.com/testacular/testacular/blob/v0.5.8/lib/preprocessors/Coverage.js
+[coffee]: https://github.com/karma-runner/karma/blob/v0.5.8/lib/preprocessors/Coffee.js
+[live]: https://github.com/karma-runner/karma/blob/v0.5.8/lib/preprocessors/Live.js
+[html2js]: https://github.com/karma-runner/karma/blob/v0.5.8/lib/preprocessors/Html2js.js
+[coverage]: https://github.com/karma-runner/karma/blob/v0.5.8/lib/preprocessors/Coverage.js

--- a/docs/dev/02-contributing.md
+++ b/docs/dev/02-contributing.md
@@ -4,7 +4,7 @@ are some tips to get you started.
 ## Getting Started
 
 * Make sure you have a [GitHub account](https://github.com/signup/free)
-* [Submit](https://github.com/testacular/testacular/issues/new) a ticket for your issue, assuming one does not
+* [Submit](https://github.com/karma-runner/karma/issues/new) a ticket for your issue, assuming one does not
   already exist.
   * Clearly describe the issue including steps to reproduce when it is a bug.
   * Make sure you fill in the earliest version that you know has the issue.
@@ -58,7 +58,7 @@ If grunt fails, make sure grunt-0.4x is installed: https://github.com/gruntjs/gr
 
 ## Additional Resources
 
-* [Issue tracker](https://github.com/testacular/testacular/issues)
+* [Issue tracker](https://github.com/karma-runner/karma/issues)
 * [Mailing List](https://groups.google.com/forum/#!forum/testacular)
 * [General GitHub documentation](http://help.github.com/)
 * [GitHub pull request documentation](http://help.github.com/send-pull-requests/)

--- a/docs/intro/02-configuration.md
+++ b/docs/intro/02-configuration.md
@@ -31,5 +31,5 @@ overrides the configuration from the config file.
 Try `testacular start --help` if you want to see all available options.
 
 
-[test/client/testacular.conf.js]: https://github.com/testacular/testacular/blob/master/test/client/testacular.conf.js
+[test/client/testacular.conf.js]: https://github.com/karma-runner/karma/blob/master/test/client/testacular.conf.js
 [configuration file docs]: configuration_file.html

--- a/docs/intro/03-troubleshooting.md
+++ b/docs/intro/03-troubleshooting.md
@@ -32,7 +32,7 @@ In the event that your tests fail or freeze, this may be the result of
 a browser having a display message show up, a browser update prompt or
 extension-related conflict that needs to be taken care of.
 
-[#202]: https://github.com/testacular/testacular/issues/202
-[#74]: https://github.com/testacular/testacular/issues/74
+[#202]: https://github.com/karma-runner/karma/issues/202
+[#74]: https://github.com/karma-runner/karma/issues/74
 [chocolatey]: (http://chocolatey.org/)
 [mailing list]: https://groups.google.com/forum/#!forum/testacular

--- a/docs/plus/02-RequireJS.md
+++ b/docs/plus/02-RequireJS.md
@@ -97,7 +97,7 @@ tests to run every time I add a test. There is no config option for
 this, but there's an easy way to get around it by filtering the tests
 from the `window.__testacular__.files` object.
 The code is included in the example below and the original suggestion
-came from <https://github.com/testacular/testacular/pull/236>.
+came from <https://github.com/karma-runner/karma/pull/236>.
 
 ### Asynchronously Run Testacular
 Because the RequireJs require statements are asynchronous, Testacular

--- a/docs/plus/06-Teamcity.md
+++ b/docs/plus/06-Teamcity.md
@@ -1,1 +1,1 @@
-Not available yet. See this [pull request](https://github.com/testacular/testacular/pull/262).
+Not available yet. See this [pull request](https://github.com/karma-runner/karma/pull/262).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Spectacular Test Runner for JavaScript.",
   "homepage": "http://vojtajina.github.com/testacular/",
   "bugs": {
-    "url": "https://github.com/vojtajina/testacular/issues"
+    "url": "https://github.com/karma-runner/karma/issues"
   },
   "keywords": [
     "Testacular",
@@ -103,7 +103,7 @@
   "preferGlobal": true,
   "repository": {
     "type": "git",
-    "url": "git://github.com/vojtajina/testacular.git"
+    "url": "git://github.com/karma-runner/karma.git"
   },
   "main": "./lib/index",
   "bin": {

--- a/tasks/lib/changelog.js
+++ b/tasks/lib/changelog.js
@@ -12,8 +12,8 @@ var GIT_TAG_CMD = 'git describe --tags --abbrev=0';
 
 var PATCH_HEADER_TPL = '<a name="%s"></a>\n### %s (%s)\n\n';
 var MINOR_HEADER_TPL = '<a name="%s"></a>\n## %s (%s)\n\n';
-var LINK_ISSUE = '[#%s](https://github.com/testacular/testacular/issues/%s)';
-var LINK_COMMIT = '[%s](https://github.com/testacular/testacular/commit/%s)';
+var LINK_ISSUE = '[#%s](https://github.com/karma-runner/karma/issues/%s)';
+var LINK_COMMIT = '[%s](https://github.com/karma-runner/karma/commit/%s)';
 
 var EMPTY_COMPONENT = '$$';
 var MAX_SUBJECT_LENGTH = 80;

--- a/test/client/testacular.conf.js
+++ b/test/client/testacular.conf.js
@@ -3,7 +3,7 @@
 // Most of the options can be overriden by cli arguments (see testacular --help)
 //
 // For all available config options and default values, see:
-// https://github.com/vojtajina/testacular/blob/stable/lib/config.js#L54
+// https://github.com/karma-runner/karma/blob/stable/lib/config.js
 
 
 // base path, that will be used to resolve files and exclude

--- a/test/unit/config.spec.coffee
+++ b/test/unit/config.spec.coffee
@@ -140,7 +140,7 @@ describe 'config', ->
 
 
     it 'should override config with cli options, but not deep merge', ->
-      # regression https://github.com/vojtajina/testacular/issues/283
+      # regression https://github.com/karma-runner/karma/issues/283
       config = e.parseConfig '/home/config7.js', {browsers: ['Safari']}
 
       expect(config.browsers).to.deep.equal ['Safari']


### PR DESCRIPTION
This updates links in docs (including changelog, contributing, readme, comments, manifest)
- https://github.com/testacular/testacular/ to https://github.com/karma-runner/karma/
- http://testacular.github.com/ to http://karma-runner.github.com/
- https://github.com/vojtajina/testacular/ to https://github.com/karma-runner/karma/
