### PR TITLE
feat(logging): Add colors and log-level options to run-command

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -177,6 +177,9 @@ var describeRun = function () {
     .describe('port', '<integer> Port where the server is listening.')
     .describe('no-refresh', 'Do not re-glob all the patterns.')
     .describe('help', 'Print usage.')
+    .describe('log-level', '<disable | error | warn | info | debug> Level of logging.')
+    .describe('colors', 'Use colors when reporting and printing logs.')
+    .describe('no-colors', 'Do not use colors when reporting or printing logs.')
 }
 
 var describeCompletion = function () {

--- a/lib/init.js
+++ b/lib/init.js
@@ -6,7 +6,6 @@ var exec = require('child_process').exec
 
 var helper = require('./helper')
 var logger = require('./logger')
-var constant = require('./constants')
 
 var log = logger.create('init')
 
@@ -211,21 +210,13 @@ var processAnswers = function (answers, basePath, testMainFile) {
 }
 
 exports.init = function (config) {
-  var useColors = true
-  var logLevel = constant.LOG_INFO
+  logger.setupFromConfig(config)
+
   var colorScheme = COLOR_SCHEME.ON
 
   if (helper.isDefined(config.colors)) {
     colorScheme = config.colors ? COLOR_SCHEME.ON : COLOR_SCHEME.OFF
-    useColors = config.colors
   }
-
-  if (helper.isDefined(config.logLevel)) {
-    logLevel = config.logLevel
-  }
-
-  logger.setup(logLevel, useColors)
-
   // need to be registered before creating readlineInterface
   process.stdin.on('keypress', function (s, key) {
     sm.onKeypress(key)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -43,6 +43,29 @@ var setup = function (level, colors, appenders) {
   })
 }
 
+// Setup the logger by passing in the config object. The function sets the
+// `colors` and `logLevel` if they are defined. It takes two arguments:
+//
+//     setupFromConfig(config, appenders)
+//
+// * `config`: *Object* The configuration object.
+// * `appenders`: *Array* This will be passed as appenders to log4js
+//   to allow for fine grained configuration of log4js. For more information
+//   see https://github.com/nomiddlename/log4js-node.
+var setupFromConfig = function (config, appenders) {
+  var useColors = true
+  var logLevel = constant.LOG_INFO
+
+  if (helper.isDefined(config.colors)) {
+    useColors = config.colors
+  }
+
+  if (helper.isDefined(config.logLevel)) {
+    logLevel = config.logLevel
+  }
+  setup(logLevel, useColors, appenders)
+}
+
 // Create a new logger. There are two optional arguments
 // * `name`, which defaults to `karma` and
 //   If the `name = 'socket.io'` this will create a special wrapper
@@ -60,3 +83,4 @@ var create = function (name, level) {
 
 exports.create = create
 exports.setup = setup
+exports.setupFromConfig = setupFromConfig

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -3,6 +3,7 @@ var http = require('http')
 var constant = require('./constants')
 var helper = require('./helper')
 var cfg = require('./config')
+var logger = require('./logger')
 
 var parseExitCode = function (buffer, defaultCode) {
   var tailPos = buffer.length - Buffer.byteLength(constant.EXIT_CODE) - 1
@@ -24,6 +25,8 @@ var parseExitCode = function (buffer, defaultCode) {
 
 // TODO(vojta): read config file (port, host, urlRoot)
 exports.run = function (config, done) {
+  logger.setupFromConfig(config)
+
   done = helper.isFunction(done) ? done : process.exit
   config = cfg.parseConfig(config.configFile, config)
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -39,17 +39,11 @@ function createSocketIoServer (webServer, executor, config) {
   return server
 }
 
-function setupLogger (level, colors) {
-  var logLevel = logLevel || constant.LOG_INFO
-  var logColors = helper.isDefined(colors) ? colors : true
-  logger.setup(logLevel, logColors, [constant.CONSOLE_APPENDER])
-}
-
 // Constructor
 var Server = function (cliOptions, done) {
   EventEmitter.call(this)
 
-  setupLogger(cliOptions.logLevel, cliOptions.colors)
+  logger.setupFromConfig(cliOptions)
 
   this.log = logger.create()
 


### PR DESCRIPTION
 Add colors and log-level arguments to run argument.
 Refactor log-setup functions for server and init.
 Correct bug in server where log-level was ignored before `parseConfig`

Closing #1067