### PR TITLE
fix: prevent double registration on reconnect

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -7,6 +7,7 @@ var util = require('./util');
 var Karma = function(socket, context, navigator, location) {
   var hasError = false;
   var startEmitted = false;
+  var hasRegistered = false;
   var store = {};
   var self = this;
   var queryParams = util.parseQueryParams(location.search);
@@ -195,19 +196,23 @@ var Karma = function(socket, context, navigator, location) {
 
   // report browser name, id
   socket.on('connect', function() {
-    var transport = socket.socket.transport.name;
+    // prevent double registration on reconnect
+    if (!hasRegistered) {
+        hasRegistered = true;
+        var transport = socket.socket.transport.name;
 
-    // TODO(vojta): make resultsBufferLimit configurable
-    if (transport === 'websocket' || transport === 'flashsocket') {
-      resultsBufferLimit = 1;
-    } else {
-      resultsBufferLimit = 50;
+        // TODO(vojta): make resultsBufferLimit configurable
+        if (transport === 'websocket' || transport === 'flashsocket') {
+          resultsBufferLimit = 1;
+        } else {
+          resultsBufferLimit = 50;
+        }
+
+        socket.emit('register', {
+          name: navigator.userAgent,
+          id: browserId
+        });
     }
-
-    socket.emit('register', {
-      name: navigator.userAgent,
-      id: browserId
-    });
   });
 };
 

--- a/test/client/karma.spec.js
+++ b/test/client/karma.spec.js
@@ -38,6 +38,13 @@ describe('Karma', function() {
     expect(spyStart).not.toHaveBeenCalled();
   });
 
+  it('should never register twice', function() {
+      var spyInfo = jasmine.createSpy('onInfo');
+      socket.on('register', spyInfo);
+      socket.emit('connect');
+      socket.emit('connect');
+      expect(spyInfo.calls.length).toEqual(1);
+  });
 
   it('should remove reference to start even after syntax error', function() {
     k.error('syntax error', '/some/file.js', 11);


### PR DESCRIPTION
When a reconnection occurs, a connect event is emitted on the client side. Before this fix the client was registering again on reconnect and then executing again (which was then causing a full page reload).
