### PR TITLE
fix (server): uncaught error via fs.stat on symlink

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -186,17 +186,22 @@ var List = function(patterns, excludes, emitter, preprocess) {
           pending++;
           matchedAndNotIgnored++;
           fs.stat(path, function(error, stat) {
-            if (!stat.isDirectory()) {
-              // TODO(vojta): reuse file objects
-              var file = new File(path, stat.mtime);
-
-              preprocess(file, function() {
-                buckets[i].push(file);
-                finish();
-              });
-            } else {
-              log.debug('Ignored directory "%s"', path);
+            if (error) {
+              log.debug('An error occured while reading "%s"', path);
               finish();
+            } else {
+              if (!stat.isDirectory()) {
+                // TODO(vojta): reuse file objects
+                var file = new File(path, stat.mtime);
+
+                preprocess(file, function() {
+                  buckets[i].push(file);
+                  finish();
+                });
+              } else {
+                log.debug('Ignored directory "%s"', path);
+                finish();
+              }
             }
           });
         });

--- a/test/unit/file-list.spec.coffee
+++ b/test/unit/file-list.spec.coffee
@@ -144,6 +144,15 @@ describe 'file-list', ->
         expect(files.served).to.exist
         done()
 
+    it 'should handle fs.stat errors', (done) ->
+      sinon.stub(mockFs, 'stat').yields([new Error(), null])
+      list = new m.List patterns('/some/*.js'), [], emitter, preprocessMock
+
+      refreshListAndThen (files) ->
+        mockFs.stat.restore()
+        done()
+
+
 
   #============================================================================
   # List.reload()


### PR DESCRIPTION
Hey All,

Preface: I've never contributed to large open source projects like `karma`, please bear with me and let me know what I can do to help out.

I was getting this error when running `karma` inside of `/Users/muffs/project` via `./node_modules/.bin/karma start`:

``` javascript
{ [Error: ENOENT, stat '/Users/muffs/project/static/js/lib/expect/support/mocha.js']
  errno: 34,
  code: 'ENOENT',
  path: '/Users/muffs/project/static/js/lib/expect/support/mocha.js' } '/Users/muffs/project/static/js/lib/expect/support/mocha.js'
ERROR [karma]: [TypeError: Cannot call method 'isDirectory' of undefined]
TypeError: Cannot call method 'isDirectory' of undefined
    at List.refresh (/Users/muffs/project/node_modules/karma/lib/file-list.js:187:23)
    at Object.oncomplete (fs.js:297:15)
```

Turns out that `/Users/muffs/project/static/js/lib/expect/support/mocha.js` is a symlink to `../node_modules/mocha/mocha.js`. Which is broken in this case. So it seems as though the `refresh` step would break if it found a broken symlink.

My small change ignores errors on fs.stat.
