### PR TITLE
Make the requirejs config template normalize paths

### DIFF
--- a/requirejs.config.tpl.coffee
+++ b/requirejs.config.tpl.coffee
@@ -1,9 +1,14 @@
 allTestFiles = []
 TEST_REGEXP = /(spec|test)(\.coffee)?(\.js)?$/i
 
+# Get a list of all the test files to include
 Object.keys(window.__karma__.files).forEach (file) ->
-  # Normalize paths to RequireJS module names.
-  allTestFiles.push file  if TEST_REGEXP.test(file)
+
+  if TEST_REGEXP.test(file)
+    # Normalize paths to RequireJS module names.
+    # If you require sub-dependencies of test files to be loaded as-is (requiring file extension)
+    # then do not normalize the paths
+    allTestFiles.push file.replace(/^\/base\/|\.js$/g, '')
   return
 
 require.config

--- a/requirejs.config.tpl.js
+++ b/requirejs.config.tpl.js
@@ -1,10 +1,14 @@
 var allTestFiles = [];
 var TEST_REGEXP = /(spec|test)\.js$/i;
 
+// Get a list of all the test files to include
 Object.keys(window.__karma__.files).forEach(function(file) {
   if (TEST_REGEXP.test(file)) {
     // Normalize paths to RequireJS module names.
-    allTestFiles.push(file);
+    // If you require sub-dependencies of test files to be loaded as-is (requiring file extension)
+    // then do not normalize the paths
+    var normalizedTestModule = file.replace(/^\/base\/|\.js$/g, '');
+    allTestFiles.push(normalizedTestModule);
   }
 });
 


### PR DESCRIPTION
by removing the base path and file extension. This will mean sub dependencies of the test files will not be loaded as-is.
See https://github.com/karma-runner/karma/issues/513#issuecomment-48616784

Fixes https://github.com/karma-runner/karma-requirejs/issues/36 and linked

The docs will need updating too, but wasn't sure where (do I just edit 0.12 docs ?)