### PR TITLE
feat(runner): provide error code on 'ECONNREFUSED' callback

### DIFF
--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -29,3 +29,7 @@ runner.run({port: 9876}, function(exitCode) {
   process.exit(exitCode);
 });
 ```
+
+## Callback function notes
+
+- If there is an error, the error code will be provided as the second parameter to the error callback.

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -54,7 +54,7 @@ exports.run = function(config, done) {
   request.on('error', function(e) {
     if (e.code === 'ECONNREFUSED') {
       console.error('There is no server listening on port %d', options.port);
-      done(1);
+      done(1, e.code);
     } else {
       throw e;
     }


### PR DESCRIPTION
Add the error code as the second argument to the error callback. The information
can be useful in determining what to do on error when writing plugins against
the Karma API.