### PR TITLE
fix: Abort test run instead of crashing when unable to preprocess file

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -92,9 +92,11 @@ var createPreprocessor = function(config, basePath, injector) {
 
     return fs.readFile(file.originalPath, function(err, buffer) {
       if (err) {
-        throw err;
+        log.warn('Can not reload "%s" (code: %s)', file.originalPath, err.code || 'unknown');
+        done(err);
+      } else {
+        nextPreprocessor(null, thisFileIsBinary ? buffer : buffer.toString());
       }
-      nextPreprocessor(null, thisFileIsBinary ? buffer : buffer.toString());
     });
   };
 };


### PR DESCRIPTION
Partially fixes #1213 

This patch prevents karma from crashing when a file cannot be opened. Resaving the file will eventually run the tests.

Without patch:
````
INFO [watcher]: Changed file "c:/modified-file.js".
ERROR [karma]: { [Error: EBUSY, open 'c:\modified-file.js']
  errno: 10,
  code: 'EBUSY',
  path: 'c:\\modified-file.js' }
Error: EBUSY, open 'c:\modified-file.js'

$
````

With patch:
````
INFO [watcher]: Changed file "c:/modified-file.js".
WARN [preprocess]: Can not reload "c:/modified-file.js" (code: EBUSY)
PhantomJS 1.9.8 (Windows 7) ERROR
  TEST RUN WAS CANCELLED because this file contains some errors:
    c:/modified-file.js
````