### PR TITLE
feat(config): allow configurable launchers, preprocessors, reporters

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -173,6 +173,37 @@ var KarmaDsl = function(config) {
       config[key] = newConfig[key];
     });
   };
+
+  // this.defineLauncher
+  // this.defineReporter
+  // this.definePreprocessor
+  ['launcher', 'reporter', 'preprocessor'].forEach(function(type) {
+    this['define' + helper.ucFirst(type)] = function(name, base, options) {
+      var module = Object.create(null);
+      var token = type + ':' + base;
+      var locals = {
+        args: ['value', options]
+      };
+
+      if (!helper.isString(name)) {
+        return log.warn('Can not define %s. Name has to be a string.', type);
+      }
+
+      if (!helper.isString(base)) {
+        return log.warn('Can not define %s %s. Missing parent %s.', type, name, type);
+      }
+
+      if (!helper.isObject(options)) {
+        return log.warn('Can not define %s %s. Arguments has to be an object.', type, name);
+      }
+
+      module[type + ':' + name] = ['factory', function(injector) {
+        return injector.createChild([locals], [token]).get(token);
+      }];
+
+      config.plugins.push(module);
+    };
+  }, this);
 };
 
 var parseConfig = function(configFilePath, cliOptions) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -246,7 +246,8 @@ exports.start = function(cliOptions, done) {
     customFileHandlers: ['value', []],
     customScriptTypes: ['value', []],
     reporter: ['factory', reporter.createReporters],
-    capturedBrowsers: ['type', browser.Collection]
+    capturedBrowsers: ['type', browser.Collection],
+    args: ['value', {}]
   }];
 
   // load the plugins

--- a/test/unit/config.spec.coffee
+++ b/test/unit/config.spec.coffee
@@ -344,3 +344,53 @@ describe 'config', ->
       expect(pattern.included).to.equal true
       expect(pattern.watched).to.equal false
       expect(pattern.served).to.equal false
+
+
+  describe 'DSL', ->
+    di = require 'di'
+    dsl = config = null
+
+    forwardArgsFactory = (args) ->
+      args
+
+    baseModule =
+      'preprocessor:base': ['type', forwardArgsFactory]
+      'launcher:base': ['type', forwardArgsFactory]
+      'reporter:base': ['type', forwardArgsFactory]
+
+    beforeEach ->
+      config = {plugins: []}
+      dsl = new m.KarmaDsl config
+
+
+    it 'should define a custom launcher', ->
+      dsl.defineLauncher 'custom', 'base', {first: 123, whatever: 'aaa'}
+
+      injector = new di.Injector([baseModule].concat config.plugins)
+      injectedArgs = injector.get 'launcher:custom'
+
+      expect(injectedArgs).to.be.defined
+      expect(injectedArgs.first).to.equal 123
+      expect(injectedArgs.whatever).to.equal 'aaa'
+
+
+    it 'should define a custom preprocessor', ->
+      dsl.definePreprocessor 'custom', 'base', {second: 123, whatever: 'bbb'}
+
+      injector = new di.Injector([baseModule].concat config.plugins)
+      injectedArgs = injector.get 'preprocessor:custom'
+
+      expect(injectedArgs).to.be.defined
+      expect(injectedArgs.second).to.equal 123
+      expect(injectedArgs.whatever).to.equal 'bbb'
+
+
+    it 'should define a custom reporter', ->
+      dsl.defineReporter 'custom', 'base', {third: 123, whatever: 'ccc'}
+
+      injector = new di.Injector([baseModule].concat config.plugins)
+      injectedArgs = injector.get 'reporter:custom'
+
+      expect(injectedArgs).to.be.defined
+      expect(injectedArgs.third).to.equal 123
+      expect(injectedArgs.whatever).to.equal 'ccc'


### PR DESCRIPTION
``` javascript
karma.configure({
  reporters: ['progress', 'html_coverage'],
  browsers: ['Chrome', 'my_chrome']
  preprocessors: {
    '**/*.coffee': ['coffee_bare']
  }
});

karma.defineLauncher('my_chrome', 'Chrome', {
  flags: ['--start-maximized']
});

karma.definePreprocessor('coffee_bare', 'coffee', {
  options: {
    bare: true
  }
});

karma.defineReporter('html_coverage', 'coverage', {
  ...
});
```

The reason, why I decided for this solution, rather than inlining (as proposed in #317) is that this solution allows using these custom launchers/reporters from CLI. It also makes it easier to create only a single instance of a preprocessor (if the configuration is the same).

In addition to defining/configuring custom reporters/launchers/preprocessors, each can have a global config, eg:

``` javascript
karma.configure({
  coffeePreprocessor: {
    options: {bare: false}
  }
});
```

What do you think ?
