### PR TITLE
Only include original line info in stack trace when using source map

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -48,8 +48,7 @@ var createErrorFormatter = function(basePath, emitter, SourceMapConsumer) {
         var smc = new SourceMapConsumer(file.sourceMap);
         var original = smc.originalPositionFor({line: line, column: column});
 
-        return util.format('%s:%d:%d <- %s:%d:%d', path, line, column, original.source,
-            original.line, original.column);
+        return util.format('%s:%d:%d', original.source, original.line, original.column);
       }
 
       return path + (line ? ':' + line : '') + (column ? ':' + column : '');

--- a/test/unit/reporter.spec.coffee
+++ b/test/unit/reporter.spec.coffee
@@ -92,5 +92,5 @@ describe 'reporter', ->
 
         scheduleNextTick ->
           ERROR = 'at http://localhost:123/base/b.js:2:6'
-          expect(formatError ERROR).to.equal 'at /some/base/b.js:2:6 <- /original/b.js:4:8\n'
+          expect(formatError ERROR).to.equal 'at /original/b.js:4:8\n'
           done()


### PR DESCRIPTION
I don't think it's useful at all to list the compiled line number/column in stack traces, especially since it's displayed first before the original line number/column info from the source map.  Especially when using something like browserify, you get these horribly useless paths to look at.  For example:

```
at /var/folders/_p/kll4xqzn0hn9znq6607nr14m0000gn/T/a5fdf7b6ec86e5a5a2a6f44ed6234a6791e3a679.browserify:203:0 <- /Users/devongovett/projects/editor/node_modules/chai/lib/chai/assertion.js:110:0
```

This commit removes the compiled line information from stack traces and only displays the original line information.  The output of the above example would just be:

```
at /Users/devongovett/projects/editor/node_modules/chai/lib/chai/assertion.js:110:0
```