### PR TITLE
replace simple reassign with  _.merge

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -196,8 +196,14 @@ var Config = function() {
   this.LOG_INFO = constant.LOG_INFO;
   this.LOG_DEBUG = constant.LOG_DEBUG;
 
-  this.set = function(newConfig) {
-    config = _.merge(config, newConfig);
+  this.set = function(newConfig, deepMerge) {
+    if (deepMerge) {
+        config = _.merge(config, newConfig);
+    } else {
+        Object.keys(newConfig).forEach(function(key) {
+          config[key] = newConfig[key];
+        });
+    }
   };
 
   // DEFAULT CONFIG
@@ -240,7 +246,7 @@ var CONFIG_SYNTAX_HELP = '  module.exports = function(config) {\n' +
                          '    });\n' +
                          '  };\n';
 
-var parseConfig = function(configFilePath, cliOptions) {
+var parseConfig = function(configFilePath, cliOptions, deepMerge) {
   var configModule;
   if (configFilePath) {
     log.debug('Loading config %s', configFilePath);
@@ -284,7 +290,7 @@ var parseConfig = function(configFilePath, cliOptions) {
   }
 
   // merge the config from config file and cliOptions (precendense)
-  config.set(cliOptions);
+  config.set(cliOptions, deepMerge);
 
   // configure the logger as soon as we can
   logger.setup(config.logLevel, config.colors, config.loggers);

--- a/lib/config.js
+++ b/lib/config.js
@@ -198,11 +198,11 @@ var Config = function() {
 
   this.set = function(newConfig, deepMerge) {
     if (deepMerge) {
-        config = _.merge(config, newConfig);
+      config = _.merge(config, newConfig);
     } else {
-        Object.keys(newConfig).forEach(function(key) {
-          config[key] = newConfig[key];
-        });
+      Object.keys(newConfig).forEach(function(key) {
+        config[key] = newConfig[key];
+      });
     }
   };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,7 @@ var logger = require('./logger');
 var log = logger.create('config');
 var helper = require('./helper');
 var constant = require('./constants');
+var _ = require('lodash');
 
 var COFFEE_SCRIPT_AVAILABLE = false;
 var LIVE_SCRIPT_AVAILABLE = false;
@@ -196,9 +197,7 @@ var Config = function() {
   this.LOG_DEBUG = constant.LOG_DEBUG;
 
   this.set = function(newConfig) {
-    Object.keys(newConfig).forEach(function(key) {
-      config[key] = newConfig[key];
-    });
+    config = _.merge(config, newConfig);
   };
 
   // DEFAULT CONFIG

--- a/lib/server.js
+++ b/lib/server.js
@@ -270,12 +270,12 @@ var createSocketIoServer = function(webServer, executor, config) {
 };
 
 
-exports.start = function(cliOptions, done) {
+exports.start = function(cliOptions, done, deepMerge) {
   // apply the default logger config (and config from CLI) as soon as we can
   logger.setup(cliOptions.logLevel || constant.LOG_INFO,
       helper.isDefined(cliOptions.colors) ? cliOptions.colors : true, [constant.CONSOLE_APPENDER]);
 
-  var config = cfg.parseConfig(cliOptions.configFile, cliOptions);
+  var config = cfg.parseConfig(cliOptions.configFile, cliOptions, deepMerge);
   var modules = [{
     helper: ['value', helper],
     logger: ['value', logger],

--- a/test/unit/config.spec.coffee
+++ b/test/unit/config.spec.coffee
@@ -142,6 +142,14 @@ describe 'config', ->
       expect(config.browsers).to.deep.equal ['Safari']
 
 
+    it 'should deep merge config with cli options', ->
+      # https://github.com/karma-runner/karma/pull/1084
+      config = e.parseConfig '/home/config7.js', {client: {customProperty: true}}, true
+
+      expect(config.client.useIframe).to.equal true
+      expect(config.client.customProperty).to.equal true
+
+
     it 'should resolve files and excludes to overriden basePath from cli', ->
       config = e.parseConfig '/conf/both.js', {port: 456, autoWatch: false, basePath: '/xxx'}
 


### PR DESCRIPTION
The following code will override some properties that is an Object, like config.client.
```js
this.set = function(newConfig) {
    Object.keys(newConfig).forEach(function(key) {
      config[key] = newConfig[key];
    });
};
```
If someone want to  pass an custom property to client, He has to also pass all the properties:useIframe,args,and captureConsole, or they will be lost.
So I suggest replacing this with following:
```js
   this.set = function(newConfig) {
     config = _.merge(config, newConfig);
   };
```