### PR TITLE
fix(proxy) proxyDetails not normalized after the proxyUrl is.

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -24,6 +24,7 @@ var parseProxyConfig = function(proxies) {
     if (endsWithSlash(proxyPath) && !endsWithSlash(proxyUrl)) {
       log.warn('proxy "%s" normalized to "%s"', proxyUrl, proxyUrl + '/');
       proxyUrl += '/';
+      pathname += '/';
     }
 
     if (!endsWithSlash(proxyPath) && endsWithSlash(proxyUrl)) {

--- a/test/unit/middleware/proxy.spec.coffee
+++ b/test/unit/middleware/proxy.spec.coffee
@@ -154,5 +154,20 @@ describe 'middleware.proxy', ->
       baseProxyUrl: '/proxy/test', https:false}
     }
 
+  it 'should normalize proxy url with only basepaths', ->
+    proxy = {'/base/': '/proxy/test'}
+    parsedProxyConfig = m.parseProxyConfig proxy
+    expect(parsedProxyConfig).to.deep.equal {
+      '/base/': {host: c.DEFAULT_HOSTNAME, port: c.DEFAULT_PORT,
+      baseProxyUrl: '/proxy/test/', https:false}
+    }
+
+  it 'should normalize proxy url', ->
+    proxy = {'/base/': 'http://localhost:8000/proxy/test'}
+    parsedProxyConfig = m.parseProxyConfig proxy
+    expect(parsedProxyConfig).to.deep.equal {
+      '/base/': {host: 'localhost', port: '8000', baseProxyUrl: '/proxy/test/', https:false}
+    }
+
   it 'should handle empty proxy config', ->
     expect(m.parseProxyConfig {}).to.deep.equal({})


### PR DESCRIPTION
After normalizing the proxyUrl the proxyDetails should be updated to reflect the change.
