### PR TITLE
fix: exit with error on retry give up

### DIFF
--- a/lib/launchers/base.js
+++ b/lib/launchers/base.js
@@ -85,6 +85,10 @@ var BaseLauncher = function(id, emitter) {
     self.state = RESTARTING;
   };
 
+  this.fail = function() {
+    emitter.emit('browser_process_failure', this);
+  };
+
   this.markCaptured = function() {
     if (this.state === BEING_CAPTURED) {
       this.state = CAPTURED;
@@ -106,7 +110,7 @@ var BaseLauncher = function(id, emitter) {
     this.emit('done');
 
     if (this.error && this.state !== BEING_FORCE_KILLED && this.state !== RESTARTING) {
-      emitter.emit('browser_process_failure', this);
+      this.fail();
     }
 
     this.state = FINISHED;

--- a/lib/launchers/retry.js
+++ b/lib/launchers/retry.js
@@ -17,6 +17,7 @@ var RetryLauncher = function(retryLimit) {
       self._retryLimit--;
     } else if (self._retryLimit === 0) {
       log.error('%s failed %d times (%s). Giving up.', self.name, retryLimit, self.error);
+      self.fail();
     } else {
       log.debug('%s failed (%s). Not restarting.', self.name, self.error);
     }


### PR DESCRIPTION
When browser not responding karma just logs `ERROR [launcher]: <browser> failed 2 times (timeout). Giving up.` and hangs.

We should exit with error in such case.
