### PR TITLE
fix(client): serialise DOM objects

### DIFF
--- a/client/stringify.js
+++ b/client/stringify.js
@@ -1,3 +1,4 @@
+var serialize = require('dom-serialize')
 var instanceOf = require('./util').instanceOf
 
 var stringify = function stringify (obj, depth) {
@@ -37,6 +38,8 @@ var stringify = function stringify (obj, depth) {
         return '<!--' + obj.nodeValue + '-->'
       } else if (obj.outerHTML) {
         return obj.outerHTML
+      } else if (obj.tagName || obj.nodeName) {
+        return serialize(obj)
       } else {
         var constructor = 'Object'
         if (obj.constructor && typeof obj.constructor === 'function') {

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "connect": "^3.3.5",
     "core-js": "^0.9.17",
     "di": "^0.0.1",
+    "dom-serialize": "^2.2.0",
     "expand-braces": "^0.1.1",
     "glob": "^5.0.10",
     "graceful-fs": "^3.0.6",

--- a/test/client/.eslintrc
+++ b/test/client/.eslintrc
@@ -1,5 +1,6 @@
 {
   "env": {
-    "jasmine": true
+    "jasmine": true,
+    "browser": true
   }
 }

--- a/test/client/stringify.spec.js
+++ b/test/client/stringify.spec.js
@@ -61,6 +61,12 @@ describe('stringify', function () {
     expect(stringify(div)).to.be.eql('<div>some <span>text</span></div>')
   })
 
+  it('should serialize DOMParser objects', function () {
+    var parser = new DOMParser()
+    var doc = parser.parseFromString('<test></test>', 'application/xml')
+    expect(stringify(doc)).to.be.eql('<test></test>')
+  })
+
   it('should serialize across iframes', function () {
     var div = document.createElement('div')
     expect(__karma__.stringify(div)).to.be.eql('<div></div>')


### PR DESCRIPTION
DOM elements and nodes are now serialised using dom-serrialize.

Closes #1106