### PR TITLE
Use `bin` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "which": "~1.0"
   },
   "main": "./lib/index",
-  "bin": {},
+  "bin": { "karma": "./bin/karma" },
   "engines": {
     "node":  ">=0.8 <=0.12",
     "iojs": "~1"


### PR DESCRIPTION
Install karma executable into `node_modules/.bin`, which is prefixed to `$PATH` when using `npm run`