### PR TITLE
chore(travis): Test on Node 5, don't update npm in newer Nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,28 @@ node_js:
   - "0.10"
   - "0.12"
   - "4"
+  - "5"
 
 env:
   global:
   - SAUCE_USERNAME: karmarunnerbot
   - secure: "bRVY+hYZwMf1SqVnMyZRJTLD0gN1hLx9/MwO8MM/qBiu3YNjXy49XElfMdzMKN6cZeKTmhcnjmZonbJuI1PQ2t+utGkyjnlVLJ/OlWptreKLzIlcbt4hrdPoTcjmUTwDWq9Ex9cVoYX8AzCasETttpczp3P+s3+vmOUj8z25JyU="
+  - CXX=g++-4.8
 
-# Make sure we have a new npm@3
+# Make sure we have a new npm on Node 0.10. npm >= 2 should work so by not updating them
+# here we have proper version coverage, especially that most people use the npm version
+# that's included in a Node version they use.
 before_install:
-  - npm install -g npm
+  - '[ "${TRAVIS_NODE_VERSION}" != "0.10" ] || npm install -g npm'
   - npm config set loglevel warn
+  - g++-4.8 --version
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 
 before_script:
   - export DISPLAY=:99.0

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -125,6 +125,6 @@ var createProxyHandler = function (proxies, urlRoot) {
   return middleware
 }
 
-exports.create = function (/* config */ config, /* config.proxies */ proxies) {
+exports.create = function (/* config */config, /* config.proxies */proxies) {
   return createProxyHandler(parseProxyConfig(proxies, config), config.urlRoot)
 }

--- a/package.json
+++ b/package.json
@@ -323,7 +323,7 @@
     "karma": "./bin/karma"
   },
   "engines": {
-    "node": "0.10 || 0.12 || 4"
+    "node": "0.10 || 0.12 || 4 || 5"
   },
   "version": "0.13.14",
   "license": "MIT"


### PR DESCRIPTION
Node 5 includes npm 3 by default so we don't have to update npm to make sure
it works on that version. On the other hand, most people don't upgrade npm
and just use the default included version, especially that it's very hard
to update npm on Windows. It's good to make sure Karma still works with npm 2,
especially that Node 4, current LTS will never upgrade to npm 3.