### PR TITLE
fix(reporter): prevent throwing exception when null is sent to formatter

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -10,7 +10,7 @@ var createErrorFormatter = function(basePath, urlRoot) {
   return function(msg, indentation) {
     // remove domain and timestamp from source files
     // and resolve base path / absolute path urls into absolute path
-    msg = msg.replace(URL_REGEXP, function(full, prefix, path) {
+    msg = (msg || '').replace(URL_REGEXP, function(full, prefix, path) {
       if (prefix === 'base') {
         return basePath + path;
       } else if (prefix === 'absolute') {

--- a/test/unit/reporter.spec.coffee
+++ b/test/unit/reporter.spec.coffee
@@ -22,6 +22,8 @@ describe 'reporter', ->
     it 'should indent', ->
       expect(formatError 'Something', '\t').to.equal '\tSomething\n'
 
+    it 'should handle empty message', ->
+      expect(formatError null).to.equal '\n'
 
     it 'should remove domain from files', ->
       expect(formatError 'file http://localhost:8080/base/usr/a.js and ' +


### PR DESCRIPTION
In particular tests, the createErrorFormatter was recieving `null` instead of a string, causing the reporter to throw an exception and crash karma entirely. This was only happening in Firefox 22 - and I'm pretty sure it's due to the assert library I'm using, but better to protect against it.
