### PR TITLE
fix(server): don't wait for socket.io store expiration timeout

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -245,6 +245,11 @@ var createSocketIoServer = function(webServer, executor, config) {
   var server = io.listen(webServer, {
     // avoid destroying http upgrades from socket.io to get proxied websockets working
     'destroy upgrade': false,
+    // socket.io has a timeout (15s by default) before destroying a store (a data structure where
+    // data associated with a socket are stored). Unfortunately this timeout is not cleared
+    // properly on socket.io shutdown and this timeout prevents karma from exiting cleanly.
+    // We change this timeout to 0 to make Karma exit just after all tests were executed.
+    'client store expiration': 0,
     logger: logger.create('socket.io', constant.LOG_ERROR),
     resource: config.urlRoot + 'socket.io',
     transports: config.transports


### PR DESCRIPTION
This is kind of "question PR" (sorry, myself I hate those types of PRs but still too new to Karma internals to be able to say if this is the best approach or not...).

So, the story is the following one: socket.io has a timeout to clean data in a store, ex:
https://github.com/LearnBoost/socket.io/blob/0.9/lib/stores/memory.js#L137

Unfortunately this timeout prevents Karma's node process from existing properly when the test run is finished. The quickest fix is to default this timeout to 0. While it fixes my immediate problem, I'm not sure what are the consequences to Karma of doing so. I'm not sure if Karma is associating any data with a socket in the way that would make usage of socket.io store - in this case defaulting this timeout to 0 could have some side effect.

So, once again, fishing for feedback here more than expecting it to be merged immediately. 
