### PR TITLE
fix(preprocessor): treat *.tgz, *.tbz2, *.txz & *.xz as binary

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -21,8 +21,9 @@ var isBinary = Object.create(null);
   'movie', 'smv', 'bmp', 'cgm', 'g3', 'gif', 'ief', 'jpg', 'jpeg', 'ktx', 'png', 'btif',
   'sgi', 'tiff', 'psd', 'uvi', 'sub', 'djvu', 'dwg', 'dxf', 'fbs', 'fpx', 'fst', 'mmr',
   'rlc', 'mdi', 'wdp', 'npx', 'wbmp', 'xif', 'webp', '3ds', 'ras', 'cmx', 'fh', 'ico', 'pcx', 'pic',
-  'pnm', 'pbm', 'pgm', 'ppm', 'rgb', 'tga', 'xbm', 'xpm', 'xwd', 'zip', 'rar', 'tar', 'bz2', 'eot',
-  'ttf', 'woff', 'dat', 'nexe', 'pexe', 'epub', 'gz', 'mp3', 'ogg', 'swf'
+  'pnm', 'pbm', 'pgm', 'ppm', 'rgb', 'tga', 'xbm', 'xpm', 'xwd', 'xz', 'zip', 'rar', 'tar', 'tbz2',
+  'tgz', 'txz', 'bz2', 'eot', 'ttf', 'woff', 'dat', 'nexe', 'pexe', 'epub', 'gz', 'mp3', 'ogg',
+  'swf'
 ].forEach(function(extension) {
   isBinary['.' + extension] = true;
 });


### PR DESCRIPTION
Tarballs often use extensions joined with used compression, e.g. *.tgz instead
of *.tar.bz.

Also, there is a new xz lossless compression format that is slower but gives
better results than gzip or bzip2.
