### PR TITLE
adding gz to list of binary files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.8
+  - "0.10"
+  - "0.8"
 
 env:
   global:


### PR DESCRIPTION
gzip files are also considered binary and must not be preprocessed, or they will become corrupted.

We are using karma to execute jasmine unit tests that rely on gzipped fixtures, which are binary.  Please add the gz extension to the binary whitelist so that our tests will run in karma.
