### PR TITLE
feat: Add finish timestamp for every browser

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -38,6 +38,14 @@ var BaseReporter = function(formatError, reportSlow, adapter) {
 
       msg += util.format(' (%s / %s)', helper.formatTimeInterval(results.totalTime),
                                        helper.formatTimeInterval(results.netTime));
+
+      var finishTime = new Date();
+      var addLeadingZero = function(x) {
+        return x < 10 ? '0' + x : x;
+      };
+      msg += util.format(' finished at %s:%s:%s', addLeadingZero(finishTime.getHours()),
+                                                  addLeadingZero(finishTime.getMinutes()),
+                                                  addLeadingZero(finishTime.getSeconds()));
     }
 
     return msg;


### PR DESCRIPTION
Being applied we can see in console time (HH:MM:SS) when run completed. This helps in situations when you work for a while over some file and then look into console and don't know if current results are the freshest? You throw a look on clocks and realise - hey! it's five minutes old! I've forgot to click "CTRL+S"

```
Firefox 34.0.0 (Windows 7): Executed 98 of 98 (2 FAILED) (8.926 secs / 8.867 secs) finished at 01:16:27