### PR TITLE
fix(preprocessor): Lookup patterns once invoked

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -30,10 +30,10 @@ var isBinary = Object.create(null);
 
 // TODO(vojta): instantiate preprocessors at the start to show warnings immediately
 var createPreprocessor = function(config, basePath, injector) {
-  var patterns = Object.keys(config);
   var alreadyDisplayedWarnings = Object.create(null);
 
   return function(file, done) {
+    var patterns = Object.keys(config);
     var thisFileIsBinary = isBinary[path.extname(file.originalPath)];
     var preprocessors = [];
     var nextPreprocessor = function(error, content) {

--- a/test/unit/preprocessor.spec.coffee
+++ b/test/unit/preprocessor.spec.coffee
@@ -39,6 +39,26 @@ describe 'preprocessor', ->
       done()
 
 
+  it 'should check patterns after creation when invoked', (done) ->
+    fakePreprocessor = sinon.spy (content, file, done) ->
+      file.path = file.path + '-preprocessed'
+      done null, 'new-content'
+
+    injector = new di.Injector [{'preprocessor:fake': ['factory', -> fakePreprocessor]}]
+    config = {'**/*.txt': ['fake']}
+    pp = m.createPreprocessor config, null, injector
+
+    file = {originalPath: '/some/a.js', path: 'path'}
+
+    config['**/*.js'] = ['fake']
+
+    pp file, ->
+      expect(fakePreprocessor).to.have.been.called
+      expect(file.path).to.equal 'path-preprocessed'
+      expect(file.content).to.equal 'new-content'
+      done()
+
+
   it 'should ignore not matching file', (done) ->
     fakePreprocessor = sinon.spy (content, file, done) ->
       done null, ''


### PR DESCRIPTION
Don't lookup the list of patterns of files to preprocess until the
preprocessor is called. This because patterns might be added after the
preprocessor is created, and those will be missed if the patterns are
looked up too early.

Closes #1340