### PR TITLE
fix(server): Force socket.io clients disconnection on Windows

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -197,7 +197,11 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
     // TODO(vojta): change the client to not send the event (if disconnected by purpose)
     var sockets = socketServer.sockets.sockets;
     Object.getOwnPropertyNames(sockets).forEach(function(key) {
-      sockets[key].removeAllListeners('disconnect');
+      var socket = sockets[key];
+      socket.removeAllListeners('disconnect');
+      if (!socket.disconnected) {
+        socket.disconnect();
+      }
     });
 
     var removeAllListenersDone = false;


### PR DESCRIPTION
It occurs that only on Windows, socket.io clients are not properly disconnected, which causes Karma to not exit immediately when everything is done. We have to wait for some internal disconnection socket.io event timeout.

This PR basically check if all sockets are disconnected. If not we manually force the disconnection.

Fixes #1109
