### PR TITLE
add HackTimer.js to prevent slow tests when Chrome is in background

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -97,7 +97,7 @@ var createKarmaMiddleware = function (filesPromise, serveStaticFile,
     }
 
     // serve the favicon
-    if (requestUrl === '/favicon.ico') {
+    if (requestUrl === '/favicon.ico' || requestUrl === '/HackTimer.js' || requestUrl === '/HackTimerWorker.js') {
       return serveStaticFile(requestUrl, response)
     }
 

--- a/static/HackTimer.js
+++ b/static/HackTimer.js
@@ -1,0 +1,137 @@
+//https://github.com/turuslan/HackTimer
+
+(function (workerScript) {
+  try {
+    var blob = new Blob (["\
+var fakeIdToId = {};\
+onmessage = function (event) {\
+	var data = event.data,\
+		name = data.name,\
+		fakeId = data.fakeId,\
+		time;\
+	if(data.hasOwnProperty('time')) {\
+		time = data.time;\
+	}\
+	switch (name) {\
+		case 'setInterval':\
+			fakeIdToId[fakeId] = setInterval(function () {\
+				postMessage({fakeId: fakeId});\
+			}, time);\
+			break;\
+		case 'clearInterval':\
+			if (fakeIdToId.hasOwnProperty (fakeId)) {\
+				clearInterval(fakeIdToId[fakeId]);\
+				delete fakeIdToId[fakeId];\
+			}\
+			break;\
+		case 'setTimeout':\
+			fakeIdToId[fakeId] = setTimeout(function () {\
+				postMessage({fakeId: fakeId});\
+				if (fakeIdToId.hasOwnProperty (fakeId)) {\
+					delete fakeIdToId[fakeId];\
+				}\
+			}, time);\
+			break;\
+		case 'clearTimeout':\
+			if (fakeIdToId.hasOwnProperty (fakeId)) {\
+				clearTimeout(fakeIdToId[fakeId]);\
+				delete fakeIdToId[fakeId];\
+			}\
+			break;\
+	}\
+}\
+"]);
+    // Obtain a blob URL reference to our worker 'file'.
+    workerScript = window.URL.createObjectURL(blob);
+  } catch (error) {
+    /* Blob is not supported, use external script instead */
+  }
+  var worker,
+    fakeIdToCallback = {},
+    lastFakeId = 0,
+    logPrefix = 'HackTimer.js by turuslan: ';
+  if (typeof (Worker) !== 'undefined') {
+    function getFakeId () {
+      lastFakeId ++;
+      return lastFakeId;
+    }
+    try {
+      worker = new Worker (workerScript);
+      window.setInterval = function (callback, time /* , parameters */) {
+        var fakeId = getFakeId ();
+        fakeIdToCallback[fakeId] = {
+          callback: callback,
+          parameters: Array.prototype.slice.call(arguments, 2)
+        };
+        worker.postMessage ({
+          name: 'setInterval',
+          fakeId: fakeId,
+          time: time
+        });
+        return fakeId;
+      };
+      window.clearInterval = function (fakeId) {
+        if (fakeIdToCallback.hasOwnProperty(fakeId)) {
+          delete fakeIdToCallback[fakeId];
+          worker.postMessage ({
+            name: 'clearInterval',
+            fakeId: fakeId
+          });
+        }
+      };
+      window.setTimeout = function (callback, time /* , parameters */) {
+        var fakeId = getFakeId ();
+        fakeIdToCallback[fakeId] = {
+          callback: callback,
+          parameters: Array.prototype.slice.call(arguments, 2)
+        };
+        worker.postMessage ({
+          name: 'setTimeout',
+          fakeId: fakeId,
+          time: time
+        });
+        return fakeId;
+      };
+      window.clearTimeout = function (fakeId) {
+        if (fakeIdToCallback.hasOwnProperty(fakeId)) {
+          delete fakeIdToCallback[fakeId];
+          worker.postMessage ({
+            name: 'clearTimeout',
+            fakeId: fakeId
+          });
+        }
+      };
+      worker.onmessage = function (event) {
+        var data = event.data,
+          fakeId = data.fakeId,
+          request,
+          parameters,
+          callback;
+        if (fakeIdToCallback.hasOwnProperty(fakeId)) {
+          request = fakeIdToCallback[fakeId];
+          callback = request.callback;
+          parameters = request.parameters;
+        }
+        if (typeof (callback) === 'string') {
+          try {
+            callback = new Function (callback);
+          } catch (error) {
+            console.log (logPrefix + 'Error parsing callback code string: ', error);
+          }
+        }
+        if (typeof (callback) === 'function') {
+          callback.apply (window, parameters);
+        }
+      };
+      worker.onerror = function (event) {
+        console.log (event);
+      };
+      console.log (logPrefix + 'Initialisation succeeded');
+    } catch (error) {
+      console.log (logPrefix + 'Initialisation failed');
+      console.error (error);
+    }
+  } else {
+    console.log (logPrefix + 'Initialisation failed - HTML5 Web Worker is not supported');
+  }
+}) ('HackTimerWorker.js');

--- a/static/HackTimerWorker.js
+++ b/static/HackTimerWorker.js
@@ -1,0 +1,39 @@
+// https://github.com/turuslan/HackTimer
+
+var fakeIdToId = {};
+onmessage = function (event) {
+  var data = event.data,
+    name = data.name,
+    fakeId = data.fakeId,
+    time;
+  if(data.hasOwnProperty('time')) {
+    time = data.time;
+  }
+  switch (name) {
+    case 'setInterval':
+      fakeIdToId[fakeId] = setInterval(function () {
+        postMessage({fakeId: fakeId});
+      }, time);
+      break;
+    case 'clearInterval':
+      if (fakeIdToId.hasOwnProperty (fakeId)) {
+        clearInterval(fakeIdToId[fakeId]);
+        delete fakeIdToId[fakeId];
+      }
+      break;
+    case 'setTimeout':
+      fakeIdToId[fakeId] = setTimeout(function () {
+        postMessage({fakeId: fakeId});
+        if (fakeIdToId.hasOwnProperty (fakeId)) {
+          delete fakeIdToId[fakeId];
+        }
+      }, time);
+      break;
+    case 'clearTimeout':
+      if (fakeIdToId.hasOwnProperty (fakeId)) {
+        clearTimeout(fakeIdToId[fakeId]);
+        delete fakeIdToId[fakeId];
+      }
+      break;
+  }
+}

--- a/static/client.html
+++ b/static/client.html
@@ -108,7 +108,8 @@ It contains socket.io and all the communication logic.
   <ul id="browsers"></ul>
 
   <iframe id="context" src="about:blank" width="100%" height="100%"></iframe>
-
+  <script src="HackTimer.js"></script>
+  <script src="HackTimerWorker.js"></script>
   <script src="socket.io/socket.io.js"></script>
   <script src="karma.js"></script>
 </body>

--- a/static/context.html
+++ b/static/context.html
@@ -11,6 +11,10 @@ Reloaded before every execution run.
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
 </head>
 <body>
+
+  <script src="HackTimer.js"></script>
+  <script src="HackTimerWorker.js"></script>
+
   <!-- The scripts need to be at the end of body, so that some test running frameworks
        (Angular Scenario, for example) need the body to be loaded so that it can insert its magic
        into it. If it is before body, then it fails to find the body and crashes and burns in an epic

--- a/static/debug.html
+++ b/static/debug.html
@@ -13,6 +13,10 @@ just for immediate execution, without reporting to Karma server.
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
 </head>
 <body>
+
+  <script src="HackTimer.js"></script>
+  <script src="HackTimerWorker.js"></script>
+
   <!-- The scripts need to be at the end of body, so that some test running frameworks
    (Angular Scenario, for example) need the body to be loaded so that it can insert its magic
    into it. If it is before body, then it fails to find the body and crashes and burns in an epic


### PR DESCRIPTION
Some browsers (Chrome) drastically increase the `setTimeout` interval if the tab is not visible on screen. This creates [issues in karma][related] if you push Chrome to the background (i.e. while using `autoWatch`).

This inserts [HackTimer.js] before any other javascript on each html page (`client`, `debug`, `context`). That may have been overkill. I did not test to see if one page in particular was creating the problem. What I can say is that it *drastically* improves execution time for tests running in out-of-site Chrome tabs.

An [issue has been opened][chromium-issue] with the Chromium team to address this via a cli flag, but there is no movement on that yet. I have not tested to see if the problem exists in other browsers (I saw an SO posts that suggest it does).

At present, [HackTimer.js has not specified an open source license][no-license], so this PR is probably a no-go until that is resolved. There also appear to be no unit tests for the library, so that is a potential concern as well. Until those are resolved, this PR serves as a proof of concept.

An additional possibility would be making the inclusion of the scripts optional via the config. Ideally it would be configurable per browser, and have the ability to forcibly disable across all browsers via the karma `cli` (when running on CI servers for instance).

Interested parties can install this hotfix via:
```bash
 npm install --save-dev jamestalmage/karma#hack-timer-dist
```

[HackTimer.js]:https://github.com/turuslan/HackTimer
[related]:https://github.com/karma-runner/karma-chrome-launcher/issues/44
[no-license]:https://github.com/turuslan/HackTimer/issues/6
[chromium-issue]:https://code.google.com/p/chromium/issues/detail?id=485425