### PR TITLE
Add option to specify listen address

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -261,6 +261,15 @@ See [plugins] for more information.
 
 **Description:** The port where the web server will be listening.
 
+## listenAddr
+**Type:** String
+
+**Default:** `0.0.0.0`
+
+**CLI:** `--listen-addr 192.168.1.1`
+
+**Description:** The address where the web server will be listening.
+
 
 ## preprocessors
 **Type:** Object

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -143,6 +143,7 @@ var describeStart = function() {
            'Usage:\n' +
            '  $0 start [<configFile>] [<options>]')
     .describe('port', '<integer> Port where the server is running.')
+    .describe('listen-addr', '<IP> Address where the server is running.')
     .describe('auto-watch', 'Auto watch source files and run on change.')
     .describe('no-auto-watch', 'Do not watch source files.')
     .describe('log-level', '<disable | error | warn | info | debug> Level of logging.')
@@ -165,6 +166,7 @@ var describeRun = function() {
       'Usage:\n' +
       '  $0 run [<configFile>] [<options>] [ -- <clientArgs>]')
     .describe('port', '<integer> Port where the server is listening.')
+    .describe('listen-addr', '<IP> Address where the server is running.')
     .describe('no-refresh', 'Do not re-glob all the patterns.')
     .describe('help', 'Print usage.');
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -204,6 +204,7 @@ var Config = function() {
   // DEFAULT CONFIG
   this.frameworks = [];
   this.port = constant.DEFAULT_PORT;
+  this.listenAddr = constant.DEFAULT_LISTEN_ADDR;
   this.hostname = constant.DEFAULT_HOSTNAME;
   this.basePath = '';
   this.files = [];

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,6 +5,7 @@ var pkg = JSON.parse(fs.readFileSync(__dirname + '/../package.json').toString())
 exports.VERSION = pkg.version;
 
 exports.DEFAULT_PORT = process.env.PORT || 9876;
+exports.DEFAULT_LISTEN_ADDR = '0.0.0.0';
 exports.DEFAULT_HOSTNAME = process.env.IP || 'localhost';
 
 // log levels

--- a/lib/server.js
+++ b/lib/server.js
@@ -45,7 +45,7 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
     if (e.code === 'EADDRINUSE') {
       log.warn('Port %d in use', config.port);
       config.port++;
-      webServer.listen(config.port);
+      webServer.listen(config.port, config.listenAddr);
     } else {
       throw e;
     }
@@ -61,7 +61,7 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
   // Some browsers did not get captured.
   var singleRunBrowserNotCaptured = false;
 
-  webServer.listen(config.port, function() {
+  webServer.listen(config.port, config.listenAddr, function() {
     log.info('Karma v%s server started at http://%s:%s%s', constant.VERSION, config.hostname,
         config.port, config.urlRoot);
 


### PR DESCRIPTION
`listenAddr` (CLI: --listen-addr) option is added which is used in listen() call to bind to specified address. Default value is `0.0.0.0`.

Current karma version doesn't specify the address and in this case node binds to IPv4 address only. So there is no way to bind it to v6 interface. With added option it's now possible to specify v6 address.