### PR TITLE
Recommend using `karma-cli` if you are on Windows

### DIFF
--- a/docs/intro/01-installation.md
+++ b/docs/intro/01-installation.md
@@ -32,7 +32,7 @@ $ ./node_modules/karma/bin/karma start
 ```
 
 ## Commandline Interface
-Typing `./node_modules/karma/bin/karma start` sucks and so you might find it useful to install `karma-cli` globally.
+Typing `./node_modules/karma/bin/karma start` sucks and so you might find it useful to install `karma-cli` globally. You will need to do this if you want to run Karma on Windows from the command line.
 
 ```bash
 $ npm install -g karma-cli


### PR DESCRIPTION
This was inspired in part by https://github.com/bensu/doo/pull/46. 

Is the recommendation to always use `karma-cli`, even if you're on Unix where you could run `./node_modules/karma/bin/karma start`? Or is running `./node_modules/karma/bin/karma start` acceptable if you don't need to be cross platform?