### PR TITLE
Throw error when browers option is not an array

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -36,7 +36,11 @@ var Launcher = function (emitter, injector) {
     var url = protocol + '//' + hostname + ':' + port + urlRoot
 
     lastStartTime = Date.now()
-
+ 
+    if (Array.isArray(names) === false) {
+      throw new TypeError('Expected browsers option to be an array but instead got ' + typeof names)
+    }
+    
     names.forEach(function (name) {
       var locals = {
         id: ['value', Launcher.generateId()],


### PR DESCRIPTION
I forgot that the `browsers` option must be an array. This commit 
catches this case and throws a more descriptive error instead of 
something a long the lines of `TypeError: undefined is not a function`