### PR TITLE
fix(server): Start webserver and browsers after preprocessing completed

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -31,15 +31,15 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
     injector.get('framework:' + framework);
   });
 
-  var filesPromise = fileList.refresh();
+  // A map of launched browsers.
+  var singleRunDoneBrowsers = Object.create(null);
 
-  if (config.autoWatch) {
-    filesPromise.then(function() {
-      injector.invoke(watcher.watch);
-    }, function() {
-      injector.invoke(watcher.watch);
-    });
-  }
+  // Passing fake event emitter, so that it does not emit on the global,
+  // we don't care about these changes.
+  var singleRunBrowsers = new BrowserCollection(new EventEmitter());
+
+  // Some browsers did not get captured.
+  var singleRunBrowserNotCaptured = false;
 
   webServer.on('error', function(e) {
     if (e.code === 'EADDRINUSE') {
@@ -51,26 +51,24 @@ var start = function(injector, config, launcher, globalEmitter, preprocess, file
     }
   });
 
-  // A map of launched browsers.
-  var singleRunDoneBrowsers = Object.create(null);
-
-  // Passing fake event emitter, so that it does not emit on the global,
-  // we don't care about these changes.
-  var singleRunBrowsers = new BrowserCollection(new EventEmitter());
-
-  // Some browsers did not get captured.
-  var singleRunBrowserNotCaptured = false;
-
-  webServer.listen(config.port, function() {
-    log.info('Karma v%s server started at http://%s:%s%s', constant.VERSION, config.hostname,
-        config.port, config.urlRoot);
-
-    if (config.browsers && config.browsers.length) {
-      injector.invoke(launcher.launch, launcher).forEach(function(browserLauncher) {
-        singleRunDoneBrowsers[browserLauncher.id] = false;
-      });
+  var afterPreprocess = function() {
+    if (config.autoWatch) {
+      injector.invoke(watcher.watch);
     }
-  });
+
+    webServer.listen(config.port, function() {
+      log.info('Karma v%s server started at http://%s:%s%s', constant.VERSION, config.hostname,
+          config.port, config.urlRoot);
+
+      if (config.browsers && config.browsers.length) {
+        injector.invoke(launcher.launch, launcher).forEach(function(browserLauncher) {
+          singleRunDoneBrowsers[browserLauncher.id] = false;
+        });
+      }
+    });
+  };
+
+  fileList.refresh().then(afterPreprocess, afterPreprocess);
 
   globalEmitter.on('browsers_change', function() {
     // TODO(vojta): send only to interested browsers


### PR DESCRIPTION
When loading many files, it is possible that the webserver and browsers
will start before file preprocessing has completed. This causes the
browser to attempt to connect and timeout and need to be relaunched.

This change will cause the server to wait to start the webserver and
browsers until after all files have been preprocessed. When a browser
connects to the webserver, the webserver will be able to start serving content
immediately and the browser will not experience any connection errors or
timeouts.