### PR TITLE
Add note for tying karma start to App.initialize

### DIFF
--- a/docs/plus/08-emberjs.md
+++ b/docs/plus/08-emberjs.md
@@ -58,7 +58,7 @@ To execute javascript unit and integration tests with ember.js follow the steps 
 
   Note - the `files` section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application
 
-  Note - when testing ember applications, it is important that karma not being running the tests until the ember application has finished initialization.  you will need to include a small bootstrap file in the `files` section above to enforce this.  Here's an example:
+  Note - when testing ember applications, it is important that karma not begin running the tests until the ember application has finished initialization.  you will need to include a small bootstrap file in the `files` section about to enforce this.  Here's an example:
   ```javascript
   __karma__.loaded = function() {};
 


### PR DESCRIPTION
Followed through on #1012

Tests against an ember application should not start until the
App has completed initializing.  The note and suggested
bootstrap method demonstrate how to deactivate karma autostart
and how to explicitly start karma at the appropirate time.
