### PR TITLE
feat(preprocessors): add's support for configuring preprocessors

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -24,14 +24,20 @@ var createPreprocessor = function(config, basePath, injector) {
         });
       }
 
-      preprocessors.shift()(content, file, nextPreprocessor);
+      var preprocessor = preprocessors.shift();
+      preprocessor.pp(content, file, nextPreprocessor, preprocessor.options || {});
     };
-    var instantiatePreprocessor = function(preprocessorName) {
+    var instantiatePreprocessor = function(preprocessor) {
+      if (!preprocessor.name) {
+        preprocessor = {name: preprocessor};
+      }
+
       try {
-        preprocessors.push(injector.get('preprocessor:' + preprocessorName));
+        preprocessor.pp = injector.get('preprocessor:' + preprocessor.name);
+        preprocessors.push(preprocessor);
       } catch (e) {
         // TODO(vojta): log warning only once per each preprocessor
-        log.warn('Pre-processor "%s" is not registered!', preprocessorName);
+        log.warn('Pre-processor "%s" is not registered!', preprocessor.name);
       }
     };
 


### PR DESCRIPTION
this feature allow users to configure the preprocessors when setting them up on configuration, one example about where it can be useful is on Coffeescript preprocessor, to do as:

``` javascript
preprocessors = {
  '**/*.coffee': {
    name: 'coffee',
    options: {bare: false}
  }
};
```

this will enable the preprocessors to accept options, making them customizable
