### PR TITLE
Adding the `dat` file extension as a recognised binary.

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -22,7 +22,7 @@ var isBinary = Object.create(null);
   'sgi', 'svg', 'tiff', 'psd', 'uvi', 'sub', 'djvu', 'dwg', 'dxf', 'fbs', 'fpx', 'fst', 'mmr',
   'rlc', 'mdi', 'wdp', 'npx', 'wbmp', 'xif', 'webp', '3ds', 'ras', 'cmx', 'fh', 'ico', 'pcx', 'pic',
   'pnm', 'pbm', 'pgm', 'ppm', 'rgb', 'tga', 'xbm', 'xpm', 'xwd', 'zip', 'rar', 'tar', 'bz2', 'eot',
-  'ttf', 'woff'
+  'ttf', 'woff', 'dat'
 ].forEach(function(extension) {
   isBinary['.' + extension] = true;
 });


### PR DESCRIPTION
As explained in karma-runner/karma@8a30cf55751, we have a project where `dat` files are binary files.

Adding this extension to the list would make the tests passing again.
