### PR TITLE
(deps) connect@2.28.0 to pickup serve-static@~1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "log4js": "~0.6.3",
     "useragent": "~2.0.4",
     "graceful-fs": "~2.0.1",
-    "connect": "~2.26.0",
+    "connect": "~2.28.0",
     "source-map": "~0.1.31"
   },
   "devDependencies": {


### PR DESCRIPTION
a fix for #1295 as fix for [serve-static Open Redirect(CVE-2015-1164)](https://nodesecurity.io/advisories/serve-static-open-redirect):

> When using serve-static middleware version < 1.7.2 and it's configured to mount at the root it creates an open redirect on the site.