### PR TITLE
feat(preprocessors): allow multiple file patterns matching

### DIFF
--- a/docs/config/04-preprocessors.md
+++ b/docs/config/04-preprocessors.md
@@ -4,9 +4,8 @@ of the configuration file:
 
 ```javascript
 preprocessors: {
-  '**/*.coffee': ['coffee'],
-  '**/*.tea': ['coffee'],
-  '**/*.html': ['html2js']
+  'coffee': '**/*.coffee',
+  'html2js': '**/*.html'
 },
 ```
 Note the multiple expressions referencing the "coffee" preprocessor, as a preprocessor can be listed more than once,
@@ -42,7 +41,8 @@ And then inside your configuration file...
 module.exports = function(config) {
   config.set({
     preprocessors: {
-      '**/*.js': ['coverage']
+      'coffee': '**/*.coffee',
+      'coverage': ['**/*.js', '!**/*.spec.js, '!**/Route.js']
     }
   });
 };
@@ -75,14 +75,14 @@ customPreprocessors: {
 
 
 ## Minimatching
-The keys of the preprocessors config object are used to filter the files specified in
-the `files` configuration.
+The values of the preprocessors config object are used to filter the files specified in
+the `files` configuration. This can be a single string patterns or a list of patterns.
 
 * First the file paths are expanded to an absolute path, based on the
   `basePath` configuration and the directory of the configuration file. See
   [files] for more information on that.
 * Then the newly expanded path is matched using [minimatch] against the
-  specified key.
+  specified patttern.
 
 So for example the path `/my/absolute/path/to/test/unit/file.coffee` matched against
 the key `**/*.coffee` would return `true`, but matched against just `*.coffee` it would

--- a/lib/config.js
+++ b/lib/config.js
@@ -123,16 +123,29 @@ var normalizeConfig = function(config, configFilePath) {
   }
 
   // normalize preprocessors
+
+  // handle negative lookups
+  function normalizePathLookup(lookup) {
+    if (lookup.substring(0,1) === '!') {
+      return '!' + helper.normalizeWinPath(basePathResolve(lookup.substring(1)));
+    } else {
+      return helper.normalizeWinPath(basePathResolve(lookup));
+    }
+  }
   var preprocessors = config.preprocessors || {};
   var normalizedPreprocessors = config.preprocessors = Object.create(null);
 
-  Object.keys(preprocessors).forEach(function(pattern) {
-    var normalizedPattern = helper.normalizeWinPath(basePathResolve(pattern));
-
-    normalizedPreprocessors[normalizedPattern] = helper.isString(preprocessors[pattern]) ?
-        [preprocessors[pattern]] : preprocessors[pattern];
+  Object.keys(preprocessors).forEach(function(preprocessor) {
+    var patterns = preprocessors[preprocessor];
+    if (helper.isString(patterns)) {
+      normalizedPreprocessors[preprocessor] = [normalizePathLookup(patterns)];
+    } else if (helper.isArray(patterns)) {
+      normalizedPreprocessors[preprocessor] = [];
+      patterns.forEach(function(pattern) {
+        normalizedPreprocessors[preprocessor].push(normalizePathLookup(pattern));
+      });
+    }
   });
-
 
   // define custom launchers/preprocessors/reporters - create an inlined plugin
   var module = Object.create(null);

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -12,7 +12,7 @@ var sha1 = function(data) {
 
 // TODO(vojta): instantiate preprocessors at the start to show warnings immediately
 var createPreprocessor = function(config, basePath, injector) {
-  var patterns = Object.keys(config);
+  var processors = Object.keys(config);
   var alreadyDisplayedWarnings = Object.create(null);
 
   return function(file, done) {
@@ -47,9 +47,25 @@ var createPreprocessor = function(config, basePath, injector) {
 
     // collects matching preprocessors
     // TODO(vojta): should we cache this ?
-    for (var i = 0; i < patterns.length; i++) {
-      if (mm(file.originalPath, patterns[i])) {
-        config[patterns[i]].forEach(instantiatePreprocessor);
+    for (var i = 0; i < processors.length; i++) {
+      var processor = processors[i],
+          patterns = config[processor],
+          match = true;
+      if (toString.call(patterns) === '[object Array]') {
+        // iterate over patterns and break if exclusion found
+        for (var j = 0; j < patterns.length; j++) {
+          if (!mm(file.originalPath, patterns[j])) {
+                // pattern does not match so file not included
+                match = false;
+                break;
+            }
+        }
+      } else {
+        // single pattern matching
+        match = mm(file.originalPath, patterns);
+      }
+      if (match) {
+        instantiatePreprocessor(processor);
       }
     }
 

--- a/test/unit/config.spec.coffee
+++ b/test/unit/config.spec.coffee
@@ -240,23 +240,21 @@ describe 'config', ->
       config = normalizeConfigWithDefaults
         basePath: ''
         preprocessors:
-          '/*.coffee': 'coffee'
-          '/*.html': 'html2js'
+          'coffee': '/*.coffee'
+          'html2js': '/*.html'
 
-      expect(config.preprocessors[resolveWinPath('/*.coffee')]).to.deep.equal ['coffee']
-      expect(config.preprocessors[resolveWinPath('/*.html')]).to.deep.equal ['html2js']
+      expect(config.preprocessors['coffee']).to.deep.equal [resolveWinPath('/*.coffee')]
+      expect(config.preprocessors['html2js']).to.deep.equal [resolveWinPath('/*.html')]
+      #expect(config.preprocessors[resolveWinPath('/*.html')]).to.deep.equal ['html2js']
 
 
-    it 'should resolve relative preprocessor patterns', ->
+    it 'should handle negative preprocessors lookups', ->
       config = normalizeConfigWithDefaults
-        basePath: '/some/base'
+        basePath: ''
         preprocessors:
-          '*.coffee': 'coffee'
-          '/**/*.html': 'html2js'
+          'coffee': ['*.coffee', '!*.spec.coffee']
 
-      expect(config.preprocessors).to.have.property resolveWinPath('/some/base/*.coffee')
-      expect(config.preprocessors).not.to.have.property resolveWinPath('*.coffee')
-      expect(config.preprocessors).to.have.property resolveWinPath('/**/*.html')
+      expect(config.preprocessors['coffee']).to.deep.equal [resolveWinPath('*.coffee'), '!' + resolveWinPath('*.spec.coffee')]
 
 
   describe 'createPatternObject', ->


### PR DESCRIPTION
allows to specify multiple file patterns in the preprocessors config so you can add exclusions rules. useful if you want for example coverage to match all src/*_/_.js files except those ending with *.spec.js.

Should help for https://github.com/karma-runner/karma-coverage/issues/13

BREAKING CHANGE: the preprocessors config order has been reversed.

Before :

``` js
preprocessors: {
  '**/*.coffee': ['coffee'],
  '**/*.js': ['coverage']
}
```

After :

``` js
preprocessors: {
  'coffee': '**/*.coffee',
  'coverage': ['**/*.js', '!**/*.spec.js']
}
```
