### PR TITLE
fix(server): use the config.hostname to open server binding

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -213,6 +213,14 @@ Additional information can be found in [plugins].
 **Description:** Hostname to be used when capturing browsers.
 
 
+## listen
+**Type:** String
+
+**Default:** `0.0.0.0` or `KARMA_IP` env variable value if set
+
+**Description:** The address where the web server will be listening.
+
+
 ## logLevel
 **Type:** Constant
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -205,6 +205,7 @@ var Config = function() {
   this.frameworks = [];
   this.port = constant.DEFAULT_PORT;
   this.hostname = constant.DEFAULT_HOSTNAME;
+  this.listen = constant.DEFAULT_LISTEN_IP;
   this.basePath = '';
   this.files = [];
   this.exclude = [];

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -6,6 +6,7 @@ exports.VERSION = pkg.version;
 
 exports.DEFAULT_PORT = process.env.PORT || 9876;
 exports.DEFAULT_HOSTNAME = process.env.IP || 'localhost';
+exports.DEFAULT_LISTEN_IP = process.env.KARMA_IP || '0.0.0.0';
 
 // log levels
 exports.LOG_DISABLE = 'OFF';

--- a/lib/server.js
+++ b/lib/server.js
@@ -45,7 +45,7 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
     if (e.code === 'EADDRINUSE') {
       log.warn('Port %d in use', config.port);
       config.port++;
-      webServer.listen(config.port);
+      webServer.listen(config.port, config.listen);
     } else {
       throw e;
     }
@@ -61,7 +61,7 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
   // Some browsers did not get captured.
   var singleRunBrowserNotCaptured = false;
 
-  webServer.listen(config.port, function() {
+  webServer.listen(config.port, config.listen, function() {
     log.info('Karma v%s server started at http://%s:%s%s', constant.VERSION, config.hostname,
         config.port, config.urlRoot);
 


### PR DESCRIPTION
__Hello!__

I've had the issue to not be able to bind the karma webserver on the local ip in a cloud instance. 
Realising that Karma was not listenning on the configurated hostname, I am submitting a PR for that.


Let me know if this is a constraint that comes from somewhere I didn't get.

Thanks for this wonderful project!