### PR TITLE
docs(jenkins): Update Jenkins documentation

### DIFF
--- a/docs/plus/03-jenkins.md
+++ b/docs/plus/03-jenkins.md
@@ -29,8 +29,9 @@ junitReporter: {
 },
  ```
 
-Please note the `test-result.xml` file will be written to the present
-working directory (and you will need to tell Jenkins where to find it).
+Please note the `test-results.xml` files will be written to subdirectories
+named after the browsers the tests were run in inside the present working
+directory (and you will need to tell Jenkins where to find them).
 
 ## Create a new Jenkins Job
 In Jenkins, start a new job for Angular/Karma with the basic
@@ -51,8 +52,10 @@ $ PHANTOMJS_BIN=/usr/local/bin/phantomjs #or wherever PhantomJS happens to be in
 Further down the page, in the Post-build Actions sub-section add a
 `Publish JUnit test result report` from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter
-the path to where the `test-results.xml` is relative to the root of
-your Jenkins job workspace.
+the path to where the `test-results.xml` files are relative to the root of your
+Jenkins job workspace (you can use wildcards for this, so `**/test-results.xml`
+will find the file even if it was stored inside a browser-specific
+subdirectory).
 
 
 


### PR DESCRIPTION
Current versions of the `karma-junit-reporter` and the given sample configuration store the report below directories named after the browsers the tests were run in, which must be reflected in the Jenkins configuration.

We recently ran into this issue after we updated to `karma-junit-reporter` 0.3.7, and noticed that the documentation in the [Karma documentation](https://github.com/karma-runner/karma-junit-reporter) did not reflect these changes (but the original [karma-junit-reporter](https://github.com/karma-runner/karma-junit-reporter) documentation does). So I'd suggest the documentation changes in this PR, but feel free to adapt/change them, especially since I'm not a native speaker.