### PR TITLE
Add bin field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,9 @@
     "which": "~1.0"
   },
   "main": "./lib/index",
-  "bin": {},
+  "bin": {
+    "karma": "./bin/karma"
+  },
   "engines": {
     "node":  ">=0.8 <=0.12",
     "iojs": "~1"


### PR DESCRIPTION
Adding this bin field will make it easier for people using npm scripts, where karma is not installed globally. 

eg. 

`karma start`

instead of

`./node_modules/karma/bin/karma start`