### PR TITLE
feat(reporter): Replace memoizee library with a trivial solution.

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -3,7 +3,6 @@ var log = require('./logger').create('reporter')
 var MultiReporter = require('./reporters/multi')
 var baseReporterDecoratorFactory = require('./reporters/base').decoratorFactory
 var SourceMapConsumer = require('source-map').SourceMapConsumer
-var memoizeWeak = require('memoizee/weak')
 
 var createErrorFormatter = function (basePath, emitter, SourceMapConsumer) {
   var lastServedFiles = []
@@ -29,9 +28,15 @@ var createErrorFormatter = function (basePath, emitter, SourceMapConsumer) {
     '(\\:(\\d+))?' + // column
     '', 'g')
 
-  var getSourceMapConsumer = memoizeWeak(function (sourceMap) {
-    return new SourceMapConsumer(sourceMap)
-  })
+  var getSourceMapConsumer = (function () {
+    var cache = {}
+    return function (sourceMap) {
+      if (!(sourceMap in cache)) {
+        cache[sourceMap] = new SourceMapConsumer(sourceMap)
+      }
+      return cache[sourceMap]
+    }
+  }())
 
   return function (msg, indentation) {
     // remove domain and timestamp from source files

--- a/package.json
+++ b/package.json
@@ -239,7 +239,6 @@
     "http-proxy": "^1.11.1",
     "lodash": "^3.8.0",
     "log4js": "^0.6.25",
-    "memoizee": "^0.3.8",
     "mime": "^1.3.4",
     "minimatch": "^2.0.7",
     "optimist": "^0.6.1",


### PR DESCRIPTION
The reporter functionality was pulling the entire memoizee library with all its dependencies for a simple memoization solution, and using almost none of the functionality. This seems like not the most critically performant codepath. This PR replaces that with a good-case solution that lowers the dependency footprint.