### PR TITLE
fix (proxy): Pass protocol in target object to enable https requests.

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -35,6 +35,7 @@ var parseProxyConfig = function (proxies, config) {
     }
 
     var hostname = proxyDetails.hostname || config.hostname
+    var protocol = proxyDetails.protocol || config.protocol
     var port = proxyDetails.port || config.port ||
       (proxyDetails.protocol === 'https:' ? '443' : '80')
     var https = proxyDetails.protocol === 'https:'
@@ -43,7 +44,8 @@ var parseProxyConfig = function (proxies, config) {
       target: {
         host: hostname,
         port: port,
-        https: https
+        https: https,
+        protocol: protocol
       },
       xfwd: true,
       secure: config.proxyValidateSSL

--- a/test/unit/middleware/proxy.spec.js
+++ b/test/unit/middleware/proxy.spec.js
@@ -166,7 +166,7 @@ describe('middleware.proxy', () => {
     expect(parsedProxyConfig[0].proxy).to.exist
   })
 
-  it('should set defualt https port', () => {
+  it('should set default https port', () => {
     var proxy = {'/base/': 'https://localhost/'}
     var parsedProxyConfig = m.parseProxyConfig(proxy, {})
     expect(parsedProxyConfig).to.have.length(1)
@@ -178,6 +178,13 @@ describe('middleware.proxy', () => {
       https: true
     })
     expect(parsedProxyConfig[0].proxy).to.exist
+    expect(parsedProxyConfig[0].proxy).to.containSubset({
+      options: {
+        target: {
+          protocol: 'https:'
+        }
+      }
+    })
   })
 
   it('should handle proxy configs with paths', () => {
@@ -206,6 +213,13 @@ describe('middleware.proxy', () => {
       https: true
     })
     expect(parsedProxyConfig[0].proxy).to.exist
+    expect(parsedProxyConfig[0].proxy).to.containSubset({
+      options: {
+        target: {
+          protocol: 'https:'
+        }
+      }
+    })
   })
 
   it('should handle proxy configs with only basepaths', () => {


### PR DESCRIPTION
The `protocol` parameter is necessary to allow proxying of an HTTPS server.