### PR TITLE
fix (config) properly pass the config object on to the adapters

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -243,6 +243,9 @@ var parseConfig = function(configFilePath, cliOptions) {
   // configure the logger as soon as we can
   logger.setup(config.logLevel, config.colors, config.loggers);
 
+  // keep non-karma options, useful for passing options on to adapters
+  helper._.defaults(config, cliOptions);
+
   return normalizeConfig(config, configFilePath);
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -100,7 +100,7 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
       pendingCount = capturedBrowsers.length;
       runningBrowsers = capturedBrowsers.clone();
       globalEmitter.emit('run_start', runningBrowsers);
-      socketServer.sockets.emit('execute', {});
+      socketServer.sockets.emit('execute', config);
       return true;
     } else {
       log.info('Delaying execution, these browsers are not ready: ' + nonReady.join(', '));

--- a/static/karma.src.js
+++ b/static/karma.src.js
@@ -1,5 +1,6 @@
 var CONTEXT_URL = 'context.html';
 var VERSION = '%KARMA_VERSION%';
+var config;
 
 // connect socket.io
 // https://github.com/LearnBoost/Socket.IO/wiki/Configuring-Socket.IO
@@ -42,7 +43,6 @@ socket.on('reconnect_failed', updateStatus('failed to reconnect'));
 
 /* jshint unused: false */
 var Karma = function(socket, context, navigator, location) {
-  var config;
   var hasError = false;
   var store = {};
 


### PR DESCRIPTION
This enables configuration of adapters via grunt-karma, command-line use, etc.
For example this enables passing a "grep" option through to the mocha adapter.

Previously the options were getting lost (all except karma-specific options) in parseConfig(). Also, the config options were never being passed on correctly to the adapters, just an empty object.

Combined with https://github.com/karma-runner/karma-mocha/pull/7 closes https://github.com/karma-runner/karma-mocha/issues/6
