### PR TITLE
fix(html2js): handling of the backslash character

### DIFF
--- a/lib/preprocessors/Html2js.js
+++ b/lib/preprocessors/Html2js.js
@@ -8,7 +8,7 @@ var template = 'angular.module(\'%s\', []).run(function($templateCache) {\n' +
     '});\n';
 
 var escapeContent = function(content) {
-  return content.replace(/'/g, '\\\'').replace(/\r?\n/g, '\\n\' +\n    \'');
+  return content.replace(/\\/g, '\\\\').replace(/'/g, '\\\'').replace(/\r?\n/g, '\\n\' +\n    \'');
 };
 
 var Html2js = function(content, file, basePath, done) {

--- a/test/unit/preprocessors/Html2js.spec.coffee
+++ b/test/unit/preprocessors/Html2js.spec.coffee
@@ -40,3 +40,11 @@ describe 'preprocessors html2js', ->
     process 'first\r\nsecond', file, '/base', (processedContent) ->
       expect(processedContent).to.not.contain '\r'
       done()
+
+
+  it 'should preserve the backslash character', (done) ->
+    file = new File '/base/path/file.html'
+
+    process 'first\\second', file, '/base', (processedContent) ->
+      expect(processedContent).to.contain "'first\\\\second'"
+      done()


### PR DESCRIPTION
At the html2js preprocessor escape the backslash character when this is
present in a template

Closes #583
