### PR TITLE
fix(server): launch browsers when file_list is ready

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -34,7 +34,7 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
   var filesPromise = fileList.refresh();
 
   if (config.autoWatch) {
-    filesPromise.then(function() {
+    filesPromise = filesPromise.then(function() {
       injector.invoke(watcher.watch);
     }, function() {
       injector.invoke(watcher.watch);
@@ -61,15 +61,21 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
   // Some browsers did not get captured.
   var singleRunBrowserNotCaptured = false;
 
-  webServer.listen(config.port, function() {
-    log.info('Karma v%s server started at http://%s:%s%s', constant.VERSION, config.hostname,
-        config.port, config.urlRoot);
-
+  var launchSingleRunBrowsers = function() {
     if (config.browsers && config.browsers.length) {
       injector.invoke(launcher.launch, launcher).forEach(function(browserLauncher) {
         singleRunDoneBrowsers[browserLauncher.id] = false;
       });
     }
+  };
+
+  webServer.listen(config.port, function() {
+    log.info('Karma v%s server started at http://%s:%s%s', constant.VERSION, config.hostname,
+        config.port, config.urlRoot);
+
+    // Wait until fileList.refresh() is done, or else we might
+    // not be ready to reply to the browser's capture request.
+    filesPromise.then(launchSingleRunBrowsers, launchSingleRunBrowsers);
   });
 
   globalEmitter.on('browsers_change', function() {


### PR DESCRIPTION
After weeks of intermittent timeouts starting PhantomJS I finally found out what's wrong–

We're having a lot of files (well, not *that* many, maybe a hundred) and we're using `grunt-karma` to trigger single-run tests with PhantomJS in a continuous integration environment.

Correct me if I'm wrong, but it looks like the web server is not ready to reply to the browser's connect request until the file list is finished. Since PhantomJS' startup is really quick, it sometimes tries to connect before `fileList.refresh()` completed.

After applying this patch, the problem seems to disappear… what do you think?