### PR TITLE
fix(runner): Karma hangs when file paths have \u in them #924

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -101,7 +101,8 @@ var createKarmaMiddleware = function(filesPromise, serveStaticFile,
 
           // TODO(vojta): don't compute if it's not in the template
           var mappings = files.served.map(function(file) {
-            var filePath = filePathToUrlPath(file.path, basePath);
+            //Windows paths contain backslashes and generate bad IDs if not escaped
+            var filePath = filePathToUrlPath(file.path, basePath).replace(/\\/g,'\\\\');
 
             return util.format('  \'%s\': \'%s\'', filePath, file.sha);
           });

--- a/test/unit/middleware/karma.spec.coffee
+++ b/test/unit/middleware/karma.spec.coffee
@@ -204,12 +204,14 @@ describe 'middleware.karma', ->
     servedFiles [
       new MockFile('/some/abc/a.js', 'sha_a')
       new MockFile('/base/path/b.js', 'sha_b')
+      new MockFile('\\windows\\path\\uuu\\c.js', 'sha_c')
     ]
 
     response.once 'end', ->
       expect(response).to.beServedAs 200, 'window.__karma__.files = {\n' +
       "  '/absolute/some/abc/a.js': 'sha_a',\n" +
-      "  '/base/b.js': 'sha_b'\n" +
+      "  '/base/b.js': 'sha_b',\n" +
+      "  '/absolute\\\\windows\\\\path\\\\uuu\\\\c.js': 'sha_c'\n" +
       "};\n"
       done()
 


### PR DESCRIPTION
Escape backslashes in paths, which happen in Windows,
to prevent bad IDs (e.g. aaa\uuuu).
Add unit test with path with backslashes.

Closes #924
