### PR TITLE
fix(config): respect -log-level during config setup

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -243,6 +243,12 @@ var CONFIG_SYNTAX_HELP = '  module.exports = function(config) {\n' +
 
 var parseConfig = function(configFilePath, cliOptions) {
   var configModule;
+
+  // potentially suppress various debug messages in this function
+  if (cliOptions && cliOptions.logLevel) {
+    log.logLevel = cliOptions.logLevel;
+  }
+
   if (configFilePath) {
     log.debug('Loading config %s', configFilePath);
 

--- a/test/unit/config.spec.coffee
+++ b/test/unit/config.spec.coffee
@@ -64,10 +64,10 @@ describe 'config', ->
   #============================================================================
   describe 'parseConfig', ->
     logSpy = null
+    logger = require '../../lib/logger.js'
 
     beforeEach ->
       logSpy = sinon.spy()
-      logger = require '../../lib/logger.js'
       logger.create('config').on 'log', logSpy
 
 
@@ -133,6 +133,13 @@ describe 'config', ->
       expect(config.port).to.equal 456
       expect(config.autoWatch).to.equal false
       expect(config.basePath).to.equal resolveWinPath('/abs/base')
+
+
+    it 'should immediately set log level set on cli option', ->
+      e.parseConfig null, {}
+      expect(logger.create('config').level.toString()).to.not.equal 'ERROR'
+      e.parseConfig null, {logLevel: 'ERROR'}
+      expect(logger.create('config').level.toString()).to.equal 'ERROR'
 
 
     it 'should override config with cli options, but not deep merge', ->


### PR DESCRIPTION
I do not use a `karma.conf.js` file; I use `grunt-karma` and my entire config is within the Grunt target(s).  

When I run my `karma` task, it always complains that I have no config file, even though I am specifying a `logLevel` of `ERROR`.  This bothered me, so I changed it.
