### PR TITLE
Cannot read property x-ua-compatible of null

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -13,7 +13,13 @@
 
 var path = require('path');
 var util = require('util');
-var urlparse = require('url').parse;
+var url = require('url');
+
+var urlparse = function(urlStr) {
+    var urlObj = url.parse(urlStr, true);
+    urlObj.query = urlObj.query || {};
+    return urlObj;
+};
 
 var common = require('./common');
 
@@ -36,7 +42,7 @@ var filePathToUrlPath = function(filePath, basePath) {
 
 var getXUACompatibleMetaElement = function(url) {
   var tag = '';
-  var urlObj = urlparse(url, true);
+  var urlObj = urlparse(url);
   if (urlObj.query['x-ua-compatible']) {
     tag = '\n<meta http-equiv="X-UA-Compatible" content="' +
      urlObj.query['x-ua-compatible'] + '"/>';
@@ -46,7 +52,7 @@ var getXUACompatibleMetaElement = function(url) {
 
 var getXUACompatibleUrl = function(url) {
   var value = '';
-  var urlObj = urlparse(url, true);
+  var urlObj = urlparse(url);
   if (urlObj.query['x-ua-compatible']) {
     value = '?x-ua-compatible=' + encodeURIComponent(urlObj.query['x-ua-compatible']);
   }


### PR DESCRIPTION
node v0.13.0-pre url.parse query returns null if no query string, and getXUACompatibleUrl and getXUACompatibleMetaElement are not checking for this
