### PR TITLE
Add X-Forwarded-Host support to proxy

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -90,6 +90,9 @@ var createProxyHandler = function(proxy, proxyConfig, proxyValidateSSL, urlRoot)
         var proxiedUrl = proxies[proxiesList[i]];
 
         log.debug('proxying request - %s to %s:%s', request.url, proxiedUrl.host, proxiedUrl.port);
+
+        request.headers['x-forwarded-host'] = request.headers.host;
+
         request.url = request.url.replace(proxiesList[i], proxiedUrl.baseProxyUrl);
         proxy.proxyRequest(request, response, {
             host: proxiedUrl.host,


### PR DESCRIPTION
This adds support for X-Forwarded-Host support to karma's proxy. This is necessary for backends that perform CSRF token checks and use X-Forwarded-Host header fields to perform referrer checks.

Example use case: an integration test against a CSRF Protected Django API endpoint. If X-Forwarded-Host header is not present and the API is configured to use this (many are) the referrer check will fail. This commit fixes that.

Also, I wasn't sure whether to include a configuration parameter to add this header field conditionally, or just always add it. Would like some input on this.

This code is tough to test because the function being changed is wrapped in createProxyHandler(). It seems like it could use a good refactor to make it more testable. I am willing to do that, but would do it in a subsequent commit. Any thoughts on that?
