### PR TITLE
fix: don't crash/terminate upon errors within chokidar

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -94,7 +94,12 @@ exports.watch = function(patterns, excludes, fileList, usePolling) {
   // register events
   chokidarWatcher.on('add', bind(fileList.addFile))
                  .on('change', bind(fileList.changeFile))
-                 .on('unlink', bind(fileList.removeFile));
+                 .on('unlink', bind(fileList.removeFile))
+                 // If we don't subscribe; unhandled errors from Chokidar will bring Karma down
+                 // (see GH Issue #959)
+                 .on('error', function(e) {
+                    log.debug(e);
+                  });
 
   return chokidarWatcher;
 };


### PR DESCRIPTION
Due to the way some editors save changes; Chokidar might throw an error
trying to stat a file that was created and then removed/renamed very
quickly. Previously this would just bring the entire Karma process down;
which seems rather unhelpful.
