### PR TITLE
Cannot read property x-ua-compatible of null

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -37,10 +37,12 @@ var filePathToUrlPath = function(filePath, basePath) {
 var getXUACompatibleMetaElement = function(url) {
   var tag = '';
   var urlObj = urlparse(url, true);
-  if (urlObj.query['x-ua-compatible']) {
-    tag = '\n<meta http-equiv="X-UA-Compatible" content="' +
-     urlObj.query['x-ua-compatible'] + '"/>';
-  }
+  // ERROR [karma]: [TypeError: Cannot read property 'x-ua-compatible' of null]
+  // TypeError: Cannot read property 'x-ua-compatible' of null
+  // if (urlObj.query['x-ua-compatible']) {
+  //   tag = '\n<meta http-equiv="X-UA-Compatible" content="' +
+  //    urlObj.query['x-ua-compatible'] + '"/>';
+  // }
   return tag;
 };
 


### PR DESCRIPTION
This occurs building Leaflet (latest) with node (latest)
Commented out the code and I can build. No idea why or how right now. 

/.bin/jake 
Checking for JS errors...
    Check passed.

Checking for specs JS errors...
    Check passed.

Running tests...

WARN [plugin]: Error during loading "karma-coverage" plugin:
  Cannot find module './lib/store'
jake aborted.
TypeError: Cannot read property 'x-ua-compatible' of null
    at getXUACompatibleMetaElement (/mnt/newdrive2/home/mdupont/experiments/Leaflet/node_modules/karma/lib/middleware/karma.js:40:19)
    at /mnt/newdrive2/home/mdupont/experiments/Leaflet/node_modules/karma/lib/middleware/karma.js:145:45
(See full trace by running task with --trace)
ERROR [karma]: [TypeError: Cannot read property 'x-ua-compatible' of null]
TypeError: Cannot read property 'x-ua-compatible' of null
    at getXUACompatibleMetaElement (/mnt/newdrive2/home/mdupont/experiments/Leaflet/node_modules/karma/lib/middleware/karma.js:40:19)
    at /mnt/newdrive2/home/mdupont/experiments/Leaflet/node_modules/karma/lib/middleware/karma.js:145:45
    at /mnt/newdrive2/home/mdupont/experiments/Leaflet/node_modules/karma/lib/middleware/common.js:65:35
    at fs.js:295:14
    at /mnt/newdrive2/home/mdupont/experiments/Leaflet/node_modules/karma/node_modules/graceful-fs/graceful-fs.js:104:5
    at Object.oncomplete (fs.js:93:15)
