### PR TITLE
docs(plugin): fix typo with inline plugin example.

### DIFF
--- a/docs/config/05-plugins.md
+++ b/docs/config/05-plugins.md
@@ -36,7 +36,7 @@ plugins: [
   'karma-chrome-launcher'
 
   // inlined plugins
-  {'framework:xyz', ['factory', factoryFn]},
+  {'framework:xyz': ['factory', factoryFn]},
   require('./plugin-required-from-config')
 ]
 ```


### PR DESCRIPTION
fix a small typo in the plugin docs.