### PR TITLE
Updated timers for limited execution environment

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,8 @@ var di = require('di')
 var util = require('util')
 var Promise = require('bluebird')
 
+var root = global || window || this
+
 var cfg = require('./config')
 var logger = require('./logger')
 var constant = require('./constants')
@@ -72,7 +74,10 @@ var Server = function (cliOptions, done) {
     reporter: ['factory', reporter.createReporters],
     capturedBrowsers: ['type', BrowserCollection],
     args: ['value', {}],
-    timer: ['value', {setTimeout: setTimeout, clearTimeout: clearTimeout}]
+    timer: ['value', {
+        setTimeout: function () { return setTimeout.apply(root, arguments)},
+        clearTimeout: function (timeoutId) { clearTimeout(timeoutId)}
+    }]
   }]
 
   // Load the plugins


### PR DESCRIPTION
In limited execution environments the setTimeout/clearTimeout functions
need to be delegated to, rather than stored as references.

This is a follow up to #1519