### PR TITLE
fix(web-server): inline the config, when serving debug.html

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -37,7 +37,6 @@ module.exports = (grunt) ->
         files: '<%= files.client %>'
         tasks: 'browserify:client'
 
-
     simplemocha:
       options:
         ui: 'bdd'

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -54,7 +54,7 @@ var getXUACompatibleUrl = function(url) {
 };
 
 var createKarmaMiddleware = function(filesPromise, serveStaticFile,
-    /* config.basePath */ basePath,  /* config.urlRoot */ urlRoot) {
+    /* config.basePath */ basePath,  /* config.urlRoot */ urlRoot, /* config.client */ client) {
 
   return function(request, response, next) {
     var requestUrl = request.url.replace(/\?.*/, '');
@@ -130,17 +130,24 @@ var createKarmaMiddleware = function(filesPromise, serveStaticFile,
             return util.format('  \'%s\': \'%s\'', filePath, file.sha);
           });
 
+          var clientConfig = '';
+
+          if (requestUrl === '/debug.html') {
+            clientConfig = 'window.__karma__.config = ' + JSON.stringify(client) + ';\n';
+          }
+
           mappings = 'window.__karma__.files = {\n' + mappings.join(',\n') + '\n};\n';
 
           return data.
             replace('%SCRIPTS%', scriptTags.join('\n'))
+            .replace('%CLIENT_CONFIG%', clientConfig)
             .replace('%MAPPINGS%', mappings)
             .replace('\n%X_UA_COMPATIBLE%', getXUACompatibleMetaElement(request.url));
         });
       }, function(errorFiles) {
         serveStaticFile(requestUrl, response, function(data) {
           common.setNoCacheHeaders(response);
-          return data.replace('%SCRIPTS%', '').replace('%MAPPINGS%',
+          return data.replace('%SCRIPTS%', '').replace('%CLIENT_CONFIG%', '').replace('%MAPPINGS%',
               'window.__karma__.error("TEST RUN WAS CANCELLED because ' +
               (errorFiles.length > 1 ? 'these files contain' : 'this file contains') +
               ' some errors:\\n  ' + errorFiles.join('\\n  ') + '");');

--- a/static/debug.html
+++ b/static/debug.html
@@ -37,6 +37,8 @@ just for immediate execution, without reporting to Karma server.
       }
     };
 
+    %CLIENT_CONFIG%
+
     // All served files with the latest timestamps
     %MAPPINGS%
   </script>

--- a/test/unit/middleware/karma.spec.coffee
+++ b/test/unit/middleware/karma.spec.coffee
@@ -27,10 +27,12 @@ describe 'middleware.karma', ->
   handler = filesDeferred = nextSpy = response = null
 
   beforeEach ->
+    clientConfig = foo: 'bar'
     nextSpy = sinon.spy()
     response = new HttpResponseMock
     filesDeferred = q.defer()
-    handler = createKarmaMiddleware filesDeferred.promise, serveFile, '/base/path', '/__karma__/'
+    handler = createKarmaMiddleware filesDeferred.promise, serveFile,
+      '/base/path', '/__karma__/', clientConfig
 
   # helpers
   includedFiles = (files) ->
@@ -271,6 +273,19 @@ describe 'middleware.karma', ->
       '<link type="text/css" href="/base/b.css" rel="stylesheet">\n' +
       '<link href="/absolute/second.html" rel="import">\n' +
       '<link href="/base/d.html" rel="import">'
+      done()
+
+    callHandlerWith '/__karma__/debug.html'
+
+
+  it 'should inline client config to debug.html', (done) ->
+    includedFiles [
+      new MockFile('/first.js')
+    ]
+    fsMock._touchFile '/karma/static/debug.html', 1, '%CLIENT_CONFIG%'
+
+    response.once 'end', ->
+      expect(response).to.beServedAs 200, 'window.__karma__.config = {"foo":"bar"};\n'
       done()
 
     callHandlerWith '/__karma__/debug.html'


### PR DESCRIPTION
Some adapters don't work correct on debug page, because we don't pass the config to debug.html
For example client config to mocha.setup doesn't work in debug

Issue https://github.com/karma-runner/karma-mocha/issues/24
