### PR TITLE
Load tasks with a one-liner

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -121,15 +121,8 @@ module.exports = (grunt) ->
 
 
   grunt.loadTasks 'tasks'
-  grunt.loadNpmTasks 'grunt-simple-mocha'
-  grunt.loadNpmTasks 'grunt-contrib-jshint'
-  grunt.loadNpmTasks 'grunt-contrib-watch'
-  grunt.loadNpmTasks 'grunt-coffeelint'
-  grunt.loadNpmTasks 'grunt-bump'
-  grunt.loadNpmTasks 'grunt-npm'
-  grunt.loadNpmTasks 'grunt-auto-release'
-  grunt.loadNpmTasks 'grunt-conventional-changelog'
-  grunt.loadNpmTasks 'grunt-browserify'
+  # Load grunt tasks automatically
+  require('load-grunt-tasks') grunt
 
   grunt.registerTask 'build', ['browserify:client']
   grunt.registerTask 'default', ['build', 'test', 'lint']

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "grunt-bump": "~0.0.10",
     "grunt-conventional-changelog": "~1.0.0",
     "grunt-auto-release": "~0.0.3",
+    "load-grunt-tasks": "~0.2.1",
     "mocks": "~0.0.10",
     "which": "~1.0",
     "sinon-chai": "~2.3",


### PR DESCRIPTION
Make more maintainable the Gruntfile. This automatically loads any tasks listed in devDependencies.
