### PR TITLE
fix (reporter): better handling of stack trace source map rewrite

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -22,7 +22,7 @@ var createErrorFormatter = function (basePath, emitter, SourceMapConsumer) {
     return null
   }
 
-  var URL_REGEXP = new RegExp('http:\\/\\/[^\\/]*\\/' +
+  var URL_REGEXP = new RegExp('(http:\\/\\/[^\\/]*\\/)?' +
     '(base|absolute)' + // prefix
     '((?:[A-z]\\:)?[^\\?\\s\\:]*)' + // path
     '(\\?\\w*)?' + // sha
@@ -33,7 +33,8 @@ var createErrorFormatter = function (basePath, emitter, SourceMapConsumer) {
   return function (msg, indentation) {
     // remove domain and timestamp from source files
     // and resolve base path / absolute path urls into absolute path
-    msg = (msg || '').replace(URL_REGEXP, function (_, prefix, path, __, ___, line, ____, column) {
+    msg = (msg || '').replace(URL_REGEXP, function (_, __, prefix, path, ___, ____, line, _____, column) {
+
       if (prefix === 'base') {
         path = basePath + path
       }

--- a/test/unit/reporter.spec.coffee
+++ b/test/unit/reporter.spec.coffee
@@ -135,3 +135,36 @@ describe 'reporter', ->
             ERROR = 'at http://localhost:123/absoluteC:/a/b/c.js?da39a3ee5e6:2:6'
             expect(formatError ERROR).to.equal 'at C:/a/b/c.js:2:6 <- /original/b.js:4:8\n'
             done()
+
+      describe 'Webpack', ->
+        formatError = null
+        servedFiles = null
+
+        beforeEach ->
+          formatError = m.createErrorFormatter '', emitter, MockSourceMapConsumer
+          servedFiles = [new File('/test/a.js')]
+          servedFiles[0].sourceMap = 'SOURCE MAP a.js'
+
+        it 'should correct rewrite stack traces without sha', (done) ->
+          emitter.emit 'file_list_modified', q(served: servedFiles)
+
+          scheduleNextTick ->
+            ERROR = 'at base/test/a.js:2:6'
+            expect(formatError ERROR).to.equal 'at /test/a.js:2:6 <- /original/a.js:4:8\n'
+            done()
+
+        it 'should correct rewrite stack traces with sha', (done) ->
+          emitter.emit 'file_list_modified', q(served: servedFiles)
+
+          scheduleNextTick ->
+            ERROR = 'at base/test/a.js?da39a3ee5e6:2:6'
+            expect(formatError ERROR).to.equal 'at /test/a.js:2:6 <- /original/a.js:4:8\n'
+            done()
+
+        it 'should correct rewrite stack traces with sha without column', (done) ->
+          emitter.emit 'file_list_modified', q(served: servedFiles)
+
+          scheduleNextTick ->
+            ERROR = 'at base/test/a.js?da39a3ee5e6:2'
+            expect(formatError ERROR).to.equal 'at /test/a.js:2:0 <- /original/a.js:4:2\n'
+            done()


### PR DESCRIPTION
In some cases, reported stack traces do not contain the url scheme and domain. This is the case when using the webpack preprocessor where stack entries look like: `at base/main.js?<sha1>:44977`. The previous url regexp was always assuming an url scheme and domain.

This commit make the url scheme and domain optional so more stack traces can be handled when trying to link from a transformed source code to the original location provided by the source map associated with the served file.

I might be fixing the wrong place. What I mean by this is that it's possible that the real bug is that when using webpack, the reported stack traces are not correct. Currently, there are reported like this `at base/test/main.js?1f50f4d71de2570a00bab944fc506d6900a3b1ed:44977` while from the current tests, they should have been written `at http://localhost:9876/test/main.js?1f50f4d71de2570a00bab944fc506d6900a3b1ed:44977`. If that's the case, will do the necessary research to track this elsewhere.

I built a trimmed down project using `karma` and `karma-webpack` if you would like to try.

Regards,
Matt