### PR TITLE
refactor(config) : access definition of customs from basis

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -195,7 +195,14 @@ var normalizeConfig = function (config, configFilePath) {
       }
 
       module[type + ':' + name] = ['factory', function (injector) {
-        return injector.createChild([locals], [token]).get(token)
+        var result = injector.createChild([locals], [token]).get(token)
+        // we cannot force external launchers to keep args somewhere
+        // and use it in creation, but we require to keep args for base
+        // classes/decorators usage
+        // while it stores in locals - it will be not simple DI way
+        // to access when launcher will be created, so setup it explicitly
+        result.$definition = result.$definition || definition
+        return result
       }]
       hasSomeInlinedPlugin = true
     })

--- a/lib/launchers/base.js
+++ b/lib/launchers/base.js
@@ -99,6 +99,11 @@ var BaseLauncher = function (id, emitter) {
     return this.name
   }
 
+  this.getDefinition = function () {
+    this.$definition = this.$definition || {}
+    return this.$definition
+  }
+
   this._done = function (error) {
     killingPromise = killingPromise || Promise.resolve()
 

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -71,6 +71,11 @@ var BaseReporter = function (formatError, reportSlow, adapter) {
     }
   }
 
+  this.getDefinition = function () {
+    this.$definition = this.$definition || {}
+    return this.$definition
+  }
+
   this.onSpecComplete = function (browser, result) {
     if (result.skipped) {
       this.specSkipped(browser, result)

--- a/test/unit/middleware/source_files.spec.js
+++ b/test/unit/middleware/source_files.spec.js
@@ -110,7 +110,7 @@ describe('middleware.source_files', function () {
   })
 
   it('should send no-caching headers for js source files without timestamps', function () {
-    var ZERO_DATE = (new Date(0)).toString()
+    var ZERO_DATE = new RegExp(new Date(0).toString().substring(0, 33).replace(/\+/, '\\+'))
 
     servedFiles([
       new File('/src/some.js')


### PR DESCRIPTION
Allows custom(reporter|launcher)'a args to be accessible from
Launcher(Reporter)Base

Closes #1738
