### PR TITLE
docs(migration): module.export/module.exports

### DIFF
--- a/docs/about/03-migration.md
+++ b/docs/about/03-migration.md
@@ -77,7 +77,7 @@ files = [
 ];
 
 // change to
-module.export = function(config) {
+module.exports = function(config) {
   config.set({
     frameworks: ['jasmine'],
     files: ['*.js']


### PR DESCRIPTION
Change code snippet to use module.exports rather than module.export, because that's what the runner expects, and previous sample code doesn't work from copy-paste.
