### PR TITLE
Add reference to karma-cli in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See [installation](http://karma-runner.github.io/0.12/intro/installation.html).
 
 ### Using it.
 
-See [configuration](http://karma-runner.github.io/0.10/intro/configuration.html).
+See [karma-cli](https://github.com/karma-runner/karma-cli), [configuration](http://karma-runner.github.io/0.10/intro/configuration.html).
 
 
 ## I still don't get it. Where can I get help?


### PR DESCRIPTION
After upgrading to Karma 12.0 from 10.9, our npm script that runs karma tests no longer working and complained about `karma` is missing. It turns out we need karma-cli to be able to run karma on command line. So I think it is better to reference karma-cli in README. 
