### PR TITLE
feat(web-server): enable hostname binding configuration

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -45,7 +45,7 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
     if (e.code === 'EADDRINUSE') {
       log.warn('Port %d in use', config.port);
       config.port++;
-      webServer.listen(config.port);
+      webServer.listen(config.port, config.hostname);
     } else {
       throw e;
     }
@@ -61,7 +61,10 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
   // Some browsers did not get captured.
   var singleRunBrowserNotCaptured = false;
 
-  webServer.listen(config.port, function() {
+  log.debug('Karma v%s server will start at http://%s:%s%s', constant.VERSION, config.hostname,
+      config.port, config.urlRoot);
+
+  webServer.listen(config.port, config.hostname, function() {
     log.info('Karma v%s server started at http://%s:%s%s', constant.VERSION, config.hostname,
         config.port, config.urlRoot);
 


### PR DESCRIPTION
Web server now binds to 'config.hostname' configuration option,
instead of always 'localhost'. This allows Karma web server to listen
to a specific IP address.
