### PR TITLE
Fixed a typo in a the CSS class name for .idle

### DIFF
--- a/static/client.html
+++ b/static/client.html
@@ -34,7 +34,7 @@ It contains socket.io and all the communication logic.
 
     }
 
-    .iddle {
+    .idle {
     }
 
     .executing {


### PR DESCRIPTION
Simple fix: code and CSS now match.
