### PR TITLE
feat(config): Allow tests be to run in a new window instead of iframe

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -17,5 +17,5 @@ var socket = io.connect('http://' + location.host, {
 
 // instantiate the updater of the view
 new StatusUpdater(socket, util.elm('title'), util.elm('banner'), util.elm('browsers'));
-
-window.karma = new Karma(socket, util.elm('context'), window.navigator, window.location);
+window.karma = new Karma(socket, util.elm('context'), window.open,
+	window.navigator, window.location);

--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -343,6 +343,15 @@ on whether all tests passed or any tests failed.
 is handed off to [socket.io](https://github.com/LearnBoost/Socket.IO/wiki/Configuring-Socket.IO) (which manages the communication
 between browsers and the testing server).
 
+## client.useIframe
+**Type:** Boolean
+
+**Default:** `true`
+
+**Description:** Run the tests inside an iframe or a new window
+
+If true, Karma runs the tests inside an iframe. If false, Karma runs the tests in a new window. Some tests may not run in an iFrame and may need a new window to run.
+
 
 ## urlRoot
 **Type:** String

--- a/lib/config.js
+++ b/lib/config.js
@@ -210,7 +210,8 @@ var Config = function() {
   this.transports = ['websocket', 'flashsocket', 'xhr-polling', 'jsonp-polling'];
   this.plugins = ['karma-*'];
   this.client = {
-    args: []
+    args: [],
+    useIframe: true
   };
   this.browserDisconnectTimeout = 2000;
   this.browserDisconnectTolerance = 0;

--- a/static/context.html
+++ b/static/context.html
@@ -16,7 +16,12 @@ Realoaded before every execution run.
        manner. -->
   <script type="text/javascript">
     // sets window.__karma__ and overrides console and error handling
-    window.parent.karma.setupContext(window);
+    // Use window.opener if this was opened by someone else - in a new window
+    if (window.opener) {
+      window.opener.karma.setupContext(window);
+    } else {
+      window.parent.karma.setupContext(window);
+    }
 
     // All served files with the latest timestamps
     %MAPPINGS%


### PR DESCRIPTION
Some testing frameworks would need a new window and may not be able to run in an iframe. This pull request adds an option to open context.html in a new window instead of the iframe. For example, I am working on a (karma-telemetry)[http://github.com/axemclion/karma-telemetry] framework that uses telemetry to calculate rendering times of components. The times do not work in an iframe and need a new window. 

Based on a discussion in groups - https://groups.google.com/forum/#!topic/karma-users/6Ud2TvwhESc

Note that to test this, the browsers need to enable popups. For chrome, this would be 

```
 customLaunchers: {
        'ChromeNew' : {
            base: 'Chrome',
            flags: '--disable-popup-blocking'
        }
    },

```
