### PR TITLE
fix(web-server): fix the urlRegex property for customFileHandlers

### DIFF
--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -13,7 +13,7 @@ var proxyMiddleware = require('./middleware/proxy');
 var createCustomHandler = function(customFileHandlers, /* config.basePath */ basePath) {
   return function(request, response, next) {
     for (var i = 0; i < customFileHandlers.length; i++) {
-      if (customFileHandlers[i].urlRegexp.test(request.url)) {
+      if (customFileHandlers[i].urlRegex.test(request.url)) {
         return customFileHandlers[i].handler(request, response, 'fake/static', 'fake/adapter',
             basePath, 'fake/root');
       }


### PR DESCRIPTION
karma-dart depends on the 'urlRegex' name.

We could change it there if you want to keep urlRegexp
