### PR TITLE
Fix: fail if config.client.args is set to a non-array (e.g an object)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -134,6 +134,10 @@ var normalizeConfig = function(config, configFilePath) {
     config.reporters = config.reporters.split(',');
   }
 
+  if (config.client && config.client.args && !Array.isArray(config.client.args)) {
+    throw new Error('Invalid configuration: client.args must be an array of strings');
+  }
+
   // normalize preprocessors
   var preprocessors = config.preprocessors || {};
   var normalizedPreprocessors = config.preprocessors = Object.create(null);


### PR DESCRIPTION
config.client.args was never intended to allow arbitrary objects - the karma code always sets this to an array of strings. This commit ensures that if client.args is set, it's an array.

Adding this check prevents the mess mentioned in https://github.com/karma-runner/karma-mocha/pull/25#issuecomment-35163182
