### PR TITLE
Fix RequireJS documentation typo

### DIFF
--- a/docs/plus/01-requirejs.md
+++ b/docs/plus/01-requirejs.md
@@ -115,7 +115,7 @@ to load `knockout.js` before requirejs...
 ## Configuring Require.js
 
 Just like any Require.js project, you need a main module to bootstrap
-your tests. We do this is `test/test-main.js`.
+your tests. We do this in `test/test-main.js`.
 
 ### Karma `/base` Directory
 


### PR DESCRIPTION
"We do this **is** `test/test-main.js`."
"We do this **in** `test/test-main.js`."