### PR TITLE
fix(deps): Upgrade connect 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "iojs"
   - "0.12"
   - "0.10"
-  - "0.8"
 
 env:
   global:

--- a/lib/middleware/common.js
+++ b/lib/middleware/common.js
@@ -81,7 +81,7 @@ var setNoCacheHeaders = function(response) {
 
 
 var setHeavyCacheHeaders = function(response) {
-  response.setHeader('Cache-Control', ['public', 'max-age=31536000']);
+  response.setHeader('Cache-Control', 'public, max-age=31536000');
 };
 
 

--- a/lib/middleware/runner.js
+++ b/lib/middleware/runner.js
@@ -8,7 +8,7 @@ var path = require('path');
 var helper = require('../helper');
 var log = require('../logger').create();
 var constant = require('../constants');
-var json = require('connect').json();
+var json = require('body-parser').json();
 
 // TODO(vojta): disable when single-run mode
 var createRunnerMiddleware = function(emitter, fileList, capturedBrowsers, reporter, executor,

--- a/lib/middleware/source_files.js
+++ b/lib/middleware/source_files.js
@@ -4,7 +4,6 @@
 
 var querystring = require('querystring');
 var common = require('./common');
-var pause = require('connect').utils.pause;
 
 
 var findByPath = function(files, path) {
@@ -28,10 +27,7 @@ var createSourceFilesMiddleware = function(filesPromise, serveFile,
         .replace(/^\/absolute/, '')
         .replace(/^\/base/, basePath);
 
-    // Need to pause the request because of proxying, see:
-    // https://groups.google.com/forum/#!topic/q-continuum/xr8znxc_K5E/discussion
-    // TODO(vojta): remove once we don't care about Node 0.8
-    var pausedRequest = pause(request);
+    request.pause();
 
     return filesPromise.then(function(files) {
       // TODO(vojta): change served to be a map rather then an array
@@ -51,7 +47,7 @@ var createSourceFilesMiddleware = function(filesPromise, serveFile,
         next();
       }
 
-      pausedRequest.resume();
+      request.resume();
     });
   };
 };

--- a/package.json
+++ b/package.json
@@ -162,9 +162,10 @@
     "Jeff Froom <jeff@jfroom.com>"
   ],
   "dependencies": {
+    "body-parser": "^1.12.4",
     "chokidar": "^1.0.1",
     "colors": "^1.1.0",
-    "connect": "^2.29.2",
+    "connect": "^3.3.5",
     "di": "^0.0.1",
     "glob": "^5.0.6",
     "graceful-fs": "^3.0.6",
@@ -227,7 +228,9 @@
     "which": "^1.1.1"
   },
   "main": "./lib/index",
-  "bin": { "karma": "./bin/karma" },
+  "bin": {
+    "karma": "./bin/karma"
+  },
   "engines": {
     "node": ">=0.8 <=0.12 || >=1 <=2"
   },

--- a/package.json
+++ b/package.json
@@ -224,6 +224,8 @@
     "mocks": "^0.0.15",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
+    "supertest": "^1.0.1",
+    "supertest-as-promised": "^2.0.1",
     "timer-shim": "^0.3.0",
     "which": "^1.1.1"
   },

--- a/test/unit/web-server.spec.coffee
+++ b/test/unit/web-server.spec.coffee
@@ -1,10 +1,9 @@
-describe 'web-server', ->
-  di = require 'di'
-  q = require 'q'
-  mocks = require 'mocks'
+request = require 'supertest-as-promised'
+di = require 'di'
+q = require 'q'
+mocks = require 'mocks'
 
-  HttpResponseMock = mocks.http.ServerResponse
-  HttpRequestMock = mocks.http.ServerRequest
+describe 'web-server', ->
 
   File = require('../../lib/file_list').File
 
@@ -25,10 +24,7 @@ describe 'web-server', ->
   # this relies on the fact that none of these tests mutate fs
   m = mocks.loadFile __dirname + '/../../lib/web-server.js', _mocks, _globals
 
-  customFileHandlers = server = response = emitter = null
-
-  requestPath = (path) ->
-    server.emit 'request', new HttpRequestMock(path), response
+  customFileHandlers = server = emitter = null
 
   servedFiles = (files) ->
     emitter.emit 'file_list_modified', q.resolve({included: [], served: files})
@@ -49,32 +45,20 @@ describe 'web-server', ->
 
     server = injector.invoke m.createWebServer
     servedFiles []
-    response = new HttpResponseMock
 
+  it 'should serve client.html', () ->
+    request(server)
+    .get('/')
+    .expect(200, 'CLIENT HTML')
 
-  it 'should serve client.html', (done) ->
-    response.once 'end', ->
-      expect(response).to.beServedAs 200, 'CLIENT HTML'
-      done()
-
-    requestPath '/'
-
-  it 'should serve client.html with a absoluteURI request path ', (done) ->
-    response.once 'end', ->
-      expect(response).to.beServedAs 200, 'CLIENT HTML'
-      done()
-    requestPath 'http://localhost:9876/'
-
-  it 'should serve source files', (done) ->
-    response.once 'end', ->
-      expect(response).to.beServedAs 200, 'js-source'
-      done()
-
+  it 'should serve source files', () ->
     servedFiles [new File '/base/path/one.js']
-    requestPath '/base/one.js'
 
+    request(server)
+    .get('/base/one.js')
+    .expect(200, 'js-source')
 
-  it 'should load custom handlers', (done) ->
+  it 'should load custom handlers', () ->
     # TODO(vojta): change this, only keeping because karma-dart is relying on it
     customFileHandlers.push {
       urlRegex: /\/some\/weird/
@@ -83,16 +67,11 @@ describe 'web-server', ->
         response.end 'CONTENT'
     }
 
-    response.once 'end', ->
-      expect(response).to.beServedAs 222, 'CONTENT'
-      done()
+    request(server)
+    .get('/some/weird/url')
+    .expect(222, 'CONTENT')
 
-    requestPath '/some/weird/url'
-
-
-  it 'should serve 404 for non-existing files', (done) ->
-    response.once 'end', ->
-      expect(response).to.beServedAs 404, 'NOT FOUND'
-      done()
-
-    requestPath '/non/existing.html'
+  it 'should serve 404 for non-existing files', () ->
+    request(server)
+    .get('/non/existing.html')
+    .expect(404)


### PR DESCRIPTION
This means dropping support for node 0.8.

This is pretty much working but the tests are broken as the outdated [mocks](https://github.com/vojtajina/node-mocks) library is not handling the `req.resume` and `req.pause` methods properly. 

Found a good replacement https://github.com/WhoopInc/supertest-as-promised and refactored all the failing tests. We should plan to move all the other tests for middleware to it as well, as it is much more reliable. 

---

Ref #1410 