### PR TITLE
use lodash find() instead of Array.prototype.find

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -99,7 +99,7 @@ List.prototype._isExcluded = function (path) {
 //
 // Returns the match or `undefined` if none found.
 List.prototype._isIncluded = function (path) {
-  return this._patterns.find(function (pattern) {
+  return _.find(this._patterns, function (pattern) {
     return mm(path, pattern.pattern)
   })
 }
@@ -133,7 +133,7 @@ List.prototype._exists = function (path) {
     return mm(path, pattern.pattern)
   })
 
-  return !!patterns.find(function (pattern) {
+  return !!_.find(patterns, function (pattern) {
     return self._findFile(path, pattern)
   })
 }


### PR DESCRIPTION
When i upgraded to from Karma 0.12.x to 0.13.3, my karma setup stopped working.

file-list.js uses ES6 Array.prototype.find which of course fails with `TypeError: undefined is not a function` in normal node installations (without the harmony flag).

Replacing Array.prototype.find() with lodash.find() (which is already used in other places in file-list.js) seems to fix the issue.