### PR TITLE
fix: catch exceptions from SourceMapConsumer

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -46,10 +46,15 @@ var createErrorFormatter = function(basePath, emitter, SourceMapConsumer) {
         column = parseInt(column || '0', 10);
 
         var smc = new SourceMapConsumer(file.sourceMap);
-        var original = smc.originalPositionFor({line: line, column: column});
+        try {
+          var original = smc.originalPositionFor({line: line, column: column});
 
-        return util.format('%s:%d:%d <- %s:%d:%d', path, line, column, original.source,
+          return util.format('%s:%d:%d <- %s:%d:%d', path, line, column, original.source,
             original.line, original.column);
+        } catch (e) {
+          log.warn('SourceMap position not found for trace: %s', msg);
+          // Fall back to non-source-mapped formatting.
+        }
       }
 
       return path + (line ? ':' + line : '') + (column ? ':' + column : '');


### PR DESCRIPTION
The symptom of this issue is that the test runner will die with the following error:

    Fatal error: Line must be greater than or equal to 1, got 0

The way the error happened:

1) One of my specs was failing when calling getComputedStyle(). In Firefox this resulted in an error message with some weird formatting: "TypeError: Argument 1 of Window.getComputedStyle does not implement interface Element. in http://172.20.132.80:8080/base/app/SilverApp/services/DragAvatarProducer.js?dc125e476a15c0e2f62b00901b3d0c1b6c407af8 (line 85)". The problem with that string is the line number is formatted "(line 85)" when it should be like ":85:7". This might be a bug against Firefox.
2) Karma's source-map support tried to parse the line & column, but couldn't because the formatting was weird. (see: https://github.com/karma-runner/karma/blob/master/lib/reporter.js#L36 )
3) Karma uses defaults of 0 for the line & column numbers. (see: https://github.com/karma-runner/karma/blob/master/lib/reporter.js#L45 )
4) The source-map library throws an exception if line or column is 0. (see: https://github.com/mozilla/source-map/blob/master/lib/source-map/source-map-consumer.js#L277 )

This pull request wraps `SourceMapConsumer.originalPositionFor` in a try-catch block.