### PR TITLE
docs(config): notice users about optional but used plugin

### DIFF
--- a/docs/plus/03-jenkins.md
+++ b/docs/plus/03-jenkins.md
@@ -14,7 +14,7 @@ You need the following tools installed on your Jenkins CI server:
 * Node
 * Karma
 
-Optional we highly suggest to install the following Jenkins plug-in:
+The following Jenkins plugin is optional, but the next guidelines are based on it:
 * [EnvInject] - it makes things easier under certain linux distributions and user permissions.
 
 ## Configure Karma


### PR DESCRIPTION
Reading that a plugin is optional can make confusion: readers may not install plugin.
Users can not undersand next steps of documentation, based on this plugin.