### PR TITLE
Deal with errors when calling fs.stat in file-list.js

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -186,7 +186,7 @@ var List = function(patterns, excludes, emitter, preprocess) {
           pending++;
           matchedAndNotIgnored++;
           fs.stat(path, function(error, stat) {
-            if (!stat.isDirectory()) {
+            if (!error && !stat.isDirectory()) {
               // TODO(vojta): reuse file objects
               var file = new File(path, stat.mtime);
 
@@ -195,7 +195,7 @@ var List = function(patterns, excludes, emitter, preprocess) {
                 finish();
               });
             } else {
-              log.debug('Ignored directory "%s"', path);
+              log.debug('Ignored directory "%s", error "%s"', path, error);
               finish();
             }
           });


### PR DESCRIPTION
`fs.stat` call in `file-list.js` does not handle errors. In my case, it failed when finding broken symlinks with `[TypeError: Cannot call method 'isDirectory' of undefined]`.

At the point of submitting the PR, I just realised this is addressing the exact same issue as #586.
Feel free to disregard if the other solution looks better.
