### PR TITLE
BaseReporter's specFailure method to indent nested describe output

### DIFF
--- a/lib/reporters/Base.js
+++ b/lib/reporters/Base.js
@@ -38,6 +38,11 @@ var BaseReporter = function(formatError, reportSlow, adapter) {
 
       msg += util.format(' (%s / %s)', helper.formatTimeInterval(results.totalTime),
                                        helper.formatTimeInterval(results.netTime));
+
+      if (results.failed && results.total === totalExecuted) {
+        msg += this._writeFailures(browser);
+      }
+
     }
 
     return msg;
@@ -97,15 +102,72 @@ var BaseReporter = function(formatError, reportSlow, adapter) {
   this.specSuccess = this.specSkipped = function() {};
 
 
-  this.specFailure = function(browser, result) {
-    var specName = result.suite.join(' ') + ' ' + result.description;
-    var msg = util.format(this.SPEC_FAILURE, browser, specName);
+  function repeat(n, str) {
+    var res = [];
+    var i;
+    for (i = 0; i < n; ++i) {
+      res.push(str);
+    }
+    return res.join('');
+  }
 
-    result.log.forEach(function(log) {
-      msg += formatError(log, '\t');
+  this._writeFailures = function(browser) {
+
+    var specFailures = this._failures[browser.name];
+    var specHierarchy = {};
+    var report = [];
+
+    if (!specFailures) {
+      return '';
+    }
+
+    specFailures.forEach(function(failure) {
+
+      var result = failure.result;
+      var fullSpecPath = [].concat(failure.browser.name, result.suite, result.description);
+      var maxDepth = fullSpecPath.length - 1;
+
+      fullSpecPath.reduce(function(suite, describe, depth) {
+
+        var isFirst = depth === 0;
+        var isLast = depth === maxDepth;
+        var levelExists = describe in suite;
+        var message = describe;
+
+        if (!levelExists) {
+          suite[describe] = {};
+
+          if (isFirst) {
+            message = describe;
+          } else if (isLast) {
+            message = (repeat(depth, '  ') + '✘ ' + describe.underline);
+          } else {
+            message = (repeat(depth, '  ') + 'ட ' + describe);
+          }
+
+          report.push(message + '\n');
+        }
+
+        return suite[describe];
+
+      }, specHierarchy);
+
     });
 
-    this.writeCommonMsg(msg);
+    delete this._failures[browser.name];
+    report = '\n' + report.join('').red;
+    return report;
+
+  };
+
+
+  this.specFailure = function(browser, result) {
+    this._failures = this._failures || {};
+    this._failures[browser.name] = this._failures[browser.name] || [];
+    this._failures[browser.name].push({
+      browser: browser,
+      result: result
+    });
   };
 
 


### PR DESCRIPTION
The result of this change is that, in the case of failures - we apply indendation to our console output if the spec has nested describes.

```
PhantomJS 1.9 (Mac)
 ∟ angular.equals
  ∟ when supplied two values
   ∟ where the values do not match
        Expected null not to equal {}.
```

Otherwise we render on a single line as normal.

```
PhantomJS 1.9 (Mac) AppCtrl augments $scope with an expected API FAILED
        Expected undefined to be object.
```
