### PR TITLE
fix(launcher): sigkill after sigint if not dead

### DIFF
--- a/lib/launchers/Base.js
+++ b/lib/launchers/Base.js
@@ -16,13 +16,13 @@ var BEING_TIMEOUTED = 5;
 var BaseBrowser = function(id, emitter, captureTimeout, retryLimit) {
   var self = this;
   var capturingUrl;
-  var exitCallback = function() {};
+  var exitCallbacks = [];
 
+  this.killTimeout = 2000;
   this.id = id;
   this.state = null;
   this._tempDir = path.normalize((env.TMPDIR || env.TMP || env.TEMP || '/tmp') + '/karma-' +
       id.toString());
-
 
   this.start = function(url) {
     capturingUrl = url;
@@ -59,18 +59,31 @@ var BaseBrowser = function(id, emitter, captureTimeout, retryLimit) {
 
 
   this.kill = function(callback) {
-    exitCallback = callback || function() {};
+    var exitCallback = callback || function() {};
 
     log.debug('Killing %s', self.name);
-
-    if (self.state !== FINISHED) {
+    if (self.state === FINISHED) {
+      process.nextTick(exitCallback);
+    } else if (self.state === BEING_KILLED) {
+      exitCallbacks.push(exitCallback);
+    } else {
       self.state = BEING_KILLED;
       self._process.kill();
-    } else {
-      process.nextTick(exitCallback);
+      exitCallbacks.push(exitCallback);
+      setTimeout(self._onKillTimeout, self.killTimeout);
     }
   };
 
+
+  this._onKillTimeout = function() {
+    if (self.state !== BEING_KILLED) {
+      return;
+    }
+
+    log.warn('%s was not killed in %d ms, sending SIGKILL.', self.name, self.killTimeout);
+
+    self._process.kill('SIGKILL');
+  };
 
   this._onTimeout = function() {
     if (self.state !== BEING_CAPTURED) {
@@ -169,7 +182,12 @@ var BaseBrowser = function(id, emitter, captureTimeout, retryLimit) {
     }
 
     self.state = FINISHED;
-    self._cleanUpTmp(exitCallback);
+    self._cleanUpTmp(function(err) {
+      exitCallbacks.forEach(function(exitCallback) {
+        exitCallback(err);
+      });
+      exitCallbacks = [];
+    });
   };
 
 

--- a/test/unit/launchers/Base.spec.coffee
+++ b/test/unit/launchers/Base.spec.coffee
@@ -156,8 +156,7 @@ describe 'launchers Base', ->
       expect(killSpy).not.to.have.been.called
 
       mockSpawn._processes[0].emit 'close', 0
-      expect(mockRimraf).to.have.been.calledWith path.normalize('/tmp/karma-12345'), killSpy
-
+      expect(mockRimraf).to.have.been.calledWith path.normalize('/tmp/karma-12345')
       mockRimraf._callbacks[0]() # rm tempdir
       expect(killSpy).to.have.been.called
 


### PR DESCRIPTION
In some cases chrome on linux does not die when it receives a sigint
signal. So after a sigint is sent wait 2 more seconds and issue a
sigkill if the process is still running.
