### PR TITLE
add bin to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,9 @@
     "grunt-jscs-checker": "~0.6.1"
   },
   "main": "./lib/index",
-  "bin": {},
+  "bin": {
+    "karma": "./bin/karma"
+  },
   "engines": {
     "node": "~0.8 || ~0.10"
   },


### PR DESCRIPTION
add bin to package.json, so when I install the module, the `karma` will be added to node_modules/.bin

I can add the script to my project's package.json

``` js
"script": {
  "test": "karma .........."
}
```

for now, I need

``` js
"script": {
  "test": "node_modules/karma/bin/karam .........."
}
```
