### PR TITLE
fix: launcher kill method which was throwing an error if no callback was...

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -53,7 +53,9 @@ var Launcher = function(emitter, injector) {
       }
     }
 
-    process.nextTick(callback);
+    if (callback) {
+      process.nextTick(callback);
+    }
     return false;
   };
 

--- a/test/unit/launcher.spec.coffee
+++ b/test/unit/launcher.spec.coffee
@@ -96,6 +96,13 @@ describe 'launcher', ->
         expect(l.kill 'weid-id', done).to.equal false
         expect(browser.kill).not.to.have.been.called
 
+      it 'should not resolve callback if none was defined', (done) ->
+        l.launch ['Fake']
+        browser = FakeBrowser._instances.pop()
+
+        expect(l.kill 'weid-id').to.equal false
+        process.nextTick ->
+          done()
 
     describe 'killAll', ->
       exitSpy = null


### PR DESCRIPTION
... specified

bug introduced in https://github.com/karma-runner/karma/commit/8647266fd592fe245aaf2be964319d3026432e33

In server.js when singleRun = true, no callback is passed to when a browser complete to launcher.kill so if a browser is not yet connected but one has already finished the process throw an error.

TypeError: undefined is not a function
    at process._tickCallback (node.js:415:13)
