### PR TITLE
Allow start client arguments

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -185,6 +185,8 @@ exports.process = function() {
   switch (options.cmd) {
   case 'start':
     describeStart();
+    //Allow karma start to send clientArgs to client, when (new) startCmdClientArgs options in karma.conf.js is set
+    options.startCmdClientArgs = parseClientArgs(process.argv); 
     break;
 
   case 'run':

--- a/lib/server.js
+++ b/lib/server.js
@@ -250,6 +250,12 @@ exports.start = function(cliOptions, done) {
       helper.isDefined(cliOptions.colors) ? cliOptions.colors : true, [constant.CONSOLE_APPENDER]);
 
   var config = cfg.parseConfig(cliOptions.configFile, cliOptions);
+  
+  //if configured to do so, pass start clientArgs to client
+  if (config.startClientParams){
+      config.client.args = config.startCmdClientArgs;
+  }
+  
   var modules = [{
     helper: ['value', helper],
     logger: ['value', logger],


### PR DESCRIPTION
Allow karma start to send command line parameters to client into config.args array
For backward compatibility this is only done when the (new) startCmdClientArgs option in karma.conf.js is truthy.