### PR TITLE
travis: Remove redundant node_modules/.bin prefix

### DIFF
--- a/docs/plus/02-travis.md
+++ b/docs/plus/02-travis.md
@@ -31,7 +31,7 @@ is where you tell Travis how to run your tests.
 },
 // ...snip...
 'scripts': {
-   'test': './node_modules/.bin/karma start --single-run --browsers PhantomJS'
+   'test': 'karma start --single-run --browsers PhantomJS'
 }
 // ...snip...
 ```
@@ -56,7 +56,7 @@ before_script:
 And now, you can run your tests on Firefox, just change the `npm test`
 command to
 ```bash
-./node_modules/.bin/karma start --browsers Firefox --single-run
+karma start --browsers Firefox --single-run
 ```
 
 ## Notes


### PR DESCRIPTION
npm runs scripts in a sub shell with "node_modules/.bin/" added to the PATH.

https://www.npmjs.org/doc/misc/npm-scripts.html#environment
