### PR TITLE
docs: fix typo in public api page

### DIFF
--- a/docs/dev/01-public-api.md
+++ b/docs/dev/01-public-api.md
@@ -14,7 +14,7 @@ Equivalent of `karma start`.
 ```javascript
 var server = require('karma').server;
 server.start({port: 9877}, function(exitCode) {
-  console.log('Karma has exitted with ' + exitCode);
+  console.log('Karma has exited with ' + exitCode);
   process.exit(exitCode);
 });
 ```
@@ -28,7 +28,7 @@ Equivalent of `karma run`.
 ```javascript
 var runner = require('karma').runner;
 runner.run({runnerPort: 9100}, function(exitCode) {
-  console.log('Karma has exitted with ' + exitCode);
+  console.log('Karma has exited with ' + exitCode);
   process.exit(exitCode);
 });
 ```


### PR DESCRIPTION
Change 'exitted' to 'exited' in two places on the public api page.
