### PR TITLE
fix(launcher): Continue with exit when SIGKILL fails

### DIFF
--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -134,6 +134,17 @@ var ProcessLauncher = function(spawn, tempDir, timer) {
 
     log.warn('%s was not killed in %d ms, sending SIGKILL.', self.name, killTimeout);
     self._process.kill('SIGKILL');
+
+    // NOTE: https://github.com/karma-runner/karma/pull/1184
+    // NOTE: SIGKILL is just a signal.  Processes should never ignore it, but they can.
+    // If a process gets into a state where it doesn't respond in a reasonable amout of time
+    // Karma should warn, and continue as though the kill succeeded.
+    // This a certainly suboptimal, but it is better than having the test harness hang waiting
+    // for a zombie child process to exit.
+    self._killTimer = timer.setTimeout(function() {
+      log.warn('%s was not killed by SIGKILL in %d ms, continuing.', self.name, killTimeout);
+      self._onProcessExit(-1, '');
+    }, killTimeout);
   };
 };
 


### PR DESCRIPTION
We have seen very occasional hangs where the browser fails to capture and then
also fails to exit on SIGKILL.  This results in karma hanging waiting on the
browser to restart.  It is not great to leave zombie processes around, but it is
worse to hang.

This change makes karma continue if SIGKILL doesn't make a spawned process
exit in reasonable (killTimeout) time.