### PR TITLE
added karma to "bin"

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,9 @@
     "which": "~1.0"
   },
   "main": "./lib/index",
-  "bin": {},
+  "bin": {
+    "karma": "bin/karma"
+  },
   "engines": {
     "node":  ">=0.8 <=0.12",
     "iojs": "~1"


### PR DESCRIPTION
Without installing Karma globally and only as a local devDependency, we can now write something like this into our `package.json` and call `$ npm run karma`:
````
{
  "scripts": {
    "karma": "karma start karma.conf.js"
  },
  "devDependencies": {
    "karma": "^0.12.0"
  }
}

````