### PR TITLE
feat(preprocessor): add 'mp3' and 'ogg' as binary formats

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -22,7 +22,7 @@ var isBinary = Object.create(null);
   'sgi', 'tiff', 'psd', 'uvi', 'sub', 'djvu', 'dwg', 'dxf', 'fbs', 'fpx', 'fst', 'mmr',
   'rlc', 'mdi', 'wdp', 'npx', 'wbmp', 'xif', 'webp', '3ds', 'ras', 'cmx', 'fh', 'ico', 'pcx', 'pic',
   'pnm', 'pbm', 'pgm', 'ppm', 'rgb', 'tga', 'xbm', 'xpm', 'xwd', 'zip', 'rar', 'tar', 'bz2', 'eot',
-  'ttf', 'woff', 'dat', 'nexe', 'pexe', 'epub'
+  'ttf', 'woff', 'dat', 'nexe', 'pexe', 'epub', 'mp3', 'ogg'
 ].forEach(function(extension) {
   isBinary['.' + extension] = true;
 });


### PR DESCRIPTION
Avoids media corruption in the browser.
