### PR TITLE
feat(web-server): Optionally serve JS concatenated

### DIFF
--- a/config.tpl.coffee
+++ b/config.tpl.coffee
@@ -8,6 +8,10 @@ module.exports = (config) ->
     basePath: '%BASE_PATH%'
 
 
+    # Serve all JavaScript concatenated in one request.
+    concatenate: false
+
+
     # frameworks to use
     # available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: [%FRAMEWORKS%]

--- a/config.tpl.js
+++ b/config.tpl.js
@@ -8,6 +8,10 @@ module.exports = function(config) {
     basePath: '%BASE_PATH%',
 
 
+    // Serve all JavaScript concatenated in one request.
+    concatenate: false,
+
+
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: [%FRAMEWORKS%],

--- a/config.tpl.ls
+++ b/config.tpl.ls
@@ -8,6 +8,10 @@ module.exports = (config) ->
     basePath: '%BASE_PATH%'
 
 
+    # Serve all JavaScript concatenated in one request.
+    concatenate: false
+
+
     # frameworks to use
     # available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: [%FRAMEWORKS%]

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -27,6 +27,10 @@ var processArgs = function(argv, options, fs, path) {
     options.autoWatch = options.autoWatch === 'true';
   }
 
+  if (helper.isString(options.concatenate)) {
+    options.concatenate = options.concatenate === 'true';
+  }
+
   if (helper.isString(options.colors)) {
     options.colors = options.colors === 'true';
   }
@@ -142,6 +146,7 @@ var describeStart = function() {
     .describe('no-auto-watch', 'Do not watch source files.')
     .describe('log-level', '<disable | error | warn | info | debug> Level of logging.')
     .describe('colors', 'Use colors when reporting and printing logs.')
+    .describe('concatenate', 'Concatenate all sources into one request.')
     .describe('no-colors', 'Do not use colors when reporting or printing logs.')
     .describe('reporters', 'List of reporters (available: dots, progress, junit, growl, coverage).')
     .describe('browsers', 'List of browsers to start (eg. --browsers Chrome,ChromeCanary,Firefox).')

--- a/lib/middleware/concatenated.js
+++ b/lib/middleware/concatenated.js
@@ -1,0 +1,41 @@
+var common = require('./common');
+var querystring = require('querystring');
+
+// Serves all 'served' JavaScript sources in a single request under /concatenated.js.
+var createConcatenatedJsMiddleware = function(filesPromise, /* config.basePath */ basePath) {
+  var removeBasePathRegExp = new RegExp('^' + basePath);
+  return function(request, response, next) {
+    var query = querystring.unescape(request.url);
+    if (query !== '/concatenated.js') {
+      return next();
+    }
+
+    common.setNoCacheHeaders(response);
+    response.writeHead(200, {'Content-Type': 'text/javascript'});
+
+    return filesPromise.then(function(files) {
+      for (var i = 0; i < files.served.length; i++) {
+        var file = files.served[i];
+        var dotIdx = file.originalPath.lastIndexOf('.');
+        if (dotIdx === -1 || file.originalPath.substring(dotIdx) !== '.js') {
+          continue;
+        }
+
+        var path = file.originalPath.replace(removeBasePathRegExp, '');
+        response.write('// ');
+        response.write(path);
+        response.write('\ntry{eval(');
+        var content = file.content + '\n//# sourceURL=http://concatenate' + path;
+        response.write(JSON.stringify(content));
+        // Append fileName for syntax errors in case the JS VM doesn't do it itself.
+        response.write(');} catch(e) { if (!e.fileName) e.message +=');
+        response.write(JSON.stringify(' @' + path));
+        response.write('; throw e;}\n\n');
+      }
+
+      return response.end();
+    });
+  };
+};
+
+exports.create = createConcatenatedJsMiddleware;

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -54,7 +54,8 @@ var getXUACompatibleUrl = function(url) {
 };
 
 var createKarmaMiddleware = function(filesPromise, serveStaticFile,
-    /* config.basePath */ basePath,  /* config.urlRoot */ urlRoot, /* config.client */ client) {
+    /* config.basePath */ basePath,  /* config.urlRoot */ urlRoot, /* config.client */ client,
+    /* config.concatenate */ concatenate) {
 
   return function(request, response, next) {
     var requestUrl = request.normalizedUrl.replace(/\?.*/, '');
@@ -98,7 +99,15 @@ var createKarmaMiddleware = function(filesPromise, serveStaticFile,
         serveStaticFile(requestUrl, response, function(data) {
           common.setNoCacheHeaders(response);
 
-          var scriptTags = files.included.map(function(file) {
+          var includedFiles = files.included;
+          if (concatenate) {
+            // When serving everything concatenated, do not include JavaScript files with individual
+            // script tags.
+            includedFiles = files.included.filter(function(f) {
+              return !/\.js(\?.*)?$/.test(f.path);
+            });
+          }
+          var scriptTags = includedFiles.map(function(file) {
             var filePath = file.path;
             var fileExt = path.extname(filePath);
 
@@ -121,6 +130,10 @@ var createKarmaMiddleware = function(filesPromise, serveStaticFile,
 
             return util.format(SCRIPT_TAG, SCRIPT_TYPE[fileExt] || 'text/javascript', filePath);
           });
+          if (concatenate) {
+            // The one concatenated source file.
+            scriptTags.push(util.format(SCRIPT_TAG, 'text/javascript', '/concatenated.js'));
+          }
 
           // TODO(vojta): don't compute if it's not in the template
           var mappings = files.served.map(function(file) {

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -8,6 +8,7 @@ var runnerMiddleware = require('./middleware/runner');
 var stripHostMiddleware = require('./middleware/strip_host');
 var karmaMiddleware = require('./middleware/karma');
 var sourceFilesMiddleware = require('./middleware/source_files');
+var concatenatedJsMiddleware = require('./middleware/concatenated');
 var proxyMiddleware = require('./middleware/proxy');
 
 var log = require('./logger').create('web-server');
@@ -49,6 +50,7 @@ var createWebServer = function(injector, emitter) {
       .use(injector.invoke(runnerMiddleware.create))
       .use(injector.invoke(stripHostMiddleware.create))
       .use(injector.invoke(karmaMiddleware.create))
+      .use(injector.invoke(concatenatedJsMiddleware.create))
       .use(injector.invoke(sourceFilesMiddleware.create))
       // TODO(vojta): extract the proxy into a plugin
       .use(proxyMiddlewareInstance)

--- a/test/e2e/concatenate/karma.conf.js
+++ b/test/e2e/concatenate/karma.conf.js
@@ -1,0 +1,23 @@
+module.exports = function(config) {
+  config.set({
+    frameworks: ['jasmine'],
+
+    concatenate: true,
+
+    files: [
+      '*.js'
+    ],
+
+    autoWatch: true,
+
+    browsers: [process.env.TRAVIS ? 'Firefox' : 'Chrome'],
+
+    reporters: ['dots'],
+
+    plugins: [
+      'karma-jasmine',
+      'karma-chrome-launcher',
+      'karma-firefox-launcher'
+    ],
+  });
+};

--- a/test/e2e/concatenate/plus.js
+++ b/test/e2e/concatenate/plus.js
@@ -1,0 +1,4 @@
+// Some code under test
+function plus(a, b) {
+  return a + b;
+}

--- a/test/e2e/concatenate/test.js
+++ b/test/e2e/concatenate/test.js
@@ -1,0 +1,9 @@
+describe('plus', function() {
+  it('should pass', function() {
+    expect(true).toBe(true);
+  });
+
+  it('should work', function() {
+    expect(plus(1, 2)).toBe(3);
+  });
+});

--- a/test/unit/middleware/concatenated.spec.coffee
+++ b/test/unit/middleware/concatenated.spec.coffee
@@ -1,0 +1,58 @@
+describe 'middleware.concatenated', ->
+  q = require 'q'
+
+  mocks = require 'mocks'
+  HttpResponseMock = mocks.http.ServerResponse
+  HttpRequestMock = mocks.http.ServerRequest
+
+  File = require('../../../lib/file_list').File
+
+  createConcatenatedJsMiddleware = require('../../../lib/middleware/concatenated').create
+  handler = filesDeferred = nextSpy = response = null
+
+  beforeEach ->
+    nextSpy = sinon.spy()
+    response = new HttpResponseMock
+    filesDeferred = q.defer()
+    handler = createConcatenatedJsMiddleware filesDeferred.promise, '/base/path'
+
+
+  file = (path, content) ->
+    f = new File(path)
+    f.content = content
+    return f
+
+  callHandlerWith = (url, next) ->
+    promise = handler new HttpRequestMock(url), response, next or nextSpy
+    if promise and promise.done then promise.done()
+
+
+  it 'should ignore requests not to /concatenated.js', ->
+    callHandlerWith '/some/other.html', ->
+      expect(response).to.beNotServed()
+
+  it 'should concatenate files for /concatenated.js', (done) ->
+    files = [
+      file '/src/some.js', 'some().js();'
+      file '/other.js', 'multi();\nline();'
+    ]
+    filesDeferred.resolve {included: [], served: files}
+
+    expected = """
+      // /src/some.js
+      try{eval("some().js();\\n//# sourceURL=http://concatenate/src/some.js");} \
+      catch(e) { if (!e.fileName) e.message +=" @/src/some.js"; throw e;}
+
+      // /other.js
+      try{eval("multi();\\nline();\\n//# sourceURL=http://concatenate/other.js");} \
+      catch(e) { if (!e.fileName) e.message +=" @/other.js"; throw e;}
+
+
+      """
+
+    response.once 'end', ->
+      expect(nextSpy).not.to.have.been.called
+      expect(response).to.beServedAs 200, expected
+      done()
+
+    callHandlerWith '/concatenated.js'

--- a/test/unit/middleware/karma.spec.coffee
+++ b/test/unit/middleware/karma.spec.coffee
@@ -33,7 +33,7 @@ describe 'middleware.karma', ->
     filesDeferred = q.defer()
     serveFile = createServeFile fsMock, '/karma/static'
     handler = createKarmaMiddleware filesDeferred.promise, serveFile,
-      '/base/path', '/__karma__/', clientConfig
+      '/base/path', '/__karma__/', clientConfig, false
 
   # helpers
   includedFiles = (files) ->
@@ -144,6 +144,23 @@ describe 'middleware.karma', ->
       expect(response).to.beServedAs 200, 'CONTEXT\n' +
       '<script type="text/javascript" src="/absolute/first.js?sha123"></script>\n' +
       '<script type="application/dart" src="/absolute/second.dart?sha456"></script>'
+      done()
+
+    callHandlerWith '/__karma__/context.html'
+
+
+  it 'should only include /concatenated.js when concatenating', (done) ->
+    handler = createKarmaMiddleware filesDeferred.promise, serveFile,
+      '/base/path', '/__karma__/', {}, true # concatenate
+
+    includedFiles [
+      new MockFile('/source.js', 'sha123')
+    ]
+
+    response.once 'end', ->
+      expect(nextSpy).not.to.have.been.called
+      expect(response).to.beServedAs 200, 'CONTEXT\n' +
+          '<script type="text/javascript" src="/concatenated.js"></script>'
       done()
 
     callHandlerWith '/__karma__/context.html'


### PR DESCRIPTION
With the option 'concatenate: true', all JavaScript is concatenated into
one JavaScript file that uses eval and the //# sourceURL=... trick to
load JavaScript in one request while maintaining debuggability.

This has substantial performance benefits with many small JavaScript
files (hundreds) and allows transforming JavaScript sources to handle
specific module loaders (e.g. goog.loadModule).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karma-runner/karma/1179)
<!-- Reviewable:end -->
