### PR TITLE
fix(runner): Fix typo in CSS class name for .idle

### DIFF
--- a/static/client.html
+++ b/static/client.html
@@ -34,7 +34,7 @@ It contains socket.io and all the communication logic.
 
     }
 
-    .iddle {
+    .idle {
     }
 
     .executing {


### PR DESCRIPTION
Fix a typo in the CSS class name applied to the runner client
web page in state idle, so the HTML markup and CSS now match.
