### PR TITLE
fix(logging): Summarize SKIPPED tests in debug.html.

### DIFF
--- a/static/debug.html
+++ b/static/debug.html
@@ -22,10 +22,17 @@ just for immediate execution, without reporting to Karma server.
       info: function(info) {
         if (info.dump && window.console) window.console.log(info.dump);
       },
-      complete: function() {},
+      complete: function() {
+        window.console.log('Skipped ' + this.skipped + ' tests');
+      },
       store: function() {},
+      skipped: 0,
       result: window.console ? function(result) {
-        var msg = result.skipped ? 'SKIPPED ' : (result.success ? 'SUCCESS ' : 'FAILED ');
+        if (result.skipped) {
+          this.skipped++;
+          return;
+        }
+        var msg = result.success ? 'SUCCESS ' : 'FAILED ';
         window.console.log(msg + result.suite.join(' ') + ' ' + result.description);
 
         for (var i = 0; i < result.log.length; i++) {


### PR DESCRIPTION
Before: hundreds of SKIPPING lines in console.log.
After: A single summary line with a count.

Closes #1111
