### PR TITLE
chore(scripts): init-dev-env.js will create .git/hooks

### DIFF
--- a/scripts/init-dev-env.js
+++ b/scripts/init-dev-env.js
@@ -25,6 +25,10 @@ var gitHookSetup = function() {
   }
 
   console.log('Adding symbolic link: %s linked to %s', scriptPath, gitHookPath);
+  try {
+    // "hooks" may not exist
+    fs.mkdirSync(path.dirname(gitHookPath));
+  } catch (e) {}
   fs.symlinkSync(scriptPath, gitHookPath, 'file');
 };
 


### PR DESCRIPTION
On my system for whatever reason (probably cause I used `GitHub.app`, of all things), when I cloned the repo, `.git/hooks` did not exist.

I attempted to run `init-dev-env.js`, but it failed because the `hooks` directory didn't exist.  So I made it do that.  Now it works.
