### PR TITLE
Fix(config): Bump chokidar - fixes npm shrinkwrap.

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   "dependencies": {
     "di": "~0.0.1",
     "socket.io": "~0.9.13",
-    "chokidar": "~0.8.0",
+    "chokidar": ">=0.8.2",
     "glob": "~3.2.7",
     "minimatch": "~0.2",
     "http-proxy": "~0.10",


### PR DESCRIPTION
`npm shrinkwrap` will fail with previous versions of chokidar because it installs deps outside of npm. Requiring the latest version(which no longer has extraneous deps) allows one to run `npm shrinkwrap` without errors.
