### PR TITLE
test(e2e): make sure config files do not collide

### DIFF
--- a/test/e2e/steps/core_steps.coffee
+++ b/test/e2e/steps/core_steps.coffee
@@ -39,10 +39,10 @@ coreSteps = ->
     callback()
 
   @When /^I (run|start|init) Karma$/, (command, callback) ->
-    @writeConfigFile tmpDir, tmpConfigFile, (err) =>
-      callback.fail new Error(err) if err
+    @writeConfigFile tmpDir, tmpConfigFile, (err, hash) =>
+      return callback.fail new Error(err) if err
 
-      configFile = path.join tmpDir, tmpConfigFile
+      configFile = path.join tmpDir, hash + '.' + tmpConfigFile
       options =
         stdio: 'pipe'
         cwd: baseDir

--- a/test/e2e/support/world.coffee
+++ b/test/e2e/support/world.coffee
@@ -1,6 +1,7 @@
 fs = require 'fs'
 vm = require 'vm'
 path = require 'path'
+hasher = require('crypto').createHash
 
 mkdirp = require 'mkdirp'
 _ = require 'lodash'
@@ -29,13 +30,15 @@ World = (callback) ->
   # Generate a configuration file and save it to path.
   @writeConfigFile = (dir, file, done) =>
     mkdirp dir, 0o0755, (err) =>
-      throw new Error(err) if err
+      return done err if err
 
       # Remove dirname from config again
       delete @configFile.__dirname
 
       content = @generateJS @configFile
-      fs.writeFile path.join(dir, file), content, done
+      hash = hasher('md5').update(content + Math.random()).digest 'hex';
+      fs.writeFile path.join(dir, hash + '.' + file), content, (err) ->
+        done err, hash
 
   @generateJS = (config) ->
     _.template @template, {content: JSON.stringify config}


### PR DESCRIPTION
Closes #1291

This fix just deals with the specific race condition I was running into, rather than solving the underlying problem that these tests are being executed in parallel where as they should be run in sequence (described [here](https://github.com/karma-runner/karma/issues/1291#issuecomment-71951739)).  I spent a good amount of time trying to fix that underlying problem, but didn't make much progress.