### PR TITLE
fix(init): fix test-main.(js/coffee) generation

### DIFF
--- a/docs/plus/01-requirejs.md
+++ b/docs/plus/01-requirejs.md
@@ -117,14 +117,10 @@ The `test/test-main.js` file ends up looking like this:
 var allTestFiles = [];
 var TEST_REGEXP = /test\.js$/;
 
-var pathToModule = function(path) {
-  return path.replace(/^\/base\//, '').replace(/\.js$/, '');
-};
-
 Object.keys(window.__karma__.files).forEach(function(file) {
   if (TEST_REGEXP.test(file)) {
     // Normalize paths to RequireJS module names.
-    allTestFiles.push(pathToModule(file));
+    allTestFiles.push(file);
   }
 });
 

--- a/requirejs.config.tpl.coffee
+++ b/requirejs.config.tpl.coffee
@@ -1,11 +1,9 @@
 allTestFiles = []
 TEST_REGEXP = /(spec|test)(\.coffee)?(\.js)?$/i
-pathToModule = (path) ->
-  path.replace(/^\/base\//, "").replace(/\.js$/, "").replace(/\.cofee$/, "")
 
 Object.keys(window.__karma__.files).forEach (file) ->
   # Normalize paths to RequireJS module names.
-  allTestFiles.push pathToModule(file)  if TEST_REGEXP.test(file)
+  allTestFiles.push file  if TEST_REGEXP.test(file)
   return
 
 require.config

--- a/requirejs.config.tpl.js
+++ b/requirejs.config.tpl.js
@@ -1,14 +1,10 @@
 var allTestFiles = [];
 var TEST_REGEXP = /(spec|test)\.js$/i;
 
-var pathToModule = function(path) {
-  return path.replace(/^\/base\//, '').replace(/\.js$/, '');
-};
-
 Object.keys(window.__karma__.files).forEach(function(file) {
   if (TEST_REGEXP.test(file)) {
     // Normalize paths to RequireJS module names.
-    allTestFiles.push(pathToModule(file));
+    allTestFiles.push(file);
   }
 });
 


### PR DESCRIPTION
The `pathToModule` function sets a project up such that your spec
directory must be within your src directory. This approach directly
contradicts the example describing how to use RequireJS with Karma in
the documentation.

Fixes #1120, fixes #896