### PR TITLE
Change warning message with updated instructions in the config file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -163,7 +163,14 @@ var normalizeConfig = function(config, configFilePath) {
 };
 
 // TODO(vojta): remove in 0.11
-var CONST_ERR = '%s is not supported anymore.\n\tPlease use `frameworks = ["%s"];` instead.';
+var CONFIG_SYNTAX_FRAMEWORKS_HELP = '  module.exports = function(config) {\n' +
+                                    '    config.set({\n' +
+                                    '      // your config\n' +
+                                    '      frameworks: ["%s"]\n' +
+                                    '    });\n' +
+                                    '  };\n';
+
+var CONST_ERR = '%s is not supported anymore. Please use:\n'+CONFIG_SYNTAX_FRAMEWORKS_HELP;
 ['JASMINE', 'MOCHA', 'QUNIT'].forEach(function(framework) {
   [framework, framework + '_ADAPTER'].forEach(function(name) {
     Object.defineProperty(global, name, {configurable: true, get: function() {


### PR DESCRIPTION
I updated my Karma and got this message:

``` bash
WARN [config]: JASMINE is not supported anymore.
    Please use `frameworks = ["jasmine"];` instead.

WARN [config]: JASMINE_ADAPTER is not supported anymore.
    Please use `frameworks = ["jasmine"];` instead.

ERROR [config]: Config file must export a function!
  module.exports = function(config) {
    config.set({
      // your config
    });
  };
```

I thought it was very confusing, because it suggests two different solutions and only the later works. So I thought this message would be more appropriate:

``` bash
WARN [config]: JASMINE is not supported anymore. Please use:
  module.exports = function(config) {
    config.set({
      // your config
      frameworks: ["jasmine"]
    });
  };

WARN [config]: JASMINE_ADAPTER is not supported anymore. Please use:
  module.exports = function(config) {
    config.set({
      // your config
      frameworks: ["jasmine"]
    });
  };

ERROR [config]: Config file must export a function!
  module.exports = function(config) {
    config.set({
      // your config
    });
  };
```
