### PR TITLE
fix(watcher): honor 'watched: false' in patterns.

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -3,6 +3,7 @@ var mm = require('minimatch');
 
 var helper = require('./helper');
 var log = require('./logger').create('watcher');
+var _ = require('lodash');
 
 var DIR_SEP = require('path').sep;
 
@@ -45,20 +46,25 @@ var watchPatterns = function(patterns, watcher) {
 // Function to test if an item is on the exclude list
 // and therefore should not be watched by chokidar
 // TODO(vojta): ignore non-matched files as well
-var createIgnore = function(excludes) {
+var createIgnore = function(excludes, patterns) {
+  var ex = _(patterns)
+            .filter(function(p) { return !(p.watched); })
+            .map('pattern')
+            .concat(excludes);
+
   return function(item) {
     var matchExclude = function(pattern) {
       log.debug('Excluding %s', pattern);
       return mm(item, pattern, {dot: true});
     };
-    return excludes.some(matchExclude);
+    return ex.some(matchExclude);
   };
 };
 
 exports.watch = function(patterns, excludes, fileList) {
   var options = {
     ignorePermissionErrors: true,
-    ignored: createIgnore(excludes)
+    ignored: createIgnore(excludes, patterns)
   };
   var chokidarWatcher = new chokidar.FSWatcher(options);
 

--- a/test/unit/watcher.spec.coffee
+++ b/test/unit/watcher.spec.coffee
@@ -95,3 +95,21 @@ describe 'watcher', ->
       expect(ignore '/some/files/deep/.npm').to.equal false
       expect(ignore '.#files.js').to.equal true
       expect(ignore '/some/files/deeper/nested/.#files.js').to.equal true
+
+    it 'should ignore patterns with watched: false', ->
+      ignore = m.createIgnore [], [{pattern: 'app/*.html', watched: false}]
+      expect(ignore 'app/app.html').to.equal true
+
+    it 'should not ignore patterns with watched: true', ->
+      ignore = m.createIgnore [], [{pattern: 'app/*.html', watched: true}]
+      expect(ignore 'app/app.html').to.equal false
+
+    it 'should combine exclude and patterns', ->
+      ignore = m.createIgnore ['app/*.ignoreme'], [
+        {pattern: 'app/*.html', watched: false},
+        {pattern: 'app/*.js', watched: true}]
+
+      expect(ignore 'app/please.ignoreme').to.equal true
+      expect(ignore 'app/dontwatch.html').to.equal true
+      expect(ignore 'app/dowatch.js').to.equal false
+


### PR DESCRIPTION
Includes the patterns for files to include, but not to watch, in
addition to the excludes list when creating a list of patterns
to ignore. This makes the watcher ignore patterns marked as
"watched: false" in karma's configuration file.

Closes: #616
