### PR TITLE
fix(proxy): More useful proxyError log message

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -79,7 +79,7 @@ var createProxyHandler = function(proxy, proxyConfig, proxyValidateSSL, urlRoot)
     if (err.code === 'ECONNRESET' && req.socket.destroyed) {
       log.debug('failed to proxy %s (browser hung up the socket)', req.url);
     } else {
-      log.warn('failed to proxy %s (%s)', req.url, err);
+      log.warn('failed to proxy %s (%s)', req.url, err.message);
     }
   });
 


### PR DESCRIPTION
Update the log message to output the 'message' attribute of the Error so
that more is logged than merely "[object Object]".
