### PR TITLE
Safeguard IE against console.log

### DIFF
--- a/static/debug.html
+++ b/static/debug.html
@@ -23,7 +23,7 @@ just for immediate execution, without reporting to Karma server.
         if (info.dump && window.console) window.console.log(info.dump);
       },
       complete: function() {
-        window.console.log('Skipped ' + this.skipped + ' tests');
+        if (window.console) window.console.log('Skipped ' + this.skipped + ' tests');
       },
       store: function() {},
       skipped: 0,


### PR DESCRIPTION
Shielding a reference to `window.console.log`. Fixes the ability to use this page in IE without the inspector open. Fixes #1209.