### PR TITLE
feat(config): binpath for custom launchers

### DIFF
--- a/docs/config/03-browsers.md
+++ b/docs/config/03-browsers.md
@@ -82,6 +82,21 @@ customLaunchers: {
 Each plugin has some default paths where to find the browser binary on particular OS.
 You can override these settings by `<BROWSER>_BIN` ENV variable, or alternatively by creating a `symlink`.
 
+NEW: you can assign path to browser explicitly from config with `binpath` option:
+
+```javascript
+customLaunchers: {
+  special_chrome_instance: {
+    base: 'Chrome',
+    binpath : '/my/path/to/chrome.exe' // by defining full path to binary
+  },
+  special_firefox: {
+    base: 'Firefox',
+    binpath: 'env:MYFIREFOX' // by environment variable (use env: prefix for it)
+  }
+}
+```
+
 ### POSIX shells
 ```bash
 # Changing the path to the Chrome binary

--- a/lib/config.js
+++ b/lib/config.js
@@ -195,7 +195,14 @@ var normalizeConfig = function (config, configFilePath) {
       }
 
       module[type + ':' + name] = ['factory', function (injector) {
-        return injector.createChild([locals], [token]).get(token)
+        var result = injector.createChild([locals], [token]).get(token)
+        // we cannot force external launchers to keep args somewhere
+        // and use it in creation, but we require to keep args for base
+        // classes/decorators usage
+        // while it stores in locals - it will be not simple DI way
+        // to access when launcher will be created, so setup it explicitly
+        result.$definition = result.$definition || definition
+        return result
       }]
       hasSomeInlinedPlugin = true
     })

--- a/lib/launchers/base.js
+++ b/lib/launchers/base.js
@@ -99,6 +99,11 @@ var BaseLauncher = function (id, emitter) {
     return this.name
   }
 
+  this.getDefinition = function () {
+    this.$definition = this.$definition || {}
+    return this.$definition
+  }
+
   this._done = function (error) {
     killingPromise = killingPromise || Promise.resolve()
 

--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -29,7 +29,28 @@ var ProcessLauncher = function (spawn, tempDir, timer) {
   }
 
   this._getCommand = function () {
-    return env[self.ENV_CMD] || self.DEFAULT_CMD[process.platform]
+    // get config customLaunchers : { 'xxx': { binpath : '***' }} parameter if defined
+    var binpath = self.getDefinition().binpath
+    if (binpath) {
+      // check if bin path is Environment variable name for ex env:MYCHROME
+      if (binpath.match(/^env:/)) {
+        var envvarname = binpath.substring(4)
+        // while it's custom settings (not auto-defaults) we must to check them strictly
+        // to guarantee for developer that we use exactly same instance of browser that
+        // he pointed to
+        if (!envvarname) {
+          log.error('Empty environment variable used as path')
+          throw new Error('Empty environment variable used as path')
+        }
+        binpath = env[envvarname]
+        if (!binpath) {
+          log.error('Environment variable ' + envvarname + ' not set')
+          throw new Error('Environment variable ' + envvarname + ' not set')
+        }
+      }
+    }
+    // overriden bin path is first by priority if defined
+    return binpath || env[self.ENV_CMD] || self.DEFAULT_CMD[process.platform]
   }
 
   this._getOptions = function (url) {

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -71,6 +71,11 @@ var BaseReporter = function (formatError, reportSlow, adapter) {
     }
   }
 
+  this.getDefinition = function () {
+    this.$definition = this.$definition || {}
+    return this.$definition
+  }
+
   this.onSpecComplete = function (browser, result) {
     if (result.skipped) {
       this.specSkipped(browser, result)

--- a/test/unit/launchers/process.spec.js
+++ b/test/unit/launchers/process.spec.js
@@ -63,11 +63,30 @@ describe('launchers/process.js', () => {
   describe('_normalizeCommand', () => {
     it('should remove quotes from the cmd', () => {
       ProcessLauncher.call(launcher, null, mockTempDir)
-
       expect(launcher._normalizeCommand('"/bin/brow ser"')).to.equal(path.normalize('/bin/brow ser'))
       expect(launcher._normalizeCommand("'/bin/brow ser'")).to.equal
       path.normalize('/bin/brow ser')
       expect(launcher._normalizeCommand('`/bin/brow ser`')).to.equal(path.normalize('/bin/brow ser'))
+    })
+  })
+
+  describe('bin path from config', () => {
+    it('should get overriden binpath from $definition given as path', () => {
+      ProcessLauncher.call(launcher, mockSpawn, mockTempDir)
+      const binpath = 'my/test.exe'
+      launcher.$definition = {binpath}
+      var overriden = launcher._getCommand()
+      expect(overriden).to.equal(binpath)
+    })
+
+    it('should get overriden binpath from $definition given as environment variable', () => {
+      ProcessLauncher.call(launcher, mockSpawn, mockTempDir)
+      const binpath = 'my/test.exe'
+      const envname = '_MY_BIN_PATH_'
+      process.env[envname] = binpath
+      launcher.$definition = {binpath: `env:${envname}`}
+      var overriden = launcher._getCommand()
+      expect(overriden).to.equal(binpath)
     })
   })
 

--- a/test/unit/middleware/source_files.spec.js
+++ b/test/unit/middleware/source_files.spec.js
@@ -110,7 +110,7 @@ describe('middleware.source_files', function () {
   })
 
   it('should send no-caching headers for js source files without timestamps', function () {
-    var ZERO_DATE = (new Date(0)).toString()
+    var ZERO_DATE = new RegExp(new Date(0).toString().substring(0, 33).replace(/\+/, '\\+'))
 
     servedFiles([
       new File('/src/some.js')


### PR DESCRIPTION
Allows explicitly set path to browser binary
both with full OS path or with Environment Variable

Closes #1737
