### PR TITLE
fix: restore backward compatibility for karma@0.13

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,13 +7,13 @@ var launcher = require('./launcher')
 
 // TODO: remove in 1.0
 var oldServer = {
-  start: function () {
-    throw new Error(
-      'The api interface has changed. Please use \n' +
+  start: function (cliOptions, done) {
+    console.error('WARN `start` method is deprecated since 0.13. It will be removed in 0.14. Please use \n' +
       '  server = new Server(config, [done])\n' +
       '  server.start()\n' +
-      'instead.'
-    )
+      'instead.')
+    var server = new Server(cliOptions, done)
+    server.start()
   }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -92,6 +92,15 @@ Server.prototype.start = function () {
   this._injector.invoke(this._start, this)
 }
 
+/**
+ * Backward-compatibility with karma-intellij bundled with WebStorm.
+ * Deprecated since version 0.13, to be removed in 0.14
+ */
+Server.start = function (cliOptions, done) {
+  var server = new Server(cliOptions, done)
+  server.start()
+}
+
 // Get properties from the injector
 //
 // token - String


### PR DESCRIPTION
This adds `start` method back to the object exported by `lib/server.js`.

Closes #1500