### PR TITLE
feat(watcher): Allow using braces in watcher

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,5 +1,6 @@
 var chokidar = require('chokidar');
 var mm = require('minimatch');
+var expandBraces = require('expand-braces');
 
 var helper = require('./helper');
 var log = require('./logger').create('watcher');
@@ -18,6 +19,9 @@ var watchPatterns = function(patterns, watcher) {
   var pathsToWatch = [];
   var uniqueMap = {};
   var path;
+
+  // expand ['a/{b,c}'] to ['a/b', 'a/c']
+  patterns = expandBraces(patterns);
 
   patterns.forEach(function(pattern) {
     path = baseDirFromPattern(pattern);

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "chokidar": ">=0.8.2",
     "glob": "~3.2.7",
     "minimatch": "~0.2",
+    "expand-braces": "~0.1.1",
     "http-proxy": "~0.10",
     "optimist": "~0.6.0",
     "rimraf": "~2.2.5",

--- a/test/unit/watcher.spec.coffee
+++ b/test/unit/watcher.spec.coffee
@@ -59,8 +59,18 @@ describe 'watcher', ->
       expect(chokidarWatcher.watchedPaths_).to.deep.equal ['/some', '/a']
 
 
+    it 'should expand braces and watch all the patterns', ->
+      m.watchPatterns ['/some/{a,b}/*.js', '/a/*'], chokidarWatcher
+      expect(chokidarWatcher.watchedPaths_).to.deep.equal ['/some/a', '/some/b', '/a']
+
+
     it 'should not watch the same path twice', ->
       m.watchPatterns ['/some/a*.js', '/some/*.txt'], chokidarWatcher
+      expect(chokidarWatcher.watchedPaths_).to.deep.equal ['/some']
+
+
+    it 'should not watch the same path twice when using braces', ->
+      m.watchPatterns ['/some/*.{js,txt}'], chokidarWatcher
       expect(chokidarWatcher.watchedPaths_).to.deep.equal ['/some']
 
 
@@ -73,6 +83,11 @@ describe 'watcher', ->
       # regression #521
       m.watchPatterns ['/some/test-file.js', '/some/test/**'], chokidarWatcher
       expect(chokidarWatcher.watchedPaths_).to.deep.equal ['/some/test-file.js', '/some/test']
+
+
+    it 'should watch files matching a subpath directory with braces', ->
+      m.watchPatterns ['/some/{a,b}/test.js'], chokidarWatcher
+      expect(chokidarWatcher.watchedPaths_).to.deep.equal ['/some/a/test.js', '/some/b/test.js']
 
 
   describe 'getWatchedPatterns', ->


### PR DESCRIPTION
Expands braces in watcher, so you can watch: ['a/{b,c}'] which would
expand to ['a/b', 'a/c']

Closes #1249
