### PR TITLE
return config object when done

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -287,7 +287,10 @@ exports.start = function(cliOptions, done) {
   var modules = [{
     helper: ['value', helper],
     logger: ['value', logger],
-    done: ['value', done || process.exit],
+    done: ['value', function (code) {
+        // return with the config object
+        return done(code, config);
+    } || process.exit],
     emitter: ['type', EventEmitter],
     launcher: ['type', Launcher],
     config: ['value', config],


### PR DESCRIPTION
This allows plugins such as karma-coverage to pass data to downstream processes.

Might not be the best use of the config object. Better ideas for returning data are welcome.