### PR TITLE
fix(server): complete acknowledgment

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -146,18 +146,14 @@ var Karma = function(socket, iframe, opener, navigator, location) {
     // give the browser some time to breath, there could be a page reload, but because a bunch of
     // tests could run in the same event loop, we wouldn't notice.
     setTimeout(function() {
-      socket.emit('complete', result || {});
       clearContext();
-
-      // Redirect to the return_url, however we need to give the browser some time,
-      // so that all the messages are sent.
-      // TODO(vojta): can we rather get notification from socket.io?
-      if (returnUrl) {
-        setTimeout(function() {
-          location.href = returnUrl;
-        }, (currentTransport === 'websocket' || currentTransport === 'flashsocket') ? 0 : 3000);
-      }
     }, 0);
+
+    socket.emit('complete', result || {}, function() {
+      if (returnUrl) {
+        location.href = returnUrl;
+      }
+    });
   };
 
   this.info = function(info) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -93,6 +93,10 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
 
     var replySocketEvents = events.bufferEvents(socket, EVENTS_TO_REPLY);
 
+    socket.on('complete', function(data, ack) {
+      ack();
+    });
+
     socket.on('register', function(info) {
       var newBrowser;
       var isRestart;

--- a/test/client/karma.spec.js
+++ b/test/client/karma.spec.js
@@ -258,8 +258,15 @@ describe('Karma', function() {
 
       spyOn(socket, 'disconnect');
 
+      socket.on('complete', function(data, ack) {
+        ack();
+      });
+
       k.complete();
-      expect(windowLocation.href).toBe('http://return.com');
+
+      waitsFor(function(){
+        return windowLocation.href === 'http://return.com';
+      }, '', 9000);
     });
 
     it('should patch the console if captureConsole is true', function() {


### PR DESCRIPTION
Client's `complete` message acknowledgment.

Fixes issues with `window.href = returnUrl` called before tests complete (on slow networks)

PS. Any ideas how to test server-side ack?
