### PR TITLE
fix(config): allow CoffeeScript 1.7 to be used

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,7 +7,9 @@ var constant = require('./constants');
 
 // Coffee is required here to enable config files written in coffee-script.
 // It's not directly used in this file.
-require('coffee-script');
+try {
+  require('coffee-script').register();
+} catch (e) {}
 
 // LiveScript is required here to enable config files written in LiveScript.
 // It's not directly used in this file.


### PR DESCRIPTION
CoffeeScript 1.7 requires a register call to be made. This change is still backwards compatible with older versions of CS because the needed part, the require, is still done. The register function fails but it is wrapped in a try catch block so it fails silently.
