### PR TITLE
Add core-js es5 shim to karma client, fixes #1529

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -1,6 +1,7 @@
 /* global io */
 /* eslint-disable no-new */
 
+require('core-js/modules/es5')
 var Karma = require('./karma')
 var StatusUpdater = require('./updater')
 var util = require('./util')


### PR DESCRIPTION
Added core-js es5 shim in client/main.js
It fixes for me the issue with IE8 which was preventing me to use karma runner to run tests on IE8