### PR TITLE
fix(file-list): refresh resolves before 'file_list_modified' event

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -71,19 +71,17 @@ var List = function (patterns, excludes, emitter, preprocess, batchInterval) {
   var self = this
 
   // Emit the `file_list_modified` event.
-  // This function is debounced to the value of `batchInterval`
+  // This function is throttled to the value of `batchInterval`
   // to avoid spamming the listener.
-  this._emitModified = function () {
+  function emit () {
     self._emitter.emit('file_list_modified', self.files)
-
-    self._emitModified = _.throttle(function () {
-      self._emitter.emit('file_list_modified', self.files)
-    }, self._batchInterval, {
-      leading: false
-    })
   }
-}
+  var throttledEmit = _.throttle(emit, self._batchInterval, {leading: false})
+  self._emitModified = function (immediate) {
+    immediate ? emit() : throttledEmit()
+  }
 
+}
 // Private Interface
 // -----------------
 
@@ -203,7 +201,7 @@ List.prototype._refresh = function () {
   .cancellable()
   .then(function () {
     self.buckets = buckets
-    self._emitModified()
+    self._emitModified(true)
     return self.files
   })
   .catch(Promise.CancellationError, function () {

--- a/test/unit/file-list.spec.js
+++ b/test/unit/file-list.spec.js
@@ -243,7 +243,7 @@ describe('FileList', () => {
         fs: mockFs
       })
 
-      list = new List(patterns('/some/*.js', '*.txt'), [], emitter, preprocess)
+      list = new List(patterns('/some/*.js', '*.txt'), [], emitter, preprocess, 100)
     })
 
     it('resolves patterns', () => {
@@ -354,6 +354,20 @@ describe('FileList', () => {
       return list.refresh().catch(err => {
         expect(err.message).to.be.eql('failing')
       })
+    })
+
+    it('fires modified before resolving promise after subsequent calls', () => {
+      var modified = sinon.stub()
+      emitter.on('file_list_modified', modified)
+
+      return list.refresh().then(() => {
+        expect(modified).to.have.been.calledOnce
+      })
+        .then(() => {
+          list.refresh().then(() => {
+            expect(modified).to.have.been.calledTwice
+          })
+        })
     })
   })
 


### PR DESCRIPTION
file-list - file_list_modified should be emitted before refresh promise resolves

Runner test execution is scheduled after file-list refresh resolves.  The web-server gets the file-list from the last file_list_modified event. This was resulting in a race condition where the web server would grab a stale file list.

Closes #1550