### PR TITLE
feat: Fail on launcher-, reporter-, or preprocessor-load errors.

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -57,13 +57,14 @@ var Launcher = function (emitter, injector) {
         browser = injector.createChild([locals], ['launcher:' + name]).get('launcher:' + name)
       } catch (e) {
         if (e.message.indexOf('No provider for "launcher:' + name + '"') !== -1) {
-          log.warn('Can not load "%s", it is not registered!\n  ' +
-            'Perhaps you are missing some plugin?', name)
+          log.error('Cannot load browser "%s": it is not registered! ' +
+                    'Perhaps you are missing some plugin?', name)
         } else {
-          log.warn('Can not load "%s"!\n  ' + e.stack, name)
+          log.error('Cannot load browser "%s"!\n  ' + e.stack, name)
         }
 
-        return
+        emitter.emit('load_error', 'launcher', name);
+        return;
       }
 
       // TODO(vojta): remove in v1.0 (BC for old launchers)

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -18,8 +18,9 @@ extensions.forEach(function (extension) {
 })
 
 // TODO(vojta): instantiate preprocessors at the start to show warnings immediately
-var createPreprocessor = function (config, basePath, injector) {
-  var alreadyDisplayedWarnings = Object.create(null)
+var createPreprocessor = function(config, basePath, injector, emitter) {
+  var patterns = Object.keys(config);
+  var alreadyDisplayedErrors = Object.create(null);
 
   return function (file, done) {
     var patterns = Object.keys(config)
@@ -45,24 +46,25 @@ var createPreprocessor = function (config, basePath, injector) {
         return done()
       }
 
-      preprocessors.shift()(content, file, nextPreprocessor)
-    }
-    var instantiatePreprocessor = function (name) {
-      if (alreadyDisplayedWarnings[name]) {
-        return
+      preprocessors.shift()(content, file, nextPreprocessor);
+    };
+    var instantiatePreprocessor = function(name) {
+      if (alreadyDisplayedErrors[name]) {
+        return;
       }
 
       try {
         preprocessors.push(injector.get('preprocessor:' + name))
       } catch (e) {
         if (e.message.indexOf('No provider for "preprocessor:' + name + '"') !== -1) {
-          log.warn('Can not load "%s", it is not registered!\n  ' +
-            'Perhaps you are missing some plugin?', name)
+          log.error('Cannot load preprocessor "%s": it is not registered! ' +
+                    'Perhaps you are missing some plugin?', name)
         } else {
-          log.warn('Can not load "%s"!\n  ' + e.stack, name)
+          log.error('Cannot load preprocessor "%s"!\n  ' + e.stack, name)
         }
 
-        alreadyDisplayedWarnings[name] = true
+        emitter.emit('load_error', 'preprocessor', name);
+        alreadyDisplayedErrors[name] = true;
       }
     }
 
@@ -83,10 +85,11 @@ var createPreprocessor = function (config, basePath, injector) {
       if (err) {
         throw err
       }
-      nextPreprocessor(null, thisFileIsBinary ? buffer : buffer.toString())
-    })
-  }
-}
-createPreprocessor.$inject = ['config.preprocessors', 'config.basePath', 'injector']
+      file.sha = sha1(buffer);
+      nextPreprocessor(null, thisFileIsBinary ? buffer : buffer.toString());
+    });
+  };
+};
+createPreprocessor.$inject = ['config.preprocessors', 'config.basePath', 'injector', 'emitter'];
 
 exports.createPreprocessor = createPreprocessor

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -91,11 +91,13 @@ var createReporters = function (names, config, emitter, injector) {
       reporters.push(injector.createChild([locals], ['reporter:' + name]).get('reporter:' + name))
     } catch (e) {
       if (e.message.indexOf('No provider for "reporter:' + name + '"') !== -1) {
-        log.warn('Can not load "%s", it is not registered!\n  ' +
-          'Perhaps you are missing some plugin?', name)
+        log.error('Cannot load reporter "%s": it is not registered! ' +
+                  'Perhaps you are missing some plugin?', name)
       } else {
-        log.warn('Can not load "%s"!\n  ' + e.stack, name)
+        log.error('Cannot load reporter "%s"!\n  ' + e.stack, name)
       }
+
+      emitter.emit('load_error', 'reporter', name);
     }
   })
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -50,6 +50,8 @@ var Server = function (cliOptions, done) {
 
   this.log = logger.create()
 
+  this.loadErrors = []
+
   var config = cfg.parseConfig(cliOptions.configFile, cliOptions)
 
   var modules = [{
@@ -105,6 +107,10 @@ Server.prototype._start = function (config, launcher, preprocess, fileList, webS
                                     capturedBrowsers, socketServer, executor, done) {
   var self = this
 
+  this.on('load_error', function(type, name) {
+    self.loadErrors.push([type, name])
+  })
+
   config.frameworks.forEach(function (framework) {
     self._injector.get('framework:' + framework)
   })
@@ -142,6 +148,11 @@ Server.prototype._start = function (config, launcher, preprocess, fileList, webS
         self._injector.invoke(launcher.launch, launcher).forEach(function (browserLauncher) {
           singleRunDoneBrowsers[browserLauncher.id] = false
         })
+      }
+
+      if (self.loadErrors.length > 0) {
+        // At least one plugin failed to load.
+        process.exit(1)
       }
     })
   }


### PR DESCRIPTION
Fail out of karma if a launcher, reporter, or preprocessor fails to load, after attempting to load each of them, and reporting errors for each load error.

### Update

This PR is now ready, barring the issue with changing the signature of `createPreprocessor` that I highlight [below](https://github.com/karma-runner/karma/pull/1239#issuecomment-122085301). I did not add any tests, but would be happy to if someone could point me the way there.

### Example

I put the following into a config file:

```json
preprocessors: {
  "**/*.js": ["tea"]
},
reporters: ["progress", "regress"],
browsers: ["Chrome", "Crime"],
```

and started karma:

```
$ ../bin/karma start my.conf.js 
16 07 2015 13:14:36.172:ERROR [reporter]: Cannot load reporter "regress": it is not registered! Perhaps you are missing some plugin?
16 07 2015 13:14:36.182:ERROR [preprocess]: Cannot load preprocessor "tea": it is not registered! Perhaps you are missing some plugin?
16 07 2015 13:14:36.189:INFO [karma]: Karma v0.13.0 server started at http://localhost:9876/
16 07 2015 13:14:36.189:ERROR [launcher]: Cannot load browser "Chrome": it is not registered! Perhaps you are missing some plugin?
16 07 2015 13:14:36.189:ERROR [launcher]: Cannot load browser "Crime": it is not registered! Perhaps you are missing some plugin?
```

then karma promptly exits.

Closes #855