### PR TITLE
style(runner): Add new test reporters to CLI output

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -99,7 +99,7 @@ var describeStart = function() {
     .describe('log-level', '<disable | error | warn | info | debug> Level of logging.')
     .describe('colors', 'Use colors when reporting and printing logs.')
     .describe('no-colors', 'Do not use colors when reporting or printing logs.')
-    .describe('reporters', 'List of reporters (available: dots, progress, junit).')
+    .describe('reporters', 'List of reporters (available: dots, progress, junit, growl, coverage).')
     .describe('browsers', 'List of browsers to start (eg. --browsers Chrome,ChromeCanary,Firefox).')
     .describe('capture-timeout', '<integer> Kill browser if does not capture in given time [ms].')
     .describe('single-run', 'Run the test when browsers captured and exit.')


### PR DESCRIPTION
Add 'growl' and 'coverage' to possible test reporter values in 'karma start --help'
