### PR TITLE
fix(client.html): always open debug.html in a new browser process

### DIFF
--- a/static/client.html
+++ b/static/client.html
@@ -102,7 +102,7 @@ It contains socket.io and all the communication logic.
 </head>
 <body>
   <div id="banner" class="offline">
-    <a href="debug.html%X_UA_COMPATIBLE_URL%" target="_blank" class="btn-debug">DEBUG</a>
+    <a href="debug.html%X_UA_COMPATIBLE_URL%" target="_blank" rel="noreferrer" class="btn-debug">DEBUG</a>
     <h1 id="title">Karma - starting</h1>
   </div>
 


### PR DESCRIPTION
Chrome reuses a single process for tabs opened by clicking links. This means that if I use debugger in debug.html it will
block the regular karma tab which will make karma think that the connection was lost.

By forcing the debug.html to be opened in a new process the original chrome tab will be unaffected while debugging with
debug.html.

Info about the rel attribute: http://blog.chromium.org/2009/12/links-that-open-in-new-processes.html
