### PR TITLE
package: bump `socket.io`; Fix #1577

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
     "minimatch": "^2.0.7",
     "optimist": "^0.6.1",
     "rimraf": "^2.3.3",
-    "socket.io": "~1.3.5",
+    "socket.io": "pmq20/socket.io#adac365",
     "source-map": "^0.4.4",
     "useragent": "^2.1.6"
   },


### PR DESCRIPTION
The previous reference points to 0.7.x of package `ws` which could not compile under Node 4.0.0.

We have to point to at least `ws` 0.8.0 to make it compile.

See also,

https://github.com/socketio/socket.io/pull/2248

https://github.com/websockets/ws
