### PR TITLE
Treat emscripten memory images as binary

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -23,7 +23,7 @@ var isBinary = Object.create(null);
   'rlc', 'mdi', 'wdp', 'npx', 'wbmp', 'xif', 'webp', '3ds', 'ras', 'cmx', 'fh', 'ico', 'pcx', 'pic',
   'pnm', 'pbm', 'pgm', 'ppm', 'rgb', 'tga', 'xbm', 'xpm', 'xwd', 'xz', 'zip', 'rar', 'tar', 'tbz2',
   'tgz', 'txz', 'bz2', 'eot', 'ttf', 'woff', 'dat', 'nexe', 'pexe', 'epub', 'gz', 'mp3', 'ogg',
-  'swf'
+  'swf', 'mem'
 ].forEach(function(extension) {
   isBinary['.' + extension] = true;
 });


### PR DESCRIPTION
We're using Karma to run some tests against an Emscripten-generated wrapper library. By default, it creates a .mem file which is used to initialize the static data. These files are corrupt when served by Karma, as described in #864 etc. For this change, I simply added .mem to the list of excluded extensions.
