### PR TITLE
feat: pass command line opts through to browser

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -56,6 +56,17 @@ var processArgs = function(argv, options) {
   return options;
 };
 
+var parseClientArgs = function(argv) {
+  // extract any args after '--' as clientArgs
+  var clientArgs = [];
+  argv = argv.slice(2);
+  var idx = argv.indexOf('--');
+  if (idx !== -1) {
+    clientArgs = argv.slice(idx + 1);
+  }
+  return clientArgs;
+};
+
 
 var describeShared = function() {
   optimist
@@ -65,7 +76,7 @@ var describeShared = function() {
            'Commands:\n' +
            '  start [<configFile>] [<options>] Start the server / do single run.\n' +
            '  init [<configFile>] Initialize a config file.\n' +
-           '  run [<options>] Trigger a test run.\n\n' +
+           '  run [<options>] [ -- <clientArgs>] Trigger a test run.\n\n' +
            'Run --help with particular command to see its description and available options.')
     .describe('help', 'Print usage and options.')
     .describe('version', 'Print current version.');
@@ -136,6 +147,7 @@ exports.process = function() {
 
   case 'run':
     describeRun();
+    options.clientArgs = parseClientArgs(process.argv);
     break;
 
   case 'init':
@@ -159,3 +171,4 @@ exports.process = function() {
 
 // just for testing
 exports.processArgs = processArgs;
+exports.parseClientArgs = parseClientArgs;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -50,4 +50,6 @@ exports.run = function(config, done) {
   socket.on('close', function() {
     done(exitCode);
   });
+
+  socket.write(JSON.stringify({args: config.clientArgs}) + '\0');
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -67,6 +67,7 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
   var executionScheduled = false;
   var pendingCount = 0;
   var runningBrowsers;
+  var clientConfig = {args: config.clientArgs};
 
   globalEmitter.on('browsers_change', function() {
     // TODO(vojta): send only to interested browsers
@@ -100,7 +101,7 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
       pendingCount = capturedBrowsers.length;
       runningBrowsers = capturedBrowsers.clone();
       globalEmitter.emit('run_start', runningBrowsers);
-      socketServer.sockets.emit('execute', {});
+      socketServer.sockets.emit('execute', clientConfig);
       return true;
     } else {
       log.info('Delaying execution, these browsers are not ready: ' + nonReady.join(', '));
@@ -139,34 +140,47 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
 
   // listen on port, waiting for runner
   var runnerServer = net.createServer(function (socket) {
-    log.debug('Execution (fired by runner)');
+    var buf = '';
+    socket.on('data', function(data) {
+      buf += data;
 
-    if (!capturedBrowsers.length) {
-      var url = 'http://' + config.hostname + ':' + config.port + config.urlRoot;
+      // data is followed by a NUL byte, so keep buffering until that's present
+      if (buf[buf.length - 1] !== '\0') {
+        return;
+      }
 
-      log.warn('No captured browser, open ' + url);
-      socket.end('No captured browser, open ' + url + '\n');
-      return;
-    }
+      // strip the NUL byte and parse
+      clientConfig = JSON.parse(buf.substr(0, buf.length - 1));
+      buf = '';
+      log.debug('Execution (fired by runner)');
 
-    if (!capturedBrowsers.areAllReady([])) {
-      socket.write('Waiting for previous execution...\n');
-    }
+      if (!capturedBrowsers.length) {
+        var url = 'http://' + config.hostname + ':' + config.port + config.urlRoot;
 
-    globalEmitter.once('run_start', function() {
-      var socketWrite = socket.write.bind(socket);
+        log.warn('No captured browser, open ' + url);
+        socket.end('No captured browser, open ' + url + '\n');
+        return;
+      }
 
-      resultReporter.addAdapter(socketWrite);
+      if (!capturedBrowsers.areAllReady([])) {
+        socket.write('Waiting for previous execution...\n');
+      }
 
-      // clean up, close runner socket
-      globalEmitter.once('run_complete', function(browsers, results) {
-        resultReporter.removeAdapter(socketWrite);
-        socket.end(constant.EXIT_CODE + results.exitCode);
+      globalEmitter.once('run_start', function() {
+        var socketWrite = socket.write.bind(socket);
+
+        resultReporter.addAdapter(socketWrite);
+
+        // clean up, close runner socket
+        globalEmitter.once('run_complete', function(browsers, results) {
+          resultReporter.removeAdapter(socketWrite);
+          socket.end(constant.EXIT_CODE + results.exitCode);
+        });
       });
-    });
 
-    log.debug('Refreshing all the files / patterns');
-    fileList.refresh();
+      log.debug('Refreshing all the files / patterns');
+      fileList.refresh();
+    });
   });
 
   runnerServer.on('error', function(e) {

--- a/static/karma.src.js
+++ b/static/karma.src.js
@@ -46,12 +46,12 @@ var instanceOf = function(value, constructorName) {
 
 /* jshint unused: false */
 var Karma = function(socket, context, navigator, location) {
-  var config;
   var hasError = false;
   var store = {};
   var self = this;
 
   this.VERSION = VERSION;
+  this.config = {};
 
   this.setupContext = function(contextWindow) {
     if (hasError) {
@@ -210,7 +210,7 @@ var Karma = function(socket, context, navigator, location) {
   this.loaded = function() {
     // has error -> cancel
     if (!hasError) {
-      this.start(config);
+      this.start(this.config);
     }
 
     // remove reference to child iframe
@@ -240,7 +240,7 @@ var Karma = function(socket, context, navigator, location) {
   socket.on('execute', function(cfg) {
     // reset hasError and reload the iframe
     hasError = false;
-    config = cfg;
+    self.config = cfg;
     context.src = CONTEXT_URL;
 
     // clear the console before run

--- a/test/e2e/pass-opts/karma.conf.js
+++ b/test/e2e/pass-opts/karma.conf.js
@@ -1,0 +1,19 @@
+module.exports = function(config) {
+  config.set({
+    frameworks: ['jasmine'],
+
+    files: [
+      '*.js'
+    ],
+
+    browsers: [ process.env.TRAVIS ? 'Firefox' : 'Chrome' ],
+
+    reporters: ['dots'],
+
+    plugins: [
+      'karma-jasmine',
+      'karma-chrome-launcher',
+      'karma-firefox-launcher'
+    ],
+  });
+};

--- a/test/e2e/pass-opts/test.js
+++ b/test/e2e/pass-opts/test.js
@@ -1,0 +1,6 @@
+describe('config', function() {
+  it('should be passed through to the browser', function() {
+    expect(window.__karma__.config).toBeDefined();
+    expect(window.__karma__.config.args).toEqual(['arg1','arg2','arg3']);
+  });
+});

--- a/test/unit/cli.spec.coffee
+++ b/test/unit/cli.spec.coffee
@@ -8,9 +8,9 @@ describe 'cli', ->
   CWD = process.cwd()
   path = require 'path'
 
-  processArgs = (args) ->
+  processArgs = (args, opts) ->
     argv = optimist.parse(args)
-    cli.processArgs argv, {}
+    cli.processArgs argv, opts || {}
 
   describe 'processArgs', ->
 
@@ -80,3 +80,13 @@ describe 'cli', ->
 
       options = processArgs ['--reporters', 'dots']
       expect(options.reporters).to.deep.equal ['dots']
+
+
+  describe 'parseClientArgs', ->
+    it 'should return arguments after --', ->
+      args = cli.parseClientArgs(['node', 'karma.js', 'runArg', '--flag', '--', '--foo', '--bar', 'baz']);
+      expect(args).to.deep.equal ['--foo', '--bar', 'baz']
+
+    it 'should return empty args if -- is not present', ->
+      args = cli.parseClientArgs(['node', 'karma.js', 'runArg', '--flag', '--foo', '--bar', 'baz']);
+      expect(args).to.deep.equal []


### PR DESCRIPTION
For large test suites, always running all the tests is slow. This change allows command-line arguments to be passed through to the runner as the single option to `__karma__.run`. This allows you to target specific tests per-run (when combined with a browser-side runner function that uses this feature).

BREAKING CHANGE:

The config file is no longer assumed to be the first argument, it must be specified with either -c or --config-file. I had to do this in order for unknown arguments to be pass through unmolested.
