### PR TITLE
Filling config.client.args

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -138,6 +138,10 @@ var normalizeConfig = function(config, configFilePath) {
     throw new Error('Invalid configuration: client.args must be an array of strings');
   }
 
+  if (config.client && config.client.args && config.client.args.length == 0) {
+    config.client.args = config.clientArgs;
+  }
+
   // normalize preprocessors
   var preprocessors = config.preprocessors || {};
   var normalizedPreprocessors = config.preprocessors = Object.create(null);


### PR DESCRIPTION
At the moment config.client.args is always empty. With this change, it will receive the additional parameters (config.clientArgs) given to karma on the command line. 
It can be used for example to filter which file to test in the main karma-test file for unit tests.
