### PR TITLE
fix(browser): don't add already active socket again on reconnect

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -189,8 +189,14 @@ var Browser = function(id, fullName, /* capturedBrowsers */ collection, emitter,
       emitter.emit('browser_register', this);
     }
 
-    activeSockets.push(newSocket);
-    events.bindAll(this, newSocket);
+    var exists = activeSockets.some(function(s) {
+      return s.id === newSocket.id;
+    });
+    if (!exists) {
+      activeSockets.push(newSocket);
+      events.bindAll(this, newSocket);
+    }
+
     if (pendingDisconnect) {
       timer.clearTimeout(pendingDisconnect);
     }


### PR DESCRIPTION
Sometimes one socket can send few register messages, and every time this socket is being added to browser's active sockets as new. And on disconnect we get crash with error message like "TypeError: Cannot read property '1234567' of null".

In logs I can see messages like:

```
DEBUG [karma]: A browser has connected on socket __5YycZnaOXfrHk8kQFP
INFO [IE 8.0.0 (Windows 7)]: Connected on socket __5YycZnaOXfrHk8kQFP with id 35636946
DEBUG [launcher]: internet explorer via Remote WebDriver (id 35636946) captured in 3.71 secs
DEBUG [IE 8.0.0 (Windows 7)]: New connection __5YycZnaOXfrHk8kQFP (already have __5YycZnaOXfrHk8kQFP)
DEBUG [IE 8.0.0 (Windows 7)]: New connection __5YycZnaOXfrHk8kQFP (already have __5YycZnaOXfrHk8kQFP, __5YycZnaOXfrHk8kQFP)
```

This is the cause of problem described here: https://github.com/karma-runner/karma-junit-reporter/pull/21
