### PR TITLE
feat(logger): Log errors with console.error (defaults to stderr).

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,8 @@
 var fs = require('fs');
+var log4js = require('log4js');
 
 var pkg = JSON.parse(fs.readFileSync(__dirname + '/../package.json').toString());
+var stdAppender = __dirname + "/std_appender.js";
 
 exports.VERSION = pkg.version;
 
@@ -18,9 +20,12 @@ exports.LOG_DEBUG   = 'DEBUG';
 exports.COLOR_PATTERN = '%[%p [%c]: %]%m';
 exports.NO_COLOR_PATTERN = '%p [%c]: %m';
 
+// Load the std appender.
+log4js.loadAppender(stdAppender);
+
 // Default console appender
 exports.CONSOLE_APPENDER = {
-  type: 'console',
+  type: stdAppender,
   layout: {
     type: 'pattern',
     pattern: exports.COLOR_PATTERN

--- a/lib/std_appender.js
+++ b/lib/std_appender.js
@@ -1,0 +1,31 @@
+// Custom appender to be loaded with log4js.loadAppender().
+//
+// This is the same as the 'console' appender except that ERROR level events are
+// logged with console.error.
+
+var log4js = require('log4js');
+var layouts = log4js.layouts;
+var consoleLog = console.log.bind(console);
+var consoleError = console.error.bind(console);
+
+function stdAppender(layout) {
+  layout = layout || layouts.colouredLayout;
+  return function(loggingEvent) {
+    if (loggingEvent.level === log4js.levels.ERROR) {
+      consoleError(layout(loggingEvent));
+    } else {
+      consoleLog(layout(loggingEvent));
+    }
+  };
+}
+
+function configure(config) {
+  var layout;
+  if (config.layout) {
+    layout = layouts.layout(config.layout.type, config.layout);
+  }
+  return stdAppender(layout);
+}
+
+exports.appender = stdAppender;
+exports.configure = configure;


### PR DESCRIPTION
Log errors, by default, to a new jog4js appender, the std_appender. This
new appender logs ERROR level events with console.error, and all other
events with console.log.

This std_appender is largely based on the console appender.

Closes #1011