### PR TITLE
docs: Include Node 5.x versions

### DIFF
--- a/docs/intro/01-installation.md
+++ b/docs/intro/01-installation.md
@@ -5,7 +5,7 @@ Karma runs on [Node.js] and is available as an [NPM] package.
 On Mac or Linux we recommend using [NVM](https://github.com/creationix/nvm). On Windows, download Node.js
 from [the official site](https://nodejs.org/).
 
-Note: Karma currently works on Node.js **0.10**, **0.12.x** and **4.x**. See [FAQ](04-faq.md#which-version-of-nodejs-does-karma-run-with-) for more info.
+Note: Karma currently works on Node.js **0.10**, **0.12.x**, **4.x** and **5.x**. See [FAQ](04-faq.md#which-version-of-nodejs-does-karma-run-with-) for more info.
 
 ## Installing Karma and plugins
 


### PR DESCRIPTION
Already updated the 5.x version into FAQ, but the Intro is out-of-date yet.