### PR TITLE
fix: enable proper npm bin symlinking

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,9 @@
     "grunt-jscs-checker": "~0.4.0"
   },
   "main": "./lib/index",
-  "bin": {},
+  "bin": {
+    "karma": "./bin/karma"
+  },
   "engines": {
     "node": "~0.8 || ~0.10"
   },


### PR DESCRIPTION
Enables bin symlinking for local $PATH precedence by following the
NPM JSON guidelines (https://www.npmjs.org/doc/json.html#bin)

Creates symlinks into ./node_modules/.bin of dependent projects automagically.
