### PR TITLE
refactor(watcher): Use gaze for FS watching

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,107 +1,71 @@
-var chokidar = require('chokidar');
-var mm = require('minimatch');
-
+var Gaze = require('gaze').Gaze;
+var globule = require('globule');
 var helper = require('./helper');
 var log = require('./logger').create('watcher');
-
-var DIR_SEP = require('path').sep;
-
-// Get parent folder, that be watched (does not contain any special globbing character)
-var baseDirFromPattern = function(pattern) {
-  return pattern.replace(/\/[^\/]*\*.*$/, '')           // remove parts with *
-                .replace(/\/[^\/]*[\!\+]\(.*$/, '')     // remove parts with !(...) and +(...)
-                .replace(/\/[^\/]*\)\?.*$/, '') || '/'; // remove parts with (...)?
-};
-
-var watchPatterns = function(patterns, watcher) {
-  // filter only unique non url patterns paths
-  var pathsToWatch = [];
-  var uniqueMap = {};
-  var path;
-
-  patterns.forEach(function(pattern) {
-    path = baseDirFromPattern(pattern);
-    if (!uniqueMap[path]) {
-      uniqueMap[path] = true;
-      pathsToWatch.push(path);
-    }
-  });
-
-  // watch only common parents, no sub paths
-  pathsToWatch.forEach(function(path) {
-    if (!pathsToWatch.some(function(p) {
-      return p !== path && path.substr(0, p.length + 1) === p + DIR_SEP;
-    })) {
-      watcher.add(path);
-      log.debug('Watching "%s"', path);
-    }
-  });
-};
-
-// Function to test if a path should be ignored by chokidar.
-var createIgnore = function(patterns, excludes) {
-  return function(path, stat) {
-    if (!stat || stat.isDirectory()) {
-      return false;
-    }
-
-    // Check if the path matches any of the watched patterns.
-    if (!patterns.some(function(pattern) {
-      return mm(path, pattern, {dot: true});
-    })) {
-      return true;
-    }
-
-    // Check if the path matches any of the exclude patterns.
-    if (excludes.some(function(pattern) {
-      return mm(path, pattern, {dot: true});
-    })) {
-      return true;
-    }
-
-    return false;
-  };
-};
+var path = require('path');
 
 var onlyWatchedTrue = function(pattern) {
   return pattern.watched;
 };
 
-var getWatchedPatterns = function(patternObjects) {
+var relativePath = function(base) {
+  return function(absPath){
+    return path.relative(base, absPath);
+  };
+};
+
+var getWatchedPatterns = function(patternObjects, base) {
   return patternObjects.filter(onlyWatchedTrue).map(function(patternObject) {
-    return patternObject.pattern;
+    return relativePath(base)(patternObject.pattern);
   });
 };
 
-exports.watch = function(patterns, excludes, fileList, usePolling) {
-  var watchedPatterns = getWatchedPatterns(patterns);
+exports.watch = function(patterns, excludes, fileList, usePolling, basePath) {
+  var watchedPatterns = getWatchedPatterns(patterns, basePath);
+  var excludedPatterns = excludes.map(relativePath(basePath));
+
   var options = {
-    usePolling: usePolling,
-    ignorePermissionErrors: true,
-    ignoreInitial: true,
-    ignored: createIgnore(watchedPatterns, excludes)
+    mode: usePolling ? 'poll' : 'auto',
+    debounceDelay: 50,
+    cwd: basePath
   };
-  var chokidarWatcher = new chokidar.FSWatcher(options);
 
-  watchPatterns(watchedPatterns, chokidarWatcher);
+  var gaze = new Gaze(watchedPatterns, options, function(err){
+    if(err){
+      return log.error('Error watching files', err);
+    }
 
-  var bind = function(fn) {
-    return function(path) {
-      return fn.call(fileList, helper.normalizeWinPath(path));
+    var bind = function(fn) {
+      return function(path) {
+        return fn.call(fileList, helper.normalizeWinPath(path));
+      };
     };
-  };
 
-  // register events
-  chokidarWatcher.on('add', bind(fileList.addFile))
-                 .on('change', bind(fileList.changeFile))
-                 .on('unlink', bind(fileList.removeFile))
-                 // If we don't subscribe; unhandled errors from Chokidar will bring Karma down
-                 // (see GH Issue #959)
-                 .on('error', function(e) {
-                    log.debug(e);
-                  });
+    this.on('added', bind(fileList.addFile));
+    this.on('changed', bind(fileList.changeFile));
+    this.on('deleted', bind(fileList.removeFile));
 
-  return chokidarWatcher;
+    this.on('error', function(err){
+      log.error('File watcher error', err);
+    });
+
+    //Unwatch excluded files.  file_list deals with excluded files that are added at runtime.
+    var excluded = globule.find(excludedPatterns, {cwd: basePath});
+    excluded.map(this.remove);
+    excluded.map(function(file){
+      log.info('Excluding from watched files:', file);
+    });
+
+  });
+
+  return gaze;
+
 };
 
-exports.watch.$inject = ['config.files', 'config.exclude', 'fileList', 'config.usePolling'];
+exports.watch.$inject = [
+  'config.files',
+  'config.exclude',
+  'fileList',
+  'config.usePolling',
+  'config.basePath'
+];

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -9,7 +9,7 @@ var onlyWatchedTrue = function(pattern) {
 };
 
 var relativePath = function(base) {
-  return function(absPath){
+  return function(absPath) {
     return path.relative(base, absPath);
   };
 };
@@ -30,8 +30,8 @@ exports.watch = function(patterns, excludes, fileList, usePolling, basePath) {
     cwd: basePath
   };
 
-  var gaze = new Gaze(watchedPatterns, options, function(err){
-    if(err){
+  var gaze = new Gaze(watchedPatterns, options, function(err) {
+    if (err) {
       return log.error('Error watching files', err);
     }
 
@@ -45,14 +45,14 @@ exports.watch = function(patterns, excludes, fileList, usePolling, basePath) {
     this.on('changed', bind(fileList.changeFile));
     this.on('deleted', bind(fileList.removeFile));
 
-    this.on('error', function(err){
+    this.on('error', function(err) {
       log.error('File watcher error', err);
     });
 
     //Unwatch excluded files.  file_list deals with excluded files that are added at runtime.
     var excluded = globule.find(excludedPatterns, {cwd: basePath});
     excluded.map(this.remove);
-    excluded.map(function(file){
+    excluded.map(function(file) {
       log.info('Excluding from watched files:', file);
     });
 

--- a/package.json
+++ b/package.json
@@ -128,8 +128,9 @@
   "dependencies": {
     "di": "~0.0.1",
     "socket.io": "~0.9.13",
-    "chokidar": ">=0.8.2",
+    "gaze": "~0.6.4",
     "glob": "~3.2.7",
+    "globule": "~0.2.0",
     "minimatch": "~0.2",
     "http-proxy": "~0.10",
     "optimist": "~0.6.0",

--- a/test/unit/watcher.spec.coffee
+++ b/test/unit/watcher.spec.coffee
@@ -7,123 +7,17 @@ describe 'watcher', ->
   m = null
 
   beforeEach ->
+    configuration = new config.Config()
     mocks_ = chokidar: mocks.chokidar
     m = mocks.loadFile __dirname + '/../../lib/watcher.js', mocks_
-
-  #============================================================================
-  # baseDirFromPattern() [PRIVATE]
-  #============================================================================
-  describe 'baseDirFromPattern', ->
-
-    it 'should return parent directory without start', ->
-      expect(m.baseDirFromPattern '/some/path/**/more.js').to.equal '/some/path'
-      expect(m.baseDirFromPattern '/some/p*/file.js').to.equal '/some'
-
-
-    it 'should remove part with !(x)', ->
-      expect(m.baseDirFromPattern '/some/p/!(a|b).js').to.equal '/some/p'
-      expect(m.baseDirFromPattern '/some/p!(c|b)*.js').to.equal '/some'
-
-
-    it 'should remove part with +(x)', ->
-      expect(m.baseDirFromPattern '/some/p/+(a|b).js').to.equal '/some/p'
-      expect(m.baseDirFromPattern '/some/p+(c|bb).js').to.equal '/some'
-
-
-    it 'should remove part with (x)?', ->
-      expect(m.baseDirFromPattern '/some/p/(a|b)?.js').to.equal '/some/p'
-      expect(m.baseDirFromPattern '/some/p(c|b)?.js').to.equal '/some'
-
-
-    it 'should allow paths with parentheses', ->
-      expect(m.baseDirFromPattern '/some/x (a|b)/a.js').to.equal '/some/x (a|b)/a.js'
-      expect(m.baseDirFromPattern '/some/p(c|b)/*.js').to.equal '/some/p(c|b)'
-
-
-    it 'should ignore exact files', ->
-      expect(m.baseDirFromPattern '/usr/local/bin.js').to.equal '/usr/local/bin.js'
-
-
-  #==============================================================================
-  # watchPatterns() [PRIVATE]
-  #==============================================================================
-  describe 'watchPatterns', ->
-    chokidarWatcher = null
-
-    beforeEach ->
-      chokidarWatcher = new mocks.chokidar.FSWatcher
-
-    it 'should watch all the patterns', ->
-      m.watchPatterns ['/some/*.js', '/a/*'], chokidarWatcher
-      expect(chokidarWatcher.watchedPaths_).to.deep.equal ['/some', '/a']
-
-
-    it 'should not watch the same path twice', ->
-      m.watchPatterns ['/some/a*.js', '/some/*.txt'], chokidarWatcher
-      expect(chokidarWatcher.watchedPaths_).to.deep.equal ['/some']
-
-
-    it 'should not watch subpaths that are already watched', ->
-      m.watchPatterns ['/some/sub/*.js', '/some/a*.*'], chokidarWatcher
-      expect(chokidarWatcher.watchedPaths_).to.deep.equal ['/some']
-
-
-    it 'should watch a file matching subpath directory', ->
-      # regression #521
-      m.watchPatterns ['/some/test-file.js', '/some/test/**'], chokidarWatcher
-      expect(chokidarWatcher.watchedPaths_).to.deep.equal ['/some/test-file.js', '/some/test']
 
 
   describe 'getWatchedPatterns', ->
 
     it 'should return list of watched patterns (strings)', ->
       watchedPatterns = m.getWatchedPatterns [
-        config.createPatternObject('/watched.js')
+        config.createPatternObject('watched.js')
         config.createPatternObject(pattern: 'non/*.js', watched: false)
-      ]
-      expect(watchedPatterns).to.deep.equal ['/watched.js']
+      ], process.cwd()
+      expect(watchedPatterns).to.deep.equal ['watched.js']
 
-
-  #============================================================================
-  # ignore() [PRIVATE]
-  #============================================================================
-  describe 'ignore', ->
-    FILE_STAT =
-      isDirectory: -> false
-      isFile: -> true
-    DIRECTORY_STAT =
-      isDirectory: -> true
-      isFile: -> false
-
-    it 'should ignore all files', ->
-      ignore = m.createIgnore ['**/*'], ['**/*']
-      expect(ignore '/some/files/deep/nested.js', FILE_STAT).to.equal true
-      expect(ignore '/some/files', FILE_STAT).to.equal true
-
-
-    it 'should ignore .# files', ->
-      ignore = m.createIgnore ['**/*'], ['**/.#*']
-      expect(ignore '/some/files/deep/nested.js', FILE_STAT).to.equal false
-      expect(ignore '/some/files', FILE_STAT).to.equal false
-      expect(ignore '/some/files/deep/.npm', FILE_STAT).to.equal false
-      expect(ignore '.#files.js', FILE_STAT).to.equal true
-      expect(ignore '/some/files/deeper/nested/.#files.js', FILE_STAT).to.equal true
-
-
-    it 'should ignore files that do not match any pattern', ->
-      ignore = m.createIgnore ['/some/*.js'], []
-      expect(ignore '/a.js', FILE_STAT).to.equal true
-      expect(ignore '/some.js', FILE_STAT).to.equal true
-      expect(ignore '/some/a.js', FILE_STAT).to.equal false
-
-
-    it 'should not ignore directories', ->
-      ignore = m.createIgnore ['**/*'], ['**/*']
-      expect(ignore '/some/dir', DIRECTORY_STAT).to.equal false
-
-
-    it 'should not ignore items without stat', ->
-      # before we know whether it's a directory or file, we can't ignore
-      ignore = m.createIgnore ['**/*'], ['**/*']
-      expect(ignore '/some.js', undefined).to.equal false
-      expect(ignore '/what/ever', undefined).to.equal false


### PR DESCRIPTION
There are several issues surrounding file-watching (see #974), and it makes increasingly little sense to try to address all tricky edge cases within Karma, when there are existing libraries that tackle the "tough issues" for us.

This PR replaces chokidar with Gaze, which is a purpose-built globbing file watcher.  [Gaze](https://github.com/shama/gaze) has some of its own issues (particularly related to ST3), but largely seems to be more stable and reliable than Karma's old approach.  Gaze is fairly widely used, and notbaly provides the underlying functionality for [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch).

Additionally, we now watch files according to their relative paths (rather than the absolute path that config.js computes for us).  This seems to prevent Gaze from inadvertently traversing filesystem boundaries (which hurts performance, and breaks the detection of new files).

Most unit tests in watcher.js were removed, because Gaze implements its own test suite, which doesn't need to be replicated here.  If there's any functionality that you think should be tested, please leave a comment.

When this PR is merged, it may make sense to start cleaning up file_list.js, and removing globbing hacks wherever we can, and delegate that functionality out to an external library.