### PR TITLE
Use default value that's safe with source-map@0.1.43

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -42,7 +42,7 @@ var createErrorFormatter = function(basePath, emitter, SourceMapConsumer) {
       var file = findFile(path);
 
       if (file && file.sourceMap) {
-        line = parseInt(line || '0', 10);
+        line = parseInt(line || '1', 10);
         column = parseInt(column || '0', 10);
 
         var smc = new SourceMapConsumer(file.sourceMap);


### PR DESCRIPTION
source-map@0.1.43 will throw an error if you pass a line number equal to
0. See:
https://github.com/mozilla/source-map/blob/0.1.43/lib/source-map/source-map-consumer.js#L285-L287

Since Karma is not wrapping that in a try catch, the exception will just crash karma. Changing the default line number to 1 will not throw and a test exception stack trace will still output correctly.