### PR TITLE
fix(file_list): follow symlinks

### DIFF
--- a/lib/file_list.js
+++ b/lib/file_list.js
@@ -53,6 +53,7 @@ Url.prototype.toString = File.prototype.toString = function () {
 
 var GLOB_OPTS = {
   // globDebug: true,
+  follow: true,
   cwd: '/'
 }
 


### PR DESCRIPTION
Changing to the latest version of the glob module means that
karma no longer follows symlinks to find files to serve.
Setting foillow:true in the glob options enables this
behaviour again.