### PR TITLE
Added support for HTML5 mode 

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -148,9 +148,9 @@ var createKarmaMiddleware = function (filesPromise, serveStaticFile,
           mappings = 'window.__karma__.files = {\n' + mappings.join(',\n') + '\n};\n'
 
           if (html5Mode) {
-            data = data.replace('%BASE_TAG%', '<base href="' + urlRoot + '" />');
+            data = data.replace('%BASE_TAG%', '<base href="' + urlRoot + '" />')
           } else {
-            data = data.replace('%BASE_TAG%', '');
+            data = data.replace('%BASE_TAG%', '')
           }
 
           return data

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -60,7 +60,7 @@ var getXUACompatibleUrl = function (url) {
 }
 
 var createKarmaMiddleware = function (filesPromise, serveStaticFile,
-  /* config.basePath */ basePath, /* config.urlRoot */ urlRoot, /* config.client */ client) {
+  /* config.basePath */ basePath, /* config.urlRoot */ urlRoot, /* config.client */ client, /* config.html5Mode */ html5Mode) {
   return function (request, response, next) {
     var requestUrl = request.normalizedUrl.replace(/\?.*/, '')
 
@@ -147,6 +147,12 @@ var createKarmaMiddleware = function (filesPromise, serveStaticFile,
 
           mappings = 'window.__karma__.files = {\n' + mappings.join(',\n') + '\n};\n'
 
+          if (html5Mode) {
+            data = data.replace('%BASE_TAG%', '<base href="' + urlRoot + '" />');
+          } else {
+            data = data.replace('%BASE_TAG%', '');
+          }
+
           return data
             .replace('%SCRIPTS%', scriptTags.join('\n'))
             .replace('%CLIENT_CONFIG%', clientConfig)
@@ -179,7 +185,7 @@ var createKarmaMiddleware = function (filesPromise, serveStaticFile,
 }
 
 createKarmaMiddleware.$inject = ['filesPromise', 'serveStaticFile',
-  'config.basePath', 'config.urlRoot', 'config.client']
+  'config.basePath', 'config.urlRoot', 'config.client', 'config.html5Mode']
 
 // PUBLIC API
 exports.create = createKarmaMiddleware

--- a/static/context.html
+++ b/static/context.html
@@ -7,6 +7,7 @@ Reloaded before every execution run.
 <html>
 <head>
   <title></title>
+  %BASE_TAG%
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
 </head>

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -184,7 +184,7 @@ describe('middleware.karma', () => {
   });
 
   describe('given the html5 mode is false', function () {
-    it('it should npt serve the context.html with %BASE_TAG% in the content', function (done) {
+    it('it should not serve the context.html with %BASE_TAG% in the content', function (done) {
       handler = createKarmaMiddleware(filesDeferred.promise, serveFile, '/base/path', '/__karma__/', clientConfig, false);
 
       includedFiles([])

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -34,10 +34,10 @@ describe('middleware.karma', () => {
 
   var handler = serveFile = filesDeferred = nextSpy = response = null
 
-  var clientConfig;
+  var clientConfig
 
   beforeEach(() => {
-    clientConfig = {foo: 'bar'};
+    clientConfig = {foo: 'bar'}
     nextSpy = sinon.spy()
     response = new HttpResponseMock()
     filesDeferred = helper.defer()
@@ -169,7 +169,7 @@ describe('middleware.karma', () => {
 
   describe('given html5Mode is set to true in the config', function () {
     it('it should serve the context.html with a base tag', function (done) {
-      handler = createKarmaMiddleware(filesDeferred.promise, serveFile, '/base/path', '/__karma__/', clientConfig, true);
+      handler = createKarmaMiddleware(filesDeferred.promise, serveFile, '/base/path', '/__karma__/', clientConfig, true)
 
       includedFiles([])
 
@@ -180,12 +180,12 @@ describe('middleware.karma', () => {
       })
 
       callHandlerWith('/__karma__/context.html')
-    });
-  });
+    })
+  })
 
   describe('given html5Mode is set to false in the config', function () {
     it('it should not serve the context.html with %BASE_TAG% in the content', function (done) {
-      handler = createKarmaMiddleware(filesDeferred.promise, serveFile, '/base/path', '/__karma__/', clientConfig, false);
+      handler = createKarmaMiddleware(filesDeferred.promise, serveFile, '/base/path', '/__karma__/', clientConfig, false)
 
       includedFiles([])
 
@@ -196,8 +196,8 @@ describe('middleware.karma', () => {
       })
 
       callHandlerWith('/__karma__/context.html')
-    });
-  });
+    })
+  })
 
   it('should serve context.html with replaced link tags', (done) => {
     includedFiles([

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -167,7 +167,7 @@ describe('middleware.karma', () => {
     callHandlerWith('/__karma__/context.html')
   })
 
-  describe('given the html5 mode is true', function () {
+  describe('given html5Mode is set to true in the config', function () {
     it('it should serve the context.html with a base tag', function (done) {
       handler = createKarmaMiddleware(filesDeferred.promise, serveFile, '/base/path', '/__karma__/', clientConfig, true);
 
@@ -183,7 +183,7 @@ describe('middleware.karma', () => {
     });
   });
 
-  describe('given the html5 mode is false', function () {
+  describe('given html5Mode is set to false in the config', function () {
     it('it should not serve the context.html with %BASE_TAG% in the content', function (done) {
       handler = createKarmaMiddleware(filesDeferred.promise, serveFile, '/base/path', '/__karma__/', clientConfig, false);
 

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -22,7 +22,7 @@ describe('middleware.karma', () => {
     karma: {
       static: {
         'client.html': mocks.fs.file(0, 'CLIENT HTML\n%X_UA_COMPATIBLE%%X_UA_COMPATIBLE_URL%'),
-        'context.html': mocks.fs.file(0, 'CONTEXT\n%SCRIPTS%'),
+        'context.html': mocks.fs.file(0, 'CONTEXT\n%BASE_TAG%%SCRIPTS%'),
         'debug.html': mocks.fs.file(0, 'DEBUG\n%SCRIPTS%\n%X_UA_COMPATIBLE%'),
         'karma.js': mocks.fs.file(0, 'root: %KARMA_URL_ROOT%, v: %KARMA_VERSION%')
       }
@@ -34,8 +34,10 @@ describe('middleware.karma', () => {
 
   var handler = serveFile = filesDeferred = nextSpy = response = null
 
+  var clientConfig;
+
   beforeEach(() => {
-    var clientConfig = {foo: 'bar'}
+    clientConfig = {foo: 'bar'};
     nextSpy = sinon.spy()
     response = new HttpResponseMock()
     filesDeferred = helper.defer()
@@ -165,6 +167,38 @@ describe('middleware.karma', () => {
     callHandlerWith('/__karma__/context.html')
   })
 
+  describe('given the html5 mode is true', function () {
+    it('it should serve the context.html with a base tag', function (done) {
+      handler = createKarmaMiddleware(filesDeferred.promise, serveFile, '/base/path', '/__karma__/', clientConfig, true);
+
+      includedFiles([])
+
+      response.once('end', () => {
+        expect(nextSpy).not.to.have.been.called
+        expect(response).to.beServedAs(200, 'CONTEXT\n<base href="/__karma__/" />')
+        done()
+      })
+
+      callHandlerWith('/__karma__/context.html')
+    });
+  });
+
+  describe('given the html5 mode is false', function () {
+    it('it should npt serve the context.html with %BASE_TAG% in the content', function (done) {
+      handler = createKarmaMiddleware(filesDeferred.promise, serveFile, '/base/path', '/__karma__/', clientConfig, false);
+
+      includedFiles([])
+
+      response.once('end', () => {
+        expect(nextSpy).not.to.have.been.called
+        expect(response).to.beServedAs(200, 'CONTEXT\n')
+        done()
+      })
+
+      callHandlerWith('/__karma__/context.html')
+    });
+  });
+
   it('should serve context.html with replaced link tags', (done) => {
     includedFiles([
       new MockFile('/first.css', 'sha007'),
@@ -276,6 +310,7 @@ describe('middleware.karma', () => {
 
     response.once('end', () => {
       expect(response).to.beServedAs(200, "window.__karma__.files = {\n  '/__karma__/absolute/some/abc/a.js': 'sha_a',\n  '/__karma__/base/b.js': 'sha_b',\n  '/__karma__/absolute\\\\windows\\\\path\\\\uuu\\\\c.js': 'sha_c'\n};\n")
+      fsMock._touchFile('/karma/static/context.html', 0, 'CONTEXT\n%BASE_TAG%%SCRIPTS%')
       done()
     })
 

--- a/test/unit/mocha-globals.js
+++ b/test/unit/mocha-globals.js
@@ -32,9 +32,9 @@ chai.use((chai, utils) => {
     var response = utils.flag(this, 'object')
 
     this.assert(response._status === expectedStatus,
-      `expected response status '#{response._status}' to be '#{expectedStatus}'`)
+      `expected response status '${response._status}' to be '${expectedStatus}'`)
     this.assert(response._body === expectedBody,
-      `expected response body '#{response._body}' to be '#{exp)ectedBody}'`)
+      `expected response body '${response._body}' to be '${expectedBody}'`)
   })
 
   chai.Assertion.addMethod('beNotServed', function () {


### PR DESCRIPTION
Hi, this is a fix for https://github.com/karma-runner/karma/issues/1178. When you activate html5mode in Angular it's a requirement that a `<base>`  tag is present. The fix gives the user the ability to specify whether they want to run the tests in html 5 mode or not. 

