### PR TITLE
Make sure that if query is null code still works

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -37,7 +37,7 @@ var filePathToUrlPath = function(filePath, basePath) {
 var getXUACompatibleMetaElement = function(url) {
   var tag = '';
   var urlObj = urlparse(url, true);
-  if (urlObj.query['x-ua-compatible']) {
+  if (urlObj.query && urlObj.query['x-ua-compatible']) {
     tag = '\n<meta http-equiv="X-UA-Compatible" content="' +
      urlObj.query['x-ua-compatible'] + '"/>';
   }


### PR DESCRIPTION
Fix for the following issue:
ERROR [karma]: [TypeError: Cannot read property 'x-ua-compatible' of null]
TypeError: Cannot read property 'x-ua-compatible' of null
    at getXUACompatibleMetaElement (d:\sz\start-template\sjaa-sandbox\node_modules\karma\lib\middleware\karma.js:40:19)
    at d:\sz\start-template\sjaa-sandbox\node_modules\karma\lib\middleware\karma.js:145:45
    at d:\sz\start-template\sjaa-sandbox\node_modules\karma\lib\middleware\common.js:65:35
    at fs.js:295:14
    at d:\sz\start-template\sjaa-sandbox\node_modules\karma\node_modules\graceful-fs\graceful-fs.js:104:5
    at Object.oncomplete (fs.js:93:15)
