### PR TITLE
fix(travis_ci): converted node versions as string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.8
+  - "0.10"
+  - "0.8"
 
 env:
   global:


### PR DESCRIPTION
It avoids the `0.1` version number in Travis builds.

Cf. http://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Choosing-Node-versions-to-test-against
