### PR TITLE
Add date/time stamp to log output

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -15,8 +15,8 @@ exports.LOG_INFO = 'INFO'
 exports.LOG_DEBUG = 'DEBUG'
 
 // Default patterns for the pattern layout.
-exports.COLOR_PATTERN = '%[%p [%c]: %]%m'
-exports.NO_COLOR_PATTERN = '%p [%c]: %m'
+exports.COLOR_PATTERN = '%[%d{DATE}:%p [%c]: %]%m'
+exports.NO_COLOR_PATTERN = '%d{DATE}:%p [%c]: %m'
 
 // Default console appender
 exports.CONSOLE_APPENDER = {


### PR DESCRIPTION
The "%d{DATE}" in the log pattern adds a date and time stamp to log lines.  So you get output like this from karma's logging:

>  30 06 2015 15:19:56.562:DEBUG [temp-dir]: Creating temp dir at /tmp/karma-43808925

The date and time are handy for figuring out if karma is running slowly.