### PR TITLE
Add support for custom headers for file served

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -175,6 +175,30 @@ documentation to see how (and if) it uses this value.
 **Description:** Enable or disable colors in the output (reporters and logs).
 
 
+## customHeaders
+**Type:** Array
+
+**Default:** `undefined`
+
+**Description** Custom HTTP headers that will be set upon serving files by Karma's web server.
+Custom headers are useful, especially with upcoming browser features like Service Workers.
+
+The `customHeaders` option allows you to set HTTP headers for files that match a regular expression.
+`customHeaders` is an array of `Objects` with properties as follows:
+
+* match: Regular expression string to match files
+* name: HTTP header name
+* value: HTTP header value
+
+**Example:**
+```javascript
+customHeaders: [{
+  match: '.*foo.html',
+  name: 'Service-Worker-Allowed',
+  value: '/'
+}]
+```
+
 ## exclude
 **Type:** Array
 

--- a/lib/middleware/common.js
+++ b/lib/middleware/common.js
@@ -23,7 +23,7 @@ var serve404 = function (response, path) {
   return response.end('NOT FOUND')
 }
 
-var createServeFile = function (fs, directory) {
+var createServeFile = function (fs, directory, config) {
   var cache = Object.create(null)
 
   return function (filepath, response, transform, content, doNotCache) {
@@ -35,6 +35,16 @@ var createServeFile = function (fs, directory) {
 
     if (!content && cache[filepath]) {
       content = cache[filepath]
+    }
+
+    if (config && config.customHeaders && config.customHeaders.length > 0) {
+      config.customHeaders.forEach(function (header) {
+        var regex = new RegExp(header.match)
+        if (regex.test(filepath)) {
+          log.debug('setting header: ' + header.name + ' for: ' + filepath)
+          response.setHeader(header.name, header.value)
+        }
+      })
     }
 
     // serve from cache

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -31,8 +31,8 @@ createCustomHandler.$inject = ['customFileHandlers', 'config.basePath']
 
 var createWebServer = function (injector, emitter, fileList) {
   var config = injector.get('config')
-  var serveStaticFile = common.createServeFile(fs, path.normalize(__dirname + '/../static'))
-  var serveFile = common.createServeFile(fs)
+  var serveStaticFile = common.createServeFile(fs, path.normalize(__dirname + '/../static'), config)
+  var serveFile = common.createServeFile(fs, null, config)
   var filesPromise = new common.PromiseContainer()
 
   // Set an empty list of files to avoid race issues with

--- a/test/e2e/headers.feature
+++ b/test/e2e/headers.feature
@@ -1,0 +1,26 @@
+Feature: Custom Headers
+  In order to use Karma
+  As a person who wants to write great tests
+  I want to Karma to send custom headers on files sent.
+
+  Scenario: Simple file with headers
+    Given a configuration with:
+      """
+      files = ['headers/*.js'];
+      browsers = ['PhantomJS'];
+      plugins = [
+        'karma-jasmine',
+        'karma-phantomjs-launcher'
+      ];
+      customHeaders = [{
+        match: 'foo.js',
+        name: 'Custom-Header-Awesomeness',
+        value: 'there.is.no.dana.only.zuul'
+      }];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      PhantomJS
+      """

--- a/test/e2e/support/headers/foo.js
+++ b/test/e2e/support/headers/foo.js
@@ -1,0 +1,1 @@
+'/base/headers/foo.js source'

--- a/test/e2e/support/headers/test.js
+++ b/test/e2e/support/headers/test.js
@@ -1,0 +1,14 @@
+function httpGet (url) {
+  var xmlHttp = new XMLHttpRequest()
+
+  xmlHttp.open('GET', url, false)
+  xmlHttp.send(null)
+
+  return xmlHttp
+}
+
+describe('setting custom headers', function () {
+  it('should get custom headers', function () {
+    expect(httpGet('/base/headers/foo.js').getResponseHeader('Custom-Header-Awesomeness')).toBe('there.is.no.dana.only.zuul')
+  })
+})


### PR DESCRIPTION
This pull request adds support for custom headers for files served.

My motivation:

This is important for Service Workers. In order to use service workers where the SW's are located in a different location than the html file they are referenced, a special header needs to be set.

Setting this header allows one to write tests for multiple service workers (as they'd be served from different places than debug.html for instance).