### PR TITLE
Disable "WARN [web-server]: 404: /favicon.ico"

### DIFF
--- a/lib/middleware/common.js
+++ b/lib/middleware/common.js
@@ -18,7 +18,7 @@ var PromiseContainer = function () {
 }
 
 var serve404 = function (response, path) {
-  if(path !== '/favicon.ico'){
+  if (path !== '/favicon.ico') {
     log.warn('404: ' + path)
   }
   response.writeHead(404)

--- a/lib/middleware/common.js
+++ b/lib/middleware/common.js
@@ -18,7 +18,9 @@ var PromiseContainer = function () {
 }
 
 var serve404 = function (response, path) {
-  log.warn('404: ' + path)
+  if(path !== '/favicon.ico'){
+    log.warn('404: ' + path)
+  }
   response.writeHead(404)
   return response.end('NOT FOUND')
 }


### PR DESCRIPTION
The following warning log was felt unnecessary.

```bash
$ karma start
# ...
# WARN [web-server]: 404: /favicon.ico
```
