### PR TITLE
fix karma.js: Fix for IE's console.log's lack of `apply`

### DIFF
--- a/static/karma.src.js
+++ b/static/karma.src.js
@@ -72,7 +72,7 @@ var Karma = function(socket, context, navigator, location) {
 
     localConsole.log = function() {
       contextWindow.__karma__.info({dump: Array.prototype.slice.call(arguments, 0)});
-      return browserConsoleLog.apply(localConsole, arguments);
+      return Function.prototype.apply.call(browserConsoleLog, localConsole, arguments);
     };
   };
 


### PR DESCRIPTION
Use Function.prototype.apply.call(log, ...) instead of log.apply(...)
to avoid an error when IE's console is open.

Closes #329
