### PR TITLE
feat config: Allow for JSON/object exports in config files.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -265,8 +265,8 @@ var parseConfig = function(configFilePath, cliOptions) {
       }
       return process.exit(1);
     }
-    if (!helper.isFunction(configModule)) {
-      log.error('Config file must export a function!\n' + CONFIG_SYNTAX_HELP);
+    if (!helper.isFunction(configModule) && !helper.isObject(configModule)) {
+      log.error('Config file must export a function or object!\n' + CONFIG_SYNTAX_HELP);
       return process.exit(1);
     }
   } else {
@@ -278,7 +278,11 @@ var parseConfig = function(configFilePath, cliOptions) {
   var config = new Config();
 
   try {
-    configModule(config);
+    if (helper.isFunction(configModule)) {
+      configModule(config);
+    } else {
+      config.set(configModule);
+    }
   } catch (e) {
     log.error('Error in config file!\n', e);
     return process.exit(1);


### PR DESCRIPTION
Instead of only allowing a function in a javascript file, also accept `.json` and `.js` that export objects.

Makes it easier to manipulate karma configuration files with tooling (e.g. yeoman).