### PR TITLE
lock down socket.io to 0.9.15 due to disconnects when using iit and ddescribe

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   ],
   "dependencies": {
     "di": "~0.0.1",
-    "socket.io": "~0.9.13",
+    "socket.io": "0.9.15",
     "chokidar": ">=0.8.2",
     "glob": "~3.2.7",
     "minimatch": "~0.2",


### PR DESCRIPTION
as mentioned in #1082, karma is getting latest 0.9 version of socket.io which does not play nice with Chrome when isolating tests with iit and ddescribe. Running tests in isolation with this version of socket.io causes the browser to disconnect, effectively making iit and ddescribe unusable. Until socket.io is fixed (https://github.com/Automattic/socket.io/issues/1558) karma should lock to a more stable version of socket.io.
