### PR TITLE
feat(server): expose server event lifecycle in public API

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -76,10 +76,14 @@ var start = function (injector, config, launcher, globalEmitter, preprocess, fil
   globalEmitter.on('browser_register', function (browser) {
     launcher.markCaptured(browser.id)
 
-    // TODO(vojta): This is lame, browser can get captured and then crash (before other browsers get
-    // captured).
-    if (config.autoWatch && launcher.areAllCaptured()) {
-      executor.schedule()
+    if (launcher.areAllCaptured()) {
+      globalEmitter.emit('browsers_ready')
+
+      // TODO(vojta): This is lame, browser can get captured and then crash (before other browsers get
+      // captured).
+      if (config.autoWatch) {
+        executor.schedule()
+      }
     }
   })
 
@@ -247,6 +251,8 @@ var start = function (injector, config, launcher, globalEmitter, preprocess, fil
     log.error(error)
     disconnectBrowsers(1)
   })
+
+  return globalEmitter
 }
 start.$inject = ['injector', 'config', 'launcher', 'emitter', 'preprocess', 'fileList',
   'webServer', 'capturedBrowsers', 'socketServer', 'executor', 'done']
@@ -304,5 +310,5 @@ exports.start = function (cliOptions, done) {
 
   var injector = new di.Injector(modules)
 
-  injector.invoke(start)
+  return injector.invoke(start)
 }

--- a/test/unit/server.spec.coffee
+++ b/test/unit/server.spec.coffee
@@ -120,6 +120,28 @@ describe 'server', ->
       expect(mockWebServer.listen).to.have.been.called
       expect(mockInjector.invoke).to.have.been.calledWith mockLauncher.launch, mockLauncher
 
+    it 'should return the event emitter', ->
+      emitter = m.start(mockInjector, mockConfig, mockLauncher, emitter, null, mockFileList,
+        mockWebServer, browserCollection, mockSocketServer, mockExecutor, doneSpy)
+
+      expect(emitter).not.to.be.null
+      expect(emitter).to.be.an.instanceof(EventEmitter)
+
+    it 'should emit a browsers_ready event once all the browsers are captured', ->
+      emitter = m.start(mockInjector, mockConfig, mockLauncher, emitter, null, mockFileList,
+        mockWebServer, browserCollection, mockSocketServer, mockExecutor, doneSpy)
+
+      browsersReady = sinon.spy()
+      emitter.on('browsers_ready', browsersReady)
+
+      mockLauncher.areAllCaptured = -> false
+      fileListOnResolve()
+      expect(browsersReady).not.to.have.been.called
+
+      mockLauncher.areAllCaptured = -> true
+      emitter.emit('browser_register', {})
+      expect(browsersReady).to.have.been.called
+
     it 'should try next port if already in use', ->
       m.start(mockInjector, mockConfig, mockLauncher, emitter, null, mockFileList,
         mockWebServer, browserCollection, mockSocketServer, mockExecutor, doneSpy)


### PR DESCRIPTION
Return the EventEmitter instance so that it's possible to into various lifecycle events. Add a `browsers_ready` event so that it's possible to know when the karma server has finished starting up.

Enables and partially resolves #1037

I am very interested in resolving #1037 (it's breaking our grunt and gulp builds), so if this is not quite the way you want it to be done, let me know and I'll do it differently! :)