### PR TITLE
feat(runner): Add silent option to run

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -27,6 +27,8 @@ var parseExitCode = function(buffer, defaultCode) {
 // TODO(vojta): read config file (port, host, urlRoot)
 exports.run = function(config, done) {
   done = helper.isFunction(done) ? done : process.exit;
+
+  var silent = config && config.silent;
   config = cfg.parseConfig(config.configFile, config);
 
   var exitCode = 1;
@@ -43,7 +45,9 @@ exports.run = function(config, done) {
   var request = http.request(options, function(response) {
     response.on('data', function(buffer) {
       exitCode = parseExitCode(buffer, exitCode);
-      process.stdout.write(buffer);
+      if (!silent) {
+        process.stdout.write(buffer);
+      }
     });
 
     response.on('end', function() {


### PR DESCRIPTION
This allows you to use `runner.run` without it having to log to stdout. Useful for scripts that are already spawning Karma and can simply log from that process.