### PR TITLE
fix(middleware): Correct spelling of middleware logger name

### DIFF
--- a/lib/middleware/source_files.js
+++ b/lib/middleware/source_files.js
@@ -3,7 +3,7 @@ var querystring = require('querystring')
 var common = require('./common')
 var _ = require('../helper')._
 var logger = require('../logger')
-var log = logger.create('middlware:source-files')
+var log = logger.create('middleware:source-files')
 
 // Files is a Set
 var findByPath = function (files, path) {


### PR DESCRIPTION
The `middleware:source-files` logger was spelled incorrectly.