### PR TITLE
fix(config): Error when browers option isn't array

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -149,6 +149,10 @@ var normalizeConfig = function (config, configFilePath) {
     throw new Error('Invalid configuration: client.args must be an array of strings')
   }
 
+  if (config.browsers && Array.isArray(config.browsers) === false) {
+    throw new TypeError('Invalid configuration: browsers option must be an array')
+  }
+
   var defaultClient = config.defaultClient || {}
   Object.keys(defaultClient).forEach(function (key) {
     var option = config.client[key]

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -300,6 +300,16 @@ describe('config', () => {
       expect(config.preprocessors).not.to.have.property(resolveWinPath('*.coffee'))
       expect(config.preprocessors).to.have.property(resolveWinPath('/**/*.html'))
     })
+
+    it('should validate that the browser option is an array', () => {
+      var invalid = function () {
+        normalizeConfigWithDefaults({
+          browsers: 'Firefox'
+        })
+      }
+
+      expect(invalid).to.throw('Invalid configuration: browsers option must be an array')
+    })
   })
 
   describe('createPatternObject', () => {


### PR DESCRIPTION
I forgot that the `browsers` option must be an array. This commit catches this case and throws a more descriptive error instead of something a long the lines of `TypeError: undefined is not a function`

I *think* I've got everything formatted properly. Happy to make changes.