### PR TITLE
fix(launcher): cancel kill timeout when process exits cleanly

### DIFF
--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -22,7 +22,7 @@ var ProcessLauncher = function(spawn, tempDir, timer) {
 
     onExitCallback = done;
     self._process.kill();
-    timer.setTimeout(self._onKillTimeout, killTimeout);
+    self._killTimer = timer.setTimeout(self._onKillTimeout, killTimeout);
   });
 
   this._start = function(url) {
@@ -111,6 +111,7 @@ var ProcessLauncher = function(spawn, tempDir, timer) {
 
     self._process = null;
     self._clearTempDirAndReportDone(error);
+    timer.clearTimeout(self._killTimer);
   };
 
   this._clearTempDirAndReportDone = function(error) {


### PR DESCRIPTION
By default browsers are killed with `process.kill()` but it might
happen that a process doesn't play nicelly and doesn't exit so
there is a timeout after which a process is SIGKILL-ed. Before
this commit the mentioned timeout wasn't cleared on clean process
exit, preventing Karma from exiting just after all tests were run.

Fixes #946
