### PR TITLE
docs: add ’to’ in “how it works”.

### DIFF
--- a/docs/intro/03-how-it-works.md
+++ b/docs/intro/03-how-it-works.md
@@ -7,7 +7,7 @@ A browser can be captured either
 - or automatically by letting Karma know which browsers to start when Karma is run (see [browsers]).
 
 Karma also watches all the files, specified within the configuration file, and whenever any file changes, it triggers the test run by
-sending a signal the testing server to inform all of the captured browsers to run the test code again.
+sending a signal to the testing server to inform all of the captured browsers to run the test code again.
 Each browser then loads the source files inside an IFrame, executes the tests and reports the results back to the server.
 
 The server collects the results from all of the captured browsers and presents them to the developer.


### PR DESCRIPTION
fix a typo, changing ‘..sending a signal the testing server to inform..’, into ‘..sending a signal _to_ the testing server to inform..’

Closes #980
