### PR TITLE
feat: allow frameworks to add preprocessor files

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -27,10 +27,6 @@ var log = logger.create();
 var start = function(injector, config, launcher, globalEmitter, preprocess, fileList, webServer,
     capturedBrowsers, socketServer, executor, done) {
 
-  config.frameworks.forEach(function(framework) {
-    injector.get('framework:' + framework);
-  });
-
   var filesPromise = fileList.refresh();
 
   if (config.autoWatch) {
@@ -306,6 +302,10 @@ exports.start = function(cliOptions, done) {
   modules = modules.concat(plugin.resolve(config.plugins));
 
   var injector = new di.Injector(modules);
+
+  config.frameworks.forEach(function(framework) {
+    injector.get('framework:' + framework);
+  });
 
   injector.invoke(start);
 };


### PR DESCRIPTION
This is necessary for the commonjs plugin I am using. I need to parse a npm module from the files array and add it to the preprocessors object. Since the keys are saved, it is not possible to add preprocessor patterns currently.