### PR TITLE
feat(runner): serve context in JSON format for JS-only environments

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -157,6 +157,16 @@ var createKarmaMiddleware = function (filesPromise, serveStaticFile,
             ' some errors:\\n  ' + errorFiles.join('\\n  ') + '");')
         })
       })
+    } else if (requestUrl === '/context.json') {
+      return filesPromise.then(function (files) {
+        common.setNoCacheHeaders(response)
+        response.writeHead(200)
+        response.end(JSON.stringify({
+          files: files.included.map(function (file) {
+            return filePathToUrlPath(file.path + '?' + file.sha, basePath, urlRoot);
+          })
+        }))
+      })
     }
 
     return next()

--- a/test/unit/middleware/karma.spec.coffee
+++ b/test/unit/middleware/karma.spec.coffee
@@ -199,6 +199,28 @@ describe 'middleware.karma', ->
 
     callHandlerWith '/__karma__/context.html'
 
+  it 'should serve context.json with the correct paths for all files', (done) ->
+    includedFiles [
+      new MockFile('/some/abc/a.css', 'sha1')
+      new MockFile('/base/path/b.css', 'sha2')
+      new MockFile('/some/abc/c.html', 'sha3')
+      new MockFile('/base/path/d.html', 'sha4')
+    ]
+
+    response.once 'end', ->
+      expect(nextSpy).not.to.have.been.called
+      expect(response).to.beServedAs 200, JSON.stringify {
+        files: [
+          '/__karma__/absolute/some/abc/a.css?sha1',
+          '/__karma__/base/b.css?sha2',
+          '/__karma__/absolute/some/abc/c.html?sha3',
+          '/__karma__/base/d.html?sha4'
+        ]
+      }
+      done()
+
+    callHandlerWith '/__karma__/context.json'
+
 
   it 'should not change urls', (done) ->
     includedFiles [


### PR DESCRIPTION
serve files to load at /context.json