### PR TITLE
Update 01-requirejs.md

### DIFF
--- a/docs/plus/01-requirejs.md
+++ b/docs/plus/01-requirejs.md
@@ -132,12 +132,13 @@ require.config({
   // Karma serves files under /base, which is the basePath from your config file
   baseUrl: '/base/src',
 
-  // example of using shim, to load non AMD libraries (such as underscore and jquery)
+  // example of using a couple path translations (paths), to allow us to refer to different library dependencies, without using relative paths
   paths: {
     'jquery': '../lib/jquery',
     'underscore': '../lib/underscore',
   },
 
+  // example of using a shim, to load non AMD libraries (such as underscore)
   shim: {
     'underscore': {
       exports: '_'


### PR DESCRIPTION
jquery is an AMD library and does not need a shim.  It returns $ which can be used to call it's functions.  underscore.js does not, so we need to create a shim to call functions from it's shim name.