### PR TITLE
pass cliOptions to config file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -278,7 +278,7 @@ var parseConfig = function(configFilePath, cliOptions) {
   var config = new Config();
 
   try {
-    configModule(config);
+    configModule(config, cliOptions);
   } catch (e) {
     log.error('Error in config file!\n', e);
     return process.exit(1);


### PR DESCRIPTION
This would enable the user to have access to cli options. Currently there is no way you can send extra params to config, this would atleast help in setting custom configs based on params.