### PR TITLE
fix(proxy): Replace CreatyProxyServer

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -39,7 +39,7 @@ var parseProxyConfig = function (proxies, config) {
       (proxyDetails.protocol === 'https:' ? '443' : '80')
     var https = proxyDetails.protocol === 'https:'
 
-    var proxy = httpProxy.createProxyServer({
+    var proxy = httpProxy.createServer({
       target: {
         host: hostname,
         port: port,


### PR DESCRIPTION
It seems that some of the unit tests on proxy.spec.js are failing because they try to call this method on proxy.js on line 42:

```javascript
    var proxy = httpProxy.createProxyServer({
      target: {
        host: hostname,
        port: port,
        https: https
      },
      xfwd: true,
      secure: config.proxyValidateSSL
    })
```

it seems that the http-proxy.js file that karma is using doesn't include the createProxySever method but provides the createServer method. If I change it to httpProxy.createServer all tests seems to be working.