### PR TITLE
fix(server): clear web server close timeout on clean close

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -213,12 +213,15 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
     };
 
     globalEmitter.emitAsync('exit').then(function() {
-      // shutdown the server...
-      webServer.close(removeAllListeners);
-
-      // ...but don't wait forever on webServer.close() because
+      // don't wait forever on webServer.close() because
       // pending client connections prevent it from closing.
-      setTimeout(removeAllListeners, webServerCloseTimeout);
+      var closeTimeout = setTimeout(removeAllListeners, webServerCloseTimeout);
+
+      // shutdown the server...
+      webServer.close(function() {
+        clearTimeout(closeTimeout);
+        removeAllListeners();
+      });
     });
   };
 


### PR DESCRIPTION
When Karma server shuts down it also closes a web server it started. In order to properly close the started web server, there is a setTimeout of 3s that should execute cleanup operations when a web server doesn't close cleanly. Unfortunately this fallback timeout is not canceled when a web server does close cleanly, preventing karma process from exiting for 3s.

This PR fixes this by cancelling the fallback timeout in the clan close callback.

This is is part of many fixes we need to do in order to fix https://github.com/karma-runner/karma/issues/1035 
