### PR TITLE
fix: Replace fs with graceful-fs

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,6 @@
 var path = require('path')
 var optimist = require('optimist')
-var fs = require('fs')
+var fs = require('graceful-fs')
 
 var Server = require('./server')
 var helper = require('./helper')

--- a/lib/completion.js
+++ b/lib/completion.js
@@ -130,7 +130,7 @@ var completion = function () {
   }
 
   // just print out the karma-completion.sh
-  var fs = require('fs')
+  var fs = require('graceful-fs')
   var path = require('path')
 
   fs.readFile(path.resolve(__dirname, '../karma-completion.sh'), 'utf8', function (err, data) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+var fs = require('graceful-fs')
 
 var pkg = JSON.parse(fs.readFileSync(__dirname + '/../package.json').toString())
 

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -12,7 +12,7 @@ var from = require('core-js/library/fn/array/from')
 var Promise = require('bluebird')
 var mm = require('minimatch')
 var Glob = require('glob').Glob
-var fs = Promise.promisifyAll(require('fs'))
+var fs = Promise.promisifyAll(require('graceful-fs'))
 var pathLib = require('path')
 
 var File = require('./file')

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+var fs = require('graceful-fs')
 var path = require('path')
 var _ = require('lodash')
 var useragent = require('useragent')

--- a/lib/init/formatters.js
+++ b/lib/init/formatters.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+var fs = require('graceful-fs')
 var util = require('util')
 
 var JS_TEMPLATE_PATH = __dirname + '/../../config.tpl.js'

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+var fs = require('graceful-fs')
 var path = require('path')
 
 var helper = require('./helper')

--- a/lib/temp_dir.js
+++ b/lib/temp_dir.js
@@ -1,5 +1,5 @@
 var path = require('path')
-var fs = require('fs')
+var fs = require('graceful-fs')
 var os = require('os')
 var rimraf = require('rimraf')
 var log = require('./logger').create('temp-dir')

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+var fs = require('graceful-fs')
 var http = require('http')
 var https = require('https')
 var path = require('path')


### PR DESCRIPTION
Karma sometimes exceeds the limit of open files in OS. Using of graceful-fs solves the problem.

Closes #544