### PR TITLE
feat(server): wait for frameworks to load via q.all() before starting server

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -8,6 +8,7 @@ JSHINT_BROWSER =
 JSHINT_NODE =
   node: true,
   strict: false
+  latedef: "nofunc"
 
 module.exports = (grunt) ->
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,230 +23,237 @@ var processWrapper = new EmitterWrapper(process);
 
 var log = logger.create();
 
+var q = require('q');
+
+function noop() {}
 
 var start = function(injector, config, launcher, globalEmitter, preprocess, fileList, webServer,
-    capturedBrowsers, socketServer, executor, done) {
+    capturedBrowsers, socketServer, executor, done, callbacks) {
 
-  config.frameworks.forEach(function(framework) {
-    injector.get('framework:' + framework);
-  });
+  q.all(config.frameworks.map(function(framework) {
+    return injector.get('framework:' + framework);
+  })).then(startServer, startServer);
 
-  var filesPromise = fileList.refresh();
+  function startServer() {
+    (callbacks.frameworksLoaded || noop)();
+    var filesPromise = fileList.refresh();
 
-  if (config.autoWatch) {
-    filesPromise.then(function() {
-      injector.invoke(watcher.watch);
-    }, function() {
-      injector.invoke(watcher.watch);
-    });
-  }
-
-  webServer.on('error', function(e) {
-    if (e.code === 'EADDRINUSE') {
-      log.warn('Port %d in use', config.port);
-      config.port++;
-      webServer.listen(config.port);
-    } else {
-      throw e;
-    }
-  });
-
-  // A map of launched browsers.
-  var singleRunDoneBrowsers = Object.create(null);
-
-  // Passing fake event emitter, so that it does not emit on the global,
-  // we don't care about these changes.
-  var singleRunBrowsers = new BrowserCollection(new EventEmitter());
-
-  // Some browsers did not get captured.
-  var singleRunBrowserNotCaptured = false;
-
-  webServer.listen(config.port, function() {
-    log.info('Karma v%s server started at http://%s:%s%s', constant.VERSION, config.hostname,
-        config.port, config.urlRoot);
-
-    if (config.browsers && config.browsers.length) {
-      injector.invoke(launcher.launch, launcher).forEach(function(browserLauncher) {
-        singleRunDoneBrowsers[browserLauncher.id] = false;
+    if (config.autoWatch) {
+      filesPromise.then(function() {
+        injector.invoke(watcher.watch);
+      }, function() {
+        injector.invoke(watcher.watch);
       });
     }
-  });
 
-  globalEmitter.on('browsers_change', function() {
-    // TODO(vojta): send only to interested browsers
-    socketServer.sockets.emit('info', capturedBrowsers.serialize());
-  });
-
-  globalEmitter.on('browser_register', function(browser) {
-    launcher.markCaptured(browser.id);
-
-    // TODO(vojta): This is lame, browser can get captured and then crash (before other browsers get
-    // captured).
-    if (config.autoWatch && launcher.areAllCaptured()) {
-      executor.schedule();
-    }
-  });
-
-  var EVENTS_TO_REPLY = ['start', 'info', 'error', 'result', 'complete'];
-  socketServer.sockets.on('connection', function(socket) {
-    log.debug('A browser has connected on socket ' + socket.id);
-
-    var replySocketEvents = events.bufferEvents(socket, EVENTS_TO_REPLY);
-
-    socket.on('register', function(info) {
-      var newBrowser;
-      var isRestart;
-
-      if (info.id) {
-        newBrowser = capturedBrowsers.getById(info.id) || singleRunBrowsers.getById(info.id);
-      }
-
-      if (newBrowser) {
-        isRestart = newBrowser.state === Browser.STATE_DISCONNECTED;
-        newBrowser.reconnect(socket);
-
-        // We are restarting a previously disconnected browser.
-        if (isRestart && config.singleRun) {
-          newBrowser.execute(config.client);
-        }
+    webServer.on('error', function(e) {
+      if (e.code === 'EADDRINUSE') {
+        log.warn('Port %d in use', config.port);
+        config.port++;
+        webServer.listen(config.port);
       } else {
-        newBrowser = injector.createChild([{
-          id: ['value', info.id || null],
-          fullName: ['value', info.name],
-          socket: ['value', socket]
-        }]).instantiate(Browser);
+        throw e;
+      }
+    });
 
-        newBrowser.init();
+    // A map of launched browsers.
+    var singleRunDoneBrowsers = Object.create(null);
 
-        // execute in this browser immediately
-        if (config.singleRun) {
-          newBrowser.execute(config.client);
-          singleRunBrowsers.add(newBrowser);
+    // Passing fake event emitter, so that it does not emit on the global,
+    // we don't care about these changes.
+    var singleRunBrowsers = new BrowserCollection(new EventEmitter());
+
+    // Some browsers did not get captured.
+    var singleRunBrowserNotCaptured = false;
+
+    webServer.listen(config.port, function() {
+      (callbacks.serverStarted || noop)();
+      log.info('Karma v%s server started at http://%s:%s%s', constant.VERSION, config.hostname,
+          config.port, config.urlRoot);
+
+      if (config.browsers && config.browsers.length) {
+        injector.invoke(launcher.launch, launcher).forEach(function(browserLauncher) {
+          singleRunDoneBrowsers[browserLauncher.id] = false;
+        });
+      }
+    });
+
+    globalEmitter.on('browsers_change', function() {
+      // TODO(vojta): send only to interested browsers
+      socketServer.sockets.emit('info', capturedBrowsers.serialize());
+    });
+
+    globalEmitter.on('browser_register', function(browser) {
+      launcher.markCaptured(browser.id);
+
+      // TODO(vojta): This is lame, browser can get captured and then crash (before other browsers
+      // get captured).
+      if (config.autoWatch && launcher.areAllCaptured()) {
+        executor.schedule();
+      }
+    });
+
+    var EVENTS_TO_REPLY = ['start', 'info', 'error', 'result', 'complete'];
+    socketServer.sockets.on('connection', function(socket) {
+      log.debug('A browser has connected on socket ' + socket.id);
+
+      var replySocketEvents = events.bufferEvents(socket, EVENTS_TO_REPLY);
+
+      socket.on('register', function(info) {
+        var newBrowser;
+        var isRestart;
+
+        if (info.id) {
+          newBrowser = capturedBrowsers.getById(info.id) || singleRunBrowsers.getById(info.id);
         }
-      }
 
-      replySocketEvents();
-    });
-  });
+        if (newBrowser) {
+          isRestart = newBrowser.state === Browser.STATE_DISCONNECTED;
+          newBrowser.reconnect(socket);
 
-  var emitRunCompleteIfAllBrowsersDone = function() {
-    // all browsers done
-    var isDone = Object.keys(singleRunDoneBrowsers).reduce(function(isDone, id) {
-      return isDone && singleRunDoneBrowsers[id];
-    }, true);
+          // We are restarting a previously disconnected browser.
+          if (isRestart && config.singleRun) {
+            newBrowser.execute(config.client);
+          }
+        } else {
+          newBrowser = injector.createChild([{
+            id: ['value', info.id || null],
+            fullName: ['value', info.name],
+            socket: ['value', socket]
+          }]).instantiate(Browser);
 
-    if (isDone) {
-      var results = singleRunBrowsers.getResults();
-      if (singleRunBrowserNotCaptured) {
-        results.exitCode = 1;
-      }
+          newBrowser.init();
 
-      globalEmitter.emit('run_complete', singleRunBrowsers, results);
-    }
-  };
-
-  if (config.singleRun) {
-    globalEmitter.on('browser_complete', function(completedBrowser) {
-      if (completedBrowser.lastResult.disconnected &&
-          completedBrowser.disconnectsCount <= config.browserDisconnectTolerance) {
-        log.info('Restarting %s (%d of %d attempts)', completedBrowser.name,
-            completedBrowser.disconnectsCount, config.browserDisconnectTolerance);
-        if (!launcher.restart(completedBrowser.id)) {
-          singleRunDoneBrowsers[completedBrowser.id] = true;
-          emitRunCompleteIfAllBrowsersDone();
-        }
-      } else {
-        singleRunDoneBrowsers[completedBrowser.id] = true;
-
-        if (launcher.kill(completedBrowser.id)) {
-          // workaround to supress "disconnect" warning
-          completedBrowser.state = Browser.STATE_DISCONNECTED;
+          // execute in this browser immediately
+          if (config.singleRun) {
+            newBrowser.execute(config.client);
+            singleRunBrowsers.add(newBrowser);
+          }
         }
 
-        emitRunCompleteIfAllBrowsersDone();
+        replySocketEvents();
+      });
+    });
+
+    var emitRunCompleteIfAllBrowsersDone = function() {
+      // all browsers done
+      var isDone = Object.keys(singleRunDoneBrowsers).reduce(function(isDone, id) {
+        return isDone && singleRunDoneBrowsers[id];
+      }, true);
+
+      if (isDone) {
+        var results = singleRunBrowsers.getResults();
+        if (singleRunBrowserNotCaptured) {
+          results.exitCode = 1;
+        }
+
+        globalEmitter.emit('run_complete', singleRunBrowsers, results);
       }
-    });
-
-    globalEmitter.on('browser_process_failure', function(browserLauncher) {
-      singleRunDoneBrowsers[browserLauncher.id] = true;
-      singleRunBrowserNotCaptured = true;
-
-      emitRunCompleteIfAllBrowsersDone();
-    });
-
-    globalEmitter.on('run_complete', function(browsers, results) {
-      log.debug('Run complete, exitting.');
-      disconnectBrowsers(results.exitCode);
-    });
-
-    globalEmitter.emit('run_start', singleRunBrowsers);
-  }
-
-
-  if (config.autoWatch) {
-    globalEmitter.on('file_list_modified', function() {
-      log.debug('List of files has changed, trying to execute');
-      executor.schedule();
-    });
-  }
-
-  var webServerCloseTimeout = 3000;
-  var disconnectBrowsers = function(code) {
-    // Slightly hacky way of removing disconnect listeners
-    // to suppress "browser disconnect" warnings
-    // TODO(vojta): change the client to not send the event (if disconnected by purpose)
-    var sockets = socketServer.sockets.sockets;
-    Object.getOwnPropertyNames(sockets).forEach(function(key) {
-      sockets[key].removeAllListeners('disconnect');
-    });
-
-    var removeAllListenersDone = false;
-    var removeAllListeners = function() {
-      // make sure we don't execute cleanup twice
-      if (removeAllListenersDone) {
-        return;
-      }
-      removeAllListenersDone = true;
-      webServer.removeAllListeners();
-      processWrapper.removeAllListeners();
-      done(code || 0);
     };
 
-    globalEmitter.emitAsync('exit').then(function() {
-      // don't wait forever on webServer.close() because
-      // pending client connections prevent it from closing.
-      var closeTimeout = setTimeout(removeAllListeners, webServerCloseTimeout);
+    if (config.singleRun) {
+      globalEmitter.on('browser_complete', function(completedBrowser) {
+        if (completedBrowser.lastResult.disconnected &&
+            completedBrowser.disconnectsCount <= config.browserDisconnectTolerance) {
+          log.info('Restarting %s (%d of %d attempts)', completedBrowser.name,
+              completedBrowser.disconnectsCount, config.browserDisconnectTolerance);
+          if (!launcher.restart(completedBrowser.id)) {
+            singleRunDoneBrowsers[completedBrowser.id] = true;
+            emitRunCompleteIfAllBrowsersDone();
+          }
+        } else {
+          singleRunDoneBrowsers[completedBrowser.id] = true;
 
-      // shutdown the server...
-      webServer.close(function() {
-        clearTimeout(closeTimeout);
-        removeAllListeners();
+          if (launcher.kill(completedBrowser.id)) {
+            // workaround to supress "disconnect" warning
+            completedBrowser.state = Browser.STATE_DISCONNECTED;
+          }
+
+          emitRunCompleteIfAllBrowsersDone();
+        }
       });
 
-      // shutdown socket.io flash transport, if defined
-      if (socketServer.flashPolicyServer) {
-        socketServer.flashPolicyServer.close();
-      }
+      globalEmitter.on('browser_process_failure', function(browserLauncher) {
+        singleRunDoneBrowsers[browserLauncher.id] = true;
+        singleRunBrowserNotCaptured = true;
+
+        emitRunCompleteIfAllBrowsersDone();
+      });
+
+      globalEmitter.on('run_complete', function(browsers, results) {
+        log.debug('Run complete, exitting.');
+        disconnectBrowsers(results.exitCode);
+      });
+
+      globalEmitter.emit('run_start', singleRunBrowsers);
+    }
+
+
+    if (config.autoWatch) {
+      globalEmitter.on('file_list_modified', function() {
+        log.debug('List of files has changed, trying to execute');
+        executor.schedule();
+      });
+    }
+
+    var webServerCloseTimeout = 3000;
+    var disconnectBrowsers = function(code) {
+      // Slightly hacky way of removing disconnect listeners
+      // to suppress "browser disconnect" warnings
+      // TODO(vojta): change the client to not send the event (if disconnected by purpose)
+      var sockets = socketServer.sockets.sockets;
+      Object.getOwnPropertyNames(sockets).forEach(function(key) {
+        sockets[key].removeAllListeners('disconnect');
+      });
+
+      var removeAllListenersDone = false;
+      var removeAllListeners = function() {
+        // make sure we don't execute cleanup twice
+        if (removeAllListenersDone) {
+          return;
+        }
+        removeAllListenersDone = true;
+        webServer.removeAllListeners();
+        processWrapper.removeAllListeners();
+        done(code || 0);
+      };
+
+      globalEmitter.emitAsync('exit').then(function() {
+        // don't wait forever on webServer.close() because
+        // pending client connections prevent it from closing.
+        var closeTimeout = setTimeout(removeAllListeners, webServerCloseTimeout);
+
+        // shutdown the server...
+        webServer.close(function() {
+          clearTimeout(closeTimeout);
+          removeAllListeners();
+        });
+
+        // shutdown socket.io flash transport, if defined
+        if (socketServer.flashPolicyServer) {
+          socketServer.flashPolicyServer.close();
+        }
+      });
+    };
+
+    try {
+      processWrapper.on('SIGINT', disconnectBrowsers);
+      processWrapper.on('SIGTERM', disconnectBrowsers);
+    } catch (e) {
+      // Windows doesn't support signals yet, so they simply don't get this handling.
+      // https://github.com/joyent/node/issues/1553
+    }
+
+    // Handle all unhandled exceptions, so we don't just exit but
+    // disconnect the browsers before exiting.
+    processWrapper.on('uncaughtException', function(error) {
+      log.error(error);
+      disconnectBrowsers(1);
     });
-  };
-
-  try {
-    processWrapper.on('SIGINT', disconnectBrowsers);
-    processWrapper.on('SIGTERM', disconnectBrowsers);
-  } catch (e) {
-    // Windows doesn't support signals yet, so they simply don't get this handling.
-    // https://github.com/joyent/node/issues/1553
   }
-
-  // Handle all unhandled exceptions, so we don't just exit but
-  // disconnect the browsers before exiting.
-  processWrapper.on('uncaughtException', function(error) {
-    log.error(error);
-    disconnectBrowsers(1);
-  });
 };
 start.$inject = ['injector', 'config', 'launcher', 'emitter', 'preprocess', 'fileList',
-    'webServer', 'capturedBrowsers', 'socketServer', 'executor', 'done'];
+    'webServer', 'capturedBrowsers', 'socketServer', 'executor', 'done', 'callbacks'];
 
 
 var createSocketIoServer = function(webServer, executor, config) {
@@ -265,7 +272,7 @@ var createSocketIoServer = function(webServer, executor, config) {
 };
 
 
-exports.start = function(cliOptions, done) {
+exports.start = function(cliOptions, done, callbacks) {
   // apply the default logger config (and config from CLI) as soon as we can
   logger.setup(cliOptions.logLevel || constant.LOG_INFO,
       helper.isDefined(cliOptions.colors) ? cliOptions.colors : true, [constant.CONSOLE_APPENDER]);
@@ -290,7 +297,8 @@ exports.start = function(cliOptions, done) {
     reporter: ['factory', reporter.createReporters],
     capturedBrowsers: ['type', BrowserCollection],
     args: ['value', {}],
-    timer: ['value', {setTimeout: setTimeout, clearTimeout: clearTimeout}]
+    timer: ['value', {setTimeout: setTimeout, clearTimeout: clearTimeout}],
+    callbacks: ['value', callbacks || {}]
   }];
 
   // load the plugins

--- a/package.json
+++ b/package.json
@@ -184,7 +184,8 @@
     "LiveScript": "~1.2.0",
     "coffee-errors": "~0.8.6",
     "coffee-script": "~1.6",
-    "grunt-jscs-checker": "~0.4.0"
+    "grunt-jscs-checker": "~0.4.0",
+    "mockery": "^1.4.0"
   },
   "main": "./lib/index",
   "bin": {},

--- a/test/unit/server.spec.coffee
+++ b/test/unit/server.spec.coffee
@@ -1,7 +1,57 @@
-# TODO(vojta):
-'should try next port if already in use'
-'should launch browsers after web server started'
+#==============================================================================
+# lib/server.js module
+#==============================================================================
+describe 'server', ->
+  # TODO(vojta):
+  'should try next port if already in use'
+  'should launch browsers after web server started'
 
-# single run
-'should run tests when all browsers captured'
-'should run tests when first browser captured if no browser configured'
+  # single run
+  'should run tests when all browsers captured'
+  'should run tests when first browser captured if no browser configured'
+
+  describe '', ->
+    # This suite wants to fake some modules that Karma loads with require(),
+    # hence the need for 'mockery' and these before blocks
+    mockery = di = q = constants = null
+    beforeEach ->
+      mockery = require 'mockery'
+      di = require 'di'
+      q = require 'q'
+      constants = require '../../lib/constants'
+      mockery.enable
+        useCleanCache: true
+        warnOnReplace: false
+        warnOnUnregistered: false
+
+    afterEach ->
+      mockery.disable()
+
+    it 'should not start server until frameworks are loaded', (done) ->
+      serverStarted = false
+      frameworksLoaded = false
+      mockery.registerMock 'async1',
+        'framework:async1': ['factory', ->
+          deferred = q.defer()
+          setTimeout ->
+            deferred.resolve()
+          , 25
+          return deferred.promise
+        ]
+
+      loaded = ->
+        expect(serverStarted).to.equal false
+        frameworksLoaded = true
+        done()
+      started = ->
+        serverStarted = true
+        expect(frameworksLoaded).to.equal true
+
+      (require '../../lib/server').start {
+        plugins: ['async1']
+        frameworks: ['async1']
+        logLevel: constants.LOG_DISABLE
+      }, null, {
+        frameworksLoaded: loaded
+        serverStarted: started
+      }


### PR DESCRIPTION
The API is to simply return a promise from a factory function, or use a promise as a value. The server will wait for the collection of frameworks to resolve before carrying on starting the server.

This is useful for when setup requires some asynchronous startup.

Currently, any Promise api which is interoperable with q may be used.

In addition to this feature, this CL also adds a set of callbacks to the server, via an object for the 3rd parameter. This is useful for test purposes, and enables the test case to run faster, by not waiting for the server to shut down via the second parameter.

---

There are some design decisions here which you might not like, such as using `mockery` rather than creating test fixtures outside of the test, or adding an object of callbacks to the server opener to help with testing it (it might be nice to have for other reasons, like bonus logging points or something). And of course, the main changes might be restructured in different ways too. So let me know if there are any issues with it @vojtajina, I suspect you were thinking the CL would be a bit smaller and change fewer things, but testing it seemed like a good thing to do.

Closes #851