### PR TITLE
style(server): fix jscs violations

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -40,7 +40,7 @@ var setup = function(level, colors, appenders) {
   appenders = helper.isDefined(appenders) ? appenders : [constant.CONSOLE_APPENDER];
 
   appenders = appenders.map(function(appender) {
-    if(appender.type === 'console') {
+    if (appender.type === 'console') {
       if (helper.isDefined(appender.layout) && appender.layout.type === 'pattern') {
         appender.layout.pattern = pattern;
       }


### PR DESCRIPTION
Fixes #1063

Currently all the Travis builds are broken due to the jscs version update. This is a quick fix to get the proper style but I wonder why it wasn't breaking previously. I guess something got fixed in the jscs itself...
