### PR TITLE
IE missing module - added text to config template to make it clear

### DIFF
--- a/config.tpl.coffee
+++ b/config.tpl.coffee
@@ -44,7 +44,7 @@ module.exports = (config) ->
     # - Opera
     # - Safari (only Mac)
     # - PhantomJS
-    # - IE (only Windows)
+    # - IE (only Windows - has to be installed separately with 'npm install karma-ie-launcher --save-dev')
     browsers: [%BROWSERS%]
 
     # If browser does not capture in given timeout [ms], kill it

--- a/config.tpl.js
+++ b/config.tpl.js
@@ -53,7 +53,7 @@ module.exports = function(config) {
     // - Opera
     // - Safari (only Mac)
     // - PhantomJS
-    // - IE (only Windows)
+    // - IE (only Windows - has to be installed separately with 'npm install karma-ie-launcher --save-dev')
     browsers: [%BROWSERS%],
 
 


### PR DESCRIPTION
I was experiencing following problem:

```
C:\Users\BeoXTC\tmp\karma-init>karma start --browsers IE
INFO [karma]: Karma v0.10.1 server started at http://localhost:9876/
WARN [launcher]: Can not load "IE", it is not registered!
  Perhaps you are missing some plugin?
```

Once I installed karma-ie-launcher all went well. But to make it for newer users easier or more obvious I recommend adding those lines somewhere (or in the template).

If you have them already somewhere, consider put some reference link into config file or somewhere obvious.

I'm not angry if you dump this, but this was the first thought were I would consider this information as a newbie.
