### PR TITLE
Remove trailing whitespace from generated config file

### DIFF
--- a/config.tpl.coffee
+++ b/config.tpl.coffee
@@ -14,14 +14,12 @@ module.exports = (config) ->
 
 
     # list of files / patterns to load in the browser
-    files: [
-      %FILES%
+    files: [%FILES%
     ]
 
 
     # list of files to exclude
-    exclude: [
-      %EXCLUDE%
+    exclude: [%EXCLUDE%
     ]
 
 

--- a/config.tpl.js
+++ b/config.tpl.js
@@ -14,14 +14,12 @@ module.exports = function(config) {
 
 
     // list of files / patterns to load in the browser
-    files: [
-      %FILES%
+    files: [%FILES%
     ],
 
 
     // list of files to exclude
-    exclude: [
-      %EXCLUDE%
+    exclude: [%EXCLUDE%
     ],
 
 

--- a/config.tpl.ls
+++ b/config.tpl.ls
@@ -14,14 +14,12 @@ module.exports = (config) ->
 
 
     # list of files / patterns to load in the browser
-    files: [
-      %FILES%
+    files: [%FILES%
     ]
 
 
     # list of files to exclude
-    exclude: [
-      %EXCLUDE%
+    exclude: [%EXCLUDE%
     ]
 
 

--- a/lib/init/formatters.js
+++ b/lib/init/formatters.js
@@ -29,7 +29,7 @@ var JavaScriptFormatter = function() {
   };
 
   var pad = function(str, pad) {
-    return str.replace(/\n/g, '\n' + pad);
+    return str.replace(/\n/g, '\n' + pad).replace(/\s+$/gm, '');
   };
 
   var formatQuottedList = function(list) {
@@ -46,7 +46,11 @@ var JavaScriptFormatter = function() {
       files.push(quoteNonIncludedPattern(onlyServedFile));
     });
 
-    return files.join(',\n      ');
+    files = files.map(function(file) {
+      return '\n      ' + file;
+    });
+
+    return files.join(',');
   };
 
   this.formatPreprocessors = function(preprocessors) {

--- a/test/unit/init/formatters.spec.coffee
+++ b/test/unit/init/formatters.spec.coffee
@@ -30,7 +30,7 @@ describe 'init/formatters', ->
         expect(replacements.FILES).to.equal ''
 
         replacements = formatter.formatAnswers createAnswers {files: ['*.js', 'other/file.js']}
-        expect(replacements.FILES).to.equal "'*.js',\n      'other/file.js'"
+        expect(replacements.FILES).to.equal "\n      '*.js',\n      'other/file.js'"
 
 
       it 'should format BROWSERS', ->
@@ -52,7 +52,7 @@ describe 'init/formatters', ->
           onlyServedFiles: ['src/*.js']
         }
 
-        expect(replacements.FILES).to.equal "'test-main.js',\n" +
+        expect(replacements.FILES).to.equal "\n      'test-main.js',\n" +
                                       "      {pattern: 'src/*.js', included: false}"
 
 


### PR DESCRIPTION
When `answers` object contains empty arrays for `FILES`, `EXCLUDE` or `PREPROCESSORS` it generates lines with trailing whitespace which can be annoying.
this commit changes templates and processing functions

before:

``` javascript
    // list of files / patterns to load in the browser
    files: [
______      
    ],
```

now:

```
    // list of files / patterns to load in the browser
    files: [
    ],
```
