### PR TITLE
feat(config): add restartOnFileChange option

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -220,6 +220,9 @@ var Karma = function (socket, iframe, opener, navigator, location) {
       window.console.clear()
     }
   })
+  socket.on('stop', function () {
+    this.complete()
+  }.bind(this))
 
   // report browser name, id
   socket.on('connect', function () {

--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -69,6 +69,14 @@ multiple changes into a single run so that the test runner doesn't try to start 
 tests more than it should. The configuration setting tells Karma how long to wait (in milliseconds) after any changes
 have occurred before starting the test process again.
 
+## restartOnFileChange
+**Type:** Boolean
+
+**Default:** `false`
+
+**Description:** When Karma is watching the files for changes, it will delay a new run until
+the current run is finished. Enabling this setting will cancel the current run and start a new run
+immediately when a change is detected.
 
 ## basePath
 **Type:** String

--- a/lib/config.js
+++ b/lib/config.js
@@ -236,6 +236,7 @@ var Config = function () {
   this.colors = true
   this.autoWatch = true
   this.autoWatchBatchDelay = 250
+  this.restartOnFileChange = false
   this.usePolling = process.platform === 'darwin' || process.platform === 'linux'
   this.reporters = ['progress']
   this.singleRun = false

--- a/lib/server.js
+++ b/lib/server.js
@@ -297,6 +297,9 @@ Server.prototype._start = function (config, launcher, preprocess, fileList, webS
   if (config.autoWatch) {
     self.on('file_list_modified', function () {
       self.log.debug('List of files has changed, trying to execute')
+      if (config.restartOnFileChange) {
+        socketServer.sockets.emit('stop')
+      }
       executor.schedule()
     })
   }

--- a/test/client/karma.spec.js
+++ b/test/client/karma.spec.js
@@ -49,6 +49,12 @@ describe('Karma', function () {
     expect(windowStub).to.have.been.calledWith('about:blank')
   })
 
+  it('should stop execution', function () {
+    sinon.spy(k, 'complete')
+    socket.emit('stop')
+    expect(k.complete).to.have.been.called
+  })
+
   it('should not start execution if any error during loading files', function () {
     k.error('syntax error', '/some/file.js', 11)
     k.loaded()


### PR DESCRIPTION
When autoWatch=true and restartOnFileChange=true, this will "complete"
the current run immediately then schedule a new one as before. This is
most useful in gulp/grunt/etc. tasks that auto-build/test/reload to reduce
the time-to-feedback when making many changes in quick succession.