### PR TITLE
chore(travis): Add io.js target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.8"
+  - "iojs-v1.1.0"
 
 env:
   global:


### PR DESCRIPTION
Now that nvm has got support for io.js we should add it as a target on all karma repositories, and fix any occurring issues. 
This PR is the start of this.