### PR TITLE
feat(init): run tests through promise

### DIFF
--- a/static/context.html
+++ b/static/context.html
@@ -29,7 +29,11 @@ Realoaded before every execution run.
   <!-- Dynamically replaced with <script> tags -->
   %SCRIPTS%
   <script type="text/javascript">
-    window.__karma__.loaded();
+    window.envReady = window.envReady || new Promise(function(res, rej) { res(); });
+
+    window.envReady.then(function() {
+      window.__karma__.loaded();
+    }.bind(this));
   </script>
 </body>
 </html>


### PR DESCRIPTION
I'm using System.js with PhantomJS and my tests are loading through promises so karma trying to run tests before they are loaded.
But in Chrome all is ok. I really don't fuck whats wrong with that PhantomJS, but ability to defer tests running seems to be useful not only for me.

P.S: tests failed cause of npm on Travis, see details.
