### PR TITLE
fix(reporter): preserve base/absolute word in error

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -65,7 +65,8 @@ var createErrorFormatter = function (basePath, emitter, SourceMapConsumer) {
         }
       }
 
-      return path + (line ? ':' + line : '') + (column ? ':' + column : '')
+      var result = path + (line ? ':' + line : '') + (column ? ':' + column : '')
+      return result || prefix
     })
 
     // indent every line

--- a/test/unit/reporter.spec.js
+++ b/test/unit/reporter.spec.js
@@ -64,6 +64,16 @@ describe('reporter', () => {
       expect(formatError(ERROR)).to.equal('at /usr/path.js:2\n')
     })
 
+    it('should preserve absolute word', () => {
+      var ERROR = 'contains absolute'
+      expect(formatError(ERROR)).to.equal('contains absolute\n')
+    })
+
+    it('should preserve base word', () => {
+      var ERROR = 'contains base'
+      expect(formatError(ERROR)).to.equal('contains base\n')
+    })
+
     describe('source maps', () => {
       class MockSourceMapConsumer {
         constructor (sourceMap) {


### PR DESCRIPTION
Previously, any error log message containing the words `absolute` or `base` would have those words munged by the error formatter.

Contains broken tests, and fix.