### PR TITLE
fix(preprocessor): Directory names with dots

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -74,7 +74,7 @@ var createPreprocessor = function (config, basePath, injector) {
     }
 
     for (var i = 0; i < patterns.length; i++) {
-      if (mm(file.originalPath, patterns[i])) {
+      if (mm(file.originalPath, patterns[i], {dot: true})) {
         if (thisFileIsBinary) {
           log.warn('Ignoring preprocessing (%s) %s because it is a binary file.',
             config[patterns[i]].join(', '), file.originalPath)

--- a/test/unit/preprocessor.spec.js
+++ b/test/unit/preprocessor.spec.js
@@ -13,7 +13,10 @@ describe('preprocessor', () => {
         'b.js': mocks.fs.file(0, 'content'),
         'a.txt': mocks.fs.file(0, 'some-text'),
         'photo.png': mocks.fs.file(0, 'binary'),
-        'CAM_PHOTO.JPG': mocks.fs.file(0, 'binary')
+        'CAM_PHOTO.JPG': mocks.fs.file(0, 'binary'),
+        '.dir': {
+          'a.js': mocks.fs.file(0, 'content')
+        }
       }
     })
 
@@ -35,6 +38,25 @@ describe('preprocessor', () => {
     pp = m.createPreprocessor({'**/*.js': ['fake']}, null, injector)
 
     var file = {originalPath: '/some/a.js', path: 'path'}
+
+    pp(file, () => {
+      expect(fakePreprocessor).to.have.been.called
+      expect(file.path).to.equal('path-preprocessed')
+      expect(file.content).to.equal('new-content')
+      done()
+    })
+  })
+
+  it('should match directories starting with a dot', done => {
+    var fakePreprocessor = sinon.spy((content, file, done) => {
+      file.path = file.path + '-preprocessed'
+      done(null, 'new-content')
+    })
+
+    var injector = new di.Injector([{'preprocessor:fake': ['factory', () => fakePreprocessor]}])
+    pp = m.createPreprocessor({'**/*.js': ['fake']}, null, injector)
+
+    var file = {originalPath: '/some/.dir/a.js', path: 'path'}
 
     pp(file, () => {
       expect(fakePreprocessor).to.have.been.called


### PR DESCRIPTION
Change minimatch call to match files with dots in the directory name while preprocessing. Previously these files would be ignored by the preprocessor.