### PR TITLE
test(file-list): Use path.posix to fix tests when run on Windows

### DIFF
--- a/test/unit/file-list.spec.js
+++ b/test/unit/file-list.spec.js
@@ -2,6 +2,7 @@ import Promise from 'bluebird'
 import {EventEmitter} from 'events'
 import mocks from 'mocks'
 import proxyquire from 'proxyquire'
+import pathLib from 'path'
 var helper = require('../../lib/helper')
 var _ = helper._
 
@@ -75,6 +76,7 @@ describe('FileList', () => {
       List = proxyquire('../../lib/file-list', {
         helper: helper,
         glob: glob,
+        path: pathLib.posix || pathLib/* for node 0.10 */,
         fs: mockFs
       })
     })
@@ -204,6 +206,7 @@ describe('FileList', () => {
       List = proxyquire('../../lib/file-list', {
         helper: helper,
         glob: glob,
+        path: pathLib.posix || pathLib/* for node 0.10 */,
         fs: mockFs
       })
 
@@ -240,6 +243,7 @@ describe('FileList', () => {
       List = proxyquire('../../lib/file-list', {
         helper: helper,
         glob: glob,
+        path: pathLib.posix || pathLib/* for node 0.10 */,
         fs: mockFs
       })
 
@@ -409,6 +413,7 @@ describe('FileList', () => {
       List = proxyquire('../../lib/file-list', {
         helper: helper,
         glob: glob,
+        path: pathLib.posix || pathLib/* for node 0.10 */,
         fs: mockFs
       })
 
@@ -521,6 +526,7 @@ describe('FileList', () => {
       List = proxyquire('../../lib/file-list', {
         helper: helper,
         glob: glob,
+        path: pathLib.posix || pathLib/* for node 0.10 */,
         fs: mockFs
       })
 
@@ -613,6 +619,7 @@ describe('FileList', () => {
       List = proxyquire('../../lib/file-list', {
         helper: helper,
         glob: glob,
+        path: pathLib.posix || pathLib/* for node 0.10 */,
         fs: mockFs
       })
 
@@ -681,6 +688,7 @@ describe('FileList', () => {
         helper: helper,
         glob: glob,
         fs: mockFs,
+        path: pathLib.posix || pathLib/* for node 0.10 */,
         bluebird: Promise
       })
     })


### PR DESCRIPTION
Have file-list.js use path.posix instead of path itself, so the tests can expect a '/' separator on any platform.

Closes #1028