### PR TITLE
feat: Support for custom context and/or debug html files

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -59,7 +59,7 @@ var getXUACompatibleUrl = function(url) {
   return value;
 };
 
-var createKarmaMiddleware = function(filesPromise, serveStaticFile,
+var createKarmaMiddleware = function(filesPromise, serveStaticFile, serveFile,
     /* config.basePath */ basePath,  /* config.urlRoot */ urlRoot, /* config.client */ client) {
 
   return function(request, response, next) {
@@ -101,7 +101,19 @@ var createKarmaMiddleware = function(filesPromise, serveStaticFile,
     // or debug.html - execution context without channel to the server
     if (requestUrl === '/context.html' || requestUrl === '/debug.html') {
       return filesPromise.then(function(files) {
-        serveStaticFile(requestUrl, response, function(data) {
+
+        var fileServer;
+        if (client && client.contextFile) {
+            fileServer = serveFile;
+            requestUrl = path.normalize(process.cwd() + client.contextFile);
+        } else if (client && client.debugFile) {
+            fileServer = serveFile;
+            requestUrl = path.normalize(process.cwd() + client.debugFile);
+        } else {
+            fileServer = serveStaticFile;
+        }
+
+        fileServer(requestUrl, response, function(data) {
           common.setNoCacheHeaders(response);
 
           var scriptTags = files.included.map(function(file) {

--- a/test/unit/middleware/karma.spec.coffee
+++ b/test/unit/middleware/karma.spec.coffee
@@ -32,7 +32,7 @@ describe 'middleware.karma', ->
     response = new HttpResponseMock
     filesDeferred = q.defer()
     serveFile = createServeFile fsMock, '/karma/static'
-    handler = createKarmaMiddleware filesDeferred.promise, serveFile,
+    handler = createKarmaMiddleware filesDeferred.promise, serveFile, null,
       '/base/path', '/__karma__/', clientConfig
 
   # helpers
@@ -80,7 +80,7 @@ describe 'middleware.karma', ->
 
 
   it 'should serve client.html', (done) ->
-    handler = createKarmaMiddleware null, serveFile, '/base', '/'
+    handler = createKarmaMiddleware null, serveFile, null, '/base', '/'
 
     response.once 'end', ->
       expect(nextSpy).not.to.have.been.called
@@ -91,7 +91,7 @@ describe 'middleware.karma', ->
 
 
   it 'should serve /?id=xxx', (done) ->
-    handler = createKarmaMiddleware null, serveFile, '/base', '/'
+    handler = createKarmaMiddleware null, serveFile, null, '/base', '/'
 
     response.once 'end', ->
       expect(nextSpy).not.to.have.been.called
@@ -101,7 +101,7 @@ describe 'middleware.karma', ->
     callHandlerWith '/?id=123'
 
   it 'should serve /?x-ua-compatible with replaced values', (done) ->
-    handler = createKarmaMiddleware null, serveFile, '/base', '/'
+    handler = createKarmaMiddleware null, serveFile, null, '/base', '/'
 
     response.once 'end', ->
       expect(nextSpy).not.to.have.been.called


### PR DESCRIPTION
Adding support for custom context.html and debug.html
```javascript
module.exports = function(config) {
  config.set({

    client: {
      // paths must be relative to CWD ( current working directory )
      contextFile: '/context.html',
      debugFile: '/debug.html'
    },

    ...
```
Ref: #488