### PR TITLE
fix(runner): Wait for file list refresh to finish before running

### DIFF
--- a/lib/middleware/runner.js
+++ b/lib/middleware/runner.js
@@ -73,11 +73,13 @@ var createRunnerMiddleware = function (emitter, fileList, capturedBrowsers, repo
 
       if (fullRefresh && data.refresh !== false) {
         log.debug('Refreshing all the files / patterns')
-        fileList.refresh()
-
-        if (!config.autoWatch) {
-          executor.schedule()
-        }
+        fileList.refresh().then(function () {
+          // Wait for the file list refresh to complete before starting test run,
+          // otherwise the context.html generation might not see new/updated files.
+          if (!config.autoWatch) {
+            executor.schedule()
+          }
+        })
       } else {
         executor.schedule()
       }


### PR DESCRIPTION
The runner middleware was starting a file list refresh before executing
a test run, but was not waiting for it to complete. This meant that the
context.html generation would often not see the new file list, and so
stale test files would be served.

I haven't actually managed to successfully run the client tests on my machine, but I *think* this change shouldn't have any adverse impacts. Everything should be assuming that the code in the runner is all asynchronous anyway. I did have to update some of the runner unit tests to match this assumption though.