### PR TITLE
fix(coverage): depend on a modern version of istanbul

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "LiveScript": "1.0.1",
     "colors": "0.6.0-1",
     "dateformat": "1.0.2-1.2.3",
-    "istanbul": "0.1.22",
+    "istanbul": "~0.1.40",
     "lodash": "~1.1",
     "growly": "~1.1",
     "pause": "0.0.1",


### PR DESCRIPTION
0.1.22 has function coverage issues fixed in 0.1.40; use fuzzy version matching
0.1.22: http://bl.ocks.org/johan/raw/5942388/11133099070d95c2f2d36e9f3570881888a7af1e/given.js.html
0.1.40: http://bl.ocks.org/johan/raw/5942446/bb1ce82c73451b7cda711cd60d6984748c15d6c1/given.js.html
