### PR TITLE
Add notes for coffee-script dependency when generating init files.

### DIFF
--- a/docs/intro/02-configuration.md
+++ b/docs/intro/02-configuration.md
@@ -44,7 +44,7 @@ Config file generated at "/Users/vojta/Code/karma/my.conf.js".
 ```
 
 The configuration file can be written in CoffeeScript as well.
-In fact, if you execute `karma init` with a `*.coffee` extension such as `karma init karma.conf.coffee`, it will generate a CoffeeScript file.
+In fact, if you execute `karma init` with a `*.coffee` extension such as `karma init karma.conf.coffee`, it will generate a CoffeeScript file. Don't forget to add `coffee-script` dependency in package.json to get `*.coffee` configuration files work.
 
 Of course, you can write the config file by hand or copy paste it from another project ;-)
 


### PR DESCRIPTION
Tell user to add "coffee-script" dependency in package.json when generating a config file with ".coffee" extension.

I'm new to Node.js and Karma. When I'm generating init files with ".coffee" extension, I found that it is not possible to run karma until I add "coffee-script" dependency to package.json.

The error I got was:

```
/Users/chitsaou/projects/secret/spec/karma.conf.coffee:1
(function (exports, require, module, __filename, __dirname) { # Karma configur
                                                              ^
ERROR [config]: Invalid config file!
  SyntaxError: Unexpected token ILLEGAL
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.parseConfig (/Users/chitsaou/projects/secret/node_modules/karma/lib/config.js:250:22)
    at Object.exports.start (/Users/chitsaou/projects/secret/node_modules/karma/lib/server.js:273:20)
    at Object.exports.run (/Users/chitsaou/projects/secret/node_modules/karma/lib/cli.js:224:25)
    at Object.<anonymous> (/Users/chitsaou/projects/secret/node_modules/karma/bin/karma:3:23)
ERROR [config]: You need to install CoffeeScript.
  npm install coffee-script --save-dev
```

After adding "coffee-script" dependency I can start karma server and everything seems fine.
