### PR TITLE
feat(config): allow custom properties in config file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -182,6 +182,7 @@ var readConfigFile = function(filepath) {
     process.exit(1);
   }
   
+  // Clean up the env before we return it.
   for (var i in initSandbox) {
     delete configEnv[i];
   }


### PR DESCRIPTION
Before config would only recognize a set of predefined properties. With this change it would allow arbitrary properties in the config file which would be accessible by plugins.
