### PR TITLE
feat: Allow exclude option to be configured from command line

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -51,6 +51,10 @@ var processArgs = function(argv, options) {
     options.reporters = options.reporters.split(',');
   }
 
+  if (helper.isString(options.exclude)) {
+    options.exclude = options.exclude.split(',');
+  }
+
   options.configFile = path.resolve(argv._.shift() || 'karma.conf.js');
 
   return options;

--- a/test/unit/cli.spec.coffee
+++ b/test/unit/cli.spec.coffee
@@ -80,3 +80,7 @@ describe 'cli', ->
 
       options = processArgs ['--reporters', 'dots']
       expect(options.reporters).to.deep.equal ['dots']
+
+    it 'should cast exclude to array', ->
+      options = processArgs ['--exclude', 'foo.js,bar.js']
+      expect(options.exclude).to.deep.equal ['foo.js', 'bar.js']


### PR DESCRIPTION
Allow exclude option to be passed in from command line.

Example:

``` sh
$ karma start --exclude=lib/foo.js,lib/bar.js
```

Use case:  I have two different versions of a library that I want to test against.  Instead of having two karma files, I just include both versions of the library in the karma.conf.js and exclude one or the other through a Makefile when testing.
