### PR TITLE
Force karma to use the latest 0.9.x working version of socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
   ],
   "dependencies": {
     "di": "~0.0.1",
-    "socket.io": "~0.9.13",
+    "socket.io": "0.9.16",
     "chokidar": ">=0.8.2",
     "glob": "~3.2.7",
     "minimatch": "~0.2",


### PR DESCRIPTION
When running karma tests with `ddescribe` or `iit`, as well as in some other
cases, the browser gets disconnected for some reason.

The full information on this fix can be found in:
http://jamiolkowski.it/251/karma-runner-warn-chrome-35-0-1916-mac-os-x-10-8-5-disconnected-1-times/
