### PR TITLE
Tweak tested/allowed Node.js/io.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,26 @@
 sudo: false
 language: node_js
 node_js:
-  - "iojs-v3.2.0"
-  - "0.12"
   - "0.10"
-  - "4.0.0"
+  - "0.12"
+  - "4"
+
+# Node.js 4 is supported but an optional socket.io dependency doesn't work yet, causing
+# a lot of error messages on Travis. Travis then terminates the build because of excessive
+# logging. All tests pass locally on Node.js 4.
+# TODO remove this exception when https://github.com/socketio/socket.io/issues/2228 is fixed.
+matrix:
+  allow_failures:
+    - node_js: "4"
 
 env:
   global:
   - SAUCE_USERNAME: vojtajina
   - secure: "bRVY+hYZwMf1SqVnMyZRJTLD0gN1hLx9/MwO8MM/qBiu3YNjXy49XElfMdzMKN6cZeKTmhcnjmZonbJuI1PQ2t+utGkyjnlVLJ/OlWptreKLzIlcbt4hrdPoTcjmUTwDWq9Ex9cVoYX8AzCasETttpczp3P+s3+vmOUj8z25JyU="
 
-# Make sure we have new NPM.
+# Make sure we have a new npm on Node 0.10.
 before_install:
-  - '[ "${TRAVIS_NODE_VERSION}" != "0.8"  ] || npm install -g npm@1.4.28'
-  - npm install -g npm
+  - '[ "${TRAVIS_NODE_VERSION}" != "0.10" ] || npm install -g npm'
   - npm config set loglevel warn
 
 before_script:

--- a/docs/intro/01-installation.md
+++ b/docs/intro/01-installation.md
@@ -1,11 +1,11 @@
 Karma runs on [Node.js] and is available as an [NPM] package.
 
-## Installing Node.js or iojs
+## Installing Node.js
 
-There are [node.js](http://nodejs.org/download/) or [iojs](https://iojs.org/en/index.html) for both Mac and Windows.
-On Linux, we recommend using [NVM](https://github.com/creationix/nvm).
+On Mac or Linux we recommend using [NVM](https://github.com/creationix/nvm). On Windows, download Node.js
+from [the official site](https://nodejs.org/).
 
-Note: Karma works on the two latest stable versions of node. That is **0.10.x** and **0.12.x** at this point. Also works on iojs 2.x.x.
+Note: Karma currently works on Node.js **0.10**, **0.12.x** and **4.x**. See [FAQ](04-faq.md#which-version-of-nodejs-does-karma-run-with-) for more info.
 
 ## Installing Karma and plugins
 

--- a/docs/intro/04-faq.md
+++ b/docs/intro/04-faq.md
@@ -25,7 +25,7 @@ The latest stable version from NPM (`npm install karma`). See [versioning] for m
 
 
 ### Which version of Node.js does Karma run with ?
-The three latest stable versions. That means `0.8`, `0.10` and `0.12` at this point. Also works on iojs `2.x.x`.
+Karma works on all LTS versions node in active maintenance state (see [LTS docs](https://github.com/nodejs/LTS/blob/master/README.md) for more info) as well as the latest stable version. That is **0.12.x** and **4.x** at this point. Additionally, Node **0.10** is currently supported.
 
 
 [mailing list]: https://groups.google.com/d/forum/karma-users

--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
     "karma": "./bin/karma"
   },
   "engines": {
-    "node": ">=0.10 <=0.12 || >=1 <=3"
+    "node": "0.10 || 0.12 || 4"
   },
   "version": "0.13.9",
   "license": "MIT"


### PR DESCRIPTION
chore(*): Tweak supported Node.js versions, drop io.js

Current setup means karma won't be tested on future updates to the Node v4
line. Those updates are not allowed to introduce breaking changes and only
the newest one is officially supported so that's the one that should be tested.

In the same way, ythe config doesn't contain "0.10.0" or "0.12.0" but
"0.10" & "0.12" so it catches latest updates.

io.js testing has been dropped - io.js has no official support policy as
opposed to Node.js; also, it won't see any major releases.

Refs 6b8d30f234aa77c87ac8cd720114c90a66e7e88e