### PR TITLE
fix(web-server): Correctly update filesPromise on files updated

### DIFF
--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -2,8 +2,7 @@ var fs = require('fs')
 var http = require('http')
 var path = require('path')
 var connect = require('connect')
-
-var helper = require('./helper')
+var Promise = require('bluebird')
 
 var common = require('./middleware/common')
 var runnerMiddleware = require('./middleware/runner')
@@ -32,10 +31,10 @@ createCustomHandler.$inject = ['customFileHandlers', 'config.basePath']
 var createWebServer = function (injector, emitter) {
   var serveStaticFile = common.createServeFile(fs, path.normalize(__dirname + '/../static'))
   var serveFile = common.createServeFile(fs)
-  var filesDeferred = helper.defer()
+  var filesPromise = new common.PromiseContainer()
 
   emitter.on('file_list_modified', function (files) {
-    filesDeferred.resolve(files)
+    filesPromise.set(Promise.resolve(files))
   })
 
   // locals for webserver module
@@ -43,7 +42,7 @@ var createWebServer = function (injector, emitter) {
   injector = injector.createChild([{
     serveFile: ['value', serveFile],
     serveStaticFile: ['value', serveStaticFile],
-    filesPromise: ['value', filesDeferred.promise]
+    filesPromise: ['value', filesPromise]
   }])
 
   var proxyMiddlewareInstance = injector.invoke(proxyMiddleware.create)

--- a/test/unit/web-server.spec.coffee
+++ b/test/unit/web-server.spec.coffee
@@ -21,6 +21,7 @@ describe 'web-server', ->
     base:
       path:
         'one.js': mocks.fs.file(0, 'js-source')
+        'new.js': mocks.fs.file(0, 'new-js-source')
 
   # NOTE(vojta): only loading once, to speed things up
   # this relies on the fact that none of these tests mutate fs
@@ -60,6 +61,14 @@ describe 'web-server', ->
     request(server)
     .get('/base/one.js')
     .expect(200, 'js-source')
+
+  it 'should serve updated source files on file_list_modified', () ->
+    servedFiles new Set([new File '/base/path/one.js'])
+    servedFiles new Set([new File '/base/path/new.js'])
+
+    request(server)
+    .get('/base/new.js')
+    .expect(200, 'new-js-source')
 
   it 'should load custom handlers', () ->
     servedFiles new Set()


### PR DESCRIPTION
When the `file_list_modified` event was being emitted, the filesDeferred
was simply being resolved again; this has no effect and subsequent
calls to `filesPromise.then` continued to be resolved with the old
files.

This had the effect that issuing `karma run` did not result in new test
files being served.

This has been fixed by reverting the changes to `web-server.js` made in
fabdbae.