### PR TITLE
feat: serve ePub as binary files

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -22,7 +22,7 @@ var isBinary = Object.create(null);
   'sgi', 'tiff', 'psd', 'uvi', 'sub', 'djvu', 'dwg', 'dxf', 'fbs', 'fpx', 'fst', 'mmr',
   'rlc', 'mdi', 'wdp', 'npx', 'wbmp', 'xif', 'webp', '3ds', 'ras', 'cmx', 'fh', 'ico', 'pcx', 'pic',
   'pnm', 'pbm', 'pgm', 'ppm', 'rgb', 'tga', 'xbm', 'xpm', 'xwd', 'zip', 'rar', 'tar', 'bz2', 'eot',
-  'ttf', 'woff', 'dat', 'nexe', 'pexe'
+  'ttf', 'woff', 'dat', 'nexe', 'pexe', 'epub'
 ].forEach(function(extension) {
   isBinary['.' + extension] = true;
 });


### PR DESCRIPTION
The *.epub files are now served as binary file by Karma. Otherwise they are
converted into strings and became corrupted.
