### PR TITLE
fix(tests) fix line longer that 100 chars in helper.spec.coffee

### DIFF
--- a/test/unit/helper.spec.coffee
+++ b/test/unit/helper.spec.coffee
@@ -74,8 +74,8 @@ describe 'helper', ->
 
     it 'should parse IE9', ->
       expecting('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0; ' +
-                '.NET CLR 2.0.50727; SLCC2; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center ' +
-                'PC 6.0)').
+                '.NET CLR 2.0.50727; SLCC2; .NET CLR 3.5.30729; .NET CLR 3.0.30729; '+
+                'Media Center PC 6.0)').
           to.be.equal 'IE 9.0.0 (Windows 7)'
 
 


### PR DESCRIPTION
makes `grunt lint` pass
