### PR TITLE
Fix: reconnect in singleRun mode

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -88,14 +88,15 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
     var replySocketEvents = events.bufferEvents(socket, ['info', 'error', 'result', 'complete']);
 
     socket.on('register', function(info) {
+      var capturedBrowser;
       var newBrowser;
 
       if (info.id) {
-        newBrowser = capturedBrowsers.getById(info.id);
+        capturedBrowser = capturedBrowsers.getById(info.id);
       }
 
-      if (newBrowser) {
-        newBrowser.onReconnect(socket);
+      if (capturedBrowser) {
+        capturedBrowser.onReconnect(socket);
       } else {
         newBrowser = injector.createChild([{
           id: ['value', info.id || null],
@@ -109,7 +110,7 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
       replySocketEvents();
 
       // execute in this browser immediately
-      if (config.singleRun) {
+      if (newBrowser && config.singleRun) {
         newBrowser.execute(config.client);
         singleRunBrowsers.add(newBrowser);
       }


### PR DESCRIPTION
on reconnect in singleRun mode the server was forcing the browser to execute the tests again form the beginning, which was causing a page reload error.
