### PR TITLE
fix(config): ensure basePath is always resolved

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -243,6 +243,9 @@ var parseConfig = function(configFilePath, cliOptions) {
     // always ignore the config file itself
     config.exclude.push(configFilePath);
   }
+  else {
+    config.basePath = path.resolve(config.basePath);
+  }
 
   return normalizeConfig(config);
 };

--- a/test/unit/config.spec.coffee
+++ b/test/unit/config.spec.coffee
@@ -235,6 +235,12 @@ describe 'config', ->
       expect(config.basePath).to.equal resolveWinPath('/some') # overriden by CLI
       expect(config.urlRoot).to.equal '/' # default value
 
+    it 'should not read config file, when null but still resolve cli basePath', ->
+      config = e.parseConfig null, {basePath: './some' }
+
+      expect(logSpy).not.to.have.been.called
+      expect(config.basePath).to.equal resolveWinPath('./some')
+      expect(config.urlRoot).to.equal '/' # default value
 
   describe 'normalizeConfig', ->
 


### PR DESCRIPTION
Slight addition to the commit https://github.com/karma-runner/karma/commit/98724b6ef5a6ba60d487e7b774056832c6ca9d8c for issue https://github.com/karma-runner/karma/issues/447 to make sure the base path is always resolved.
