### PR TITLE
Fix sourcemaps for errors that don't contain column information

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -45,13 +45,19 @@ var createErrorFormatter = function (basePath, emitter, SourceMapConsumer) {
 
       if (file && file.sourceMap) {
         line = parseInt(line || '0', 10)
-        column = parseInt(column || '0', 10)
+
+        column = parseInt(column, 10)
+
+        // When no column is given and we default to 0, it doesn't make sense to only search for smaller
+        // or equal columns in the sourcemap, let's search for equal or greater columns.
+        var bias = column ? SourceMapConsumer.GREATEST_LOWER_BOUND : SourceMapConsumer.LEAST_UPPER_BOUND
 
         try {
           var original = getSourceMapConsumer(file.sourceMap)
-            .originalPositionFor({line: line, column: column})
+            .originalPositionFor({line: line, column: (column || 0), bias: bias})
 
-          return util.format('%s:%d:%d <- %s:%d:%d', path, line, column, original.source,
+          var formattedColumn = column ? util.format(':%s', column) : ''
+          return util.format('%s:%d%s <- %s:%d:%d', path, line, formattedColumn, original.source,
             original.line, original.column)
         } catch (e) {
           log.warn('SourceMap position not found for trace: %s', msg)

--- a/test/unit/reporter.spec.js
+++ b/test/unit/reporter.spec.js
@@ -83,6 +83,9 @@ describe('reporter', () => {
         }
       }
 
+      MockSourceMapConsumer.GREATEST_LOWER_BOUND = 1
+      MockSourceMapConsumer.LEAST_UPPER_BOUND = 2
+
       it('should rewrite stack traces', done => {
         formatError = m.createErrorFormatter('/some/base', emitter, MockSourceMapConsumer)
         var servedFiles = [new File('/some/base/a.js'), new File('/some/base/b.js')]
@@ -94,6 +97,21 @@ describe('reporter', () => {
         _.defer(() => {
           var ERROR = 'at http://localhost:123/base/b.js:2:6'
           expect(formatError(ERROR)).to.equal('at /some/base/b.js:2:6 <- /original/b.js:4:8\n')
+          done()
+        })
+      })
+
+      it('should rewrite stack traces to the first column when no column is given', done => {
+        formatError = m.createErrorFormatter('/some/base', emitter, MockSourceMapConsumer)
+        var servedFiles = [new File('/some/base/a.js'), new File('/some/base/b.js')]
+        servedFiles[0].sourceMap = {content: 'SOURCE MAP a.js'}
+        servedFiles[1].sourceMap = {content: 'SOURCE MAP b.js'}
+
+        emitter.emit('file_list_modified', {served: servedFiles})
+
+        _.defer(() => {
+          var ERROR = 'at http://localhost:123/base/b.js:2'
+          expect(formatError(ERROR)).to.equal('at /some/base/b.js:2 <- /original/b.js:4:2\n')
           done()
         })
       })


### PR DESCRIPTION
I stumbled upon a bug where no column number was given in an error which broke the source-maps.

Not sure if using NaN here as a column number is something you guys like and also the changes to the formatting are dubious. Would appreciate suggestion to improve those.