### PR TITLE
fix(cli): override if an arg is defined multiple times

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,8 +18,13 @@ var processArgs = function(argv, options, fs, path) {
 
   // TODO(vojta): warn/throw when unknown argument (probably mispelled)
   Object.getOwnPropertyNames(argv).forEach(function(name) {
+    var argumentValue = argv[name];
     if (name !== '_' && name !== '$0') {
-      options[helper.dashToCamel(name)] = argv[name];
+      if (Array.isArray(argumentValue)) {
+        // If the same argument is defined multiple times, override.
+        argumentValue = argumentValue.pop();
+      }
+      options[helper.dashToCamel(name)] = argumentValue;
     }
   });
 

--- a/test/unit/cli.spec.coffee
+++ b/test/unit/cli.spec.coffee
@@ -32,6 +32,15 @@ describe 'cli', ->
 
   describe 'processArgs', ->
 
+    it 'should override if multiple options given', ->
+      # optimist parses --port 123 --port 456 as port = [123, 456] which makes no sense
+      options = processArgs ['some.conf', '--port', '12', '--log-level', 'info',
+                                          '--port', '34', '--log-level', 'debug']
+
+      expect(options.port).to.equal 34
+      expect(options.logLevel).to.equal 'DEBUG'
+
+
     it 'should return camelCased options', ->
       options = processArgs ['some.conf', '--port', '12', '--single-run']
 


### PR DESCRIPTION
``` bash
karma start --log-level info --port 12 --log-level debug --port 34
```

Is now parsed as:

``` js
{
  logLevel: 'DEBUG',
  port: 34
}
```

Closes #1192
