### PR TITLE
feat(config): Add a clearContext config to prevent clearing of context

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -36,7 +36,7 @@ var Karma = function (socket, iframe, opener, navigator, location) {
   }
 
   this.setupContext = function (contextWindow) {
-    if (hasError) {
+    if (self.config.clearContext && hasError) {
       return
     }
 
@@ -149,11 +149,13 @@ var Karma = function (socket, iframe, opener, navigator, location) {
       resultsBuffer = []
     }
 
-    // give the browser some time to breath, there could be a page reload, but because a bunch of
-    // tests could run in the same event loop, we wouldn't notice.
-    setTimeout(function () {
-      clearContext()
-    }, 0)
+    if (self.config.clearContext) {
+      // give the browser some time to breath, there could be a page reload, but because a bunch of
+      // tests could run in the same event loop, we wouldn't notice.
+      setTimeout(function () {
+        clearContext()
+      }, 0)
+    }
 
     socket.emit('complete', result || {}, function () {
       if (returnUrl) {
@@ -211,8 +213,9 @@ var Karma = function (socket, iframe, opener, navigator, location) {
     // reset hasError and reload the iframe
     hasError = false
     startEmitted = false
-    reloadingContext = false
     self.config = cfg
+    // if not clearing context, reloadingContext always true to prevent beforeUnload error
+    reloadingContext = !self.config.clearContext
     navigateContextTo(constant.CONTEXT_URL)
 
     // clear the console before run

--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -505,6 +505,16 @@ iFrame and may need a new window to run.
 
 **Description:** Capture all console output and pipe it to the terminal.
 
+## client.clearContext
+**Type:** Boolean
+
+**Default:** `true`
+
+**Description:** Clear the context window
+
+If true, Karma clears the context window upon the completion of running the tests. If false, Karma does not clear the context window
+upon  the completion of running the tests. Setting this to false is useful when embedding a Jasmine Spec Runner Template.
+
 ## urlRoot
 **Type:** String
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -253,7 +253,8 @@ var Config = function () {
   this.defaultClient = this.client = {
     args: [],
     useIframe: true,
-    captureConsole: true
+    captureConsole: true,
+    clearContext: true
   }
   this.browserDisconnectTimeout = 2000
   this.browserDisconnectTolerance = 0


### PR DESCRIPTION
Enable a clearContext config which when set to false:
- prevents clearing of context window upon completion of running of the tests.
- always (re)sets up context regardless of errors
This configuration is useful when embedding the Jasmine html reporter within the context window.