### PR TITLE
docs(config): typo

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -312,7 +312,7 @@ var parseConfig = function (configFilePath, cliOptions) {
     return process.exit(1)
   }
 
-  // merge the config from config file and cliOptions (precendense)
+  // merge the config from config file and cliOptions (precedence)
   config.set(cliOptions)
 
   // configure the logger as soon as we can


### PR DESCRIPTION
Typo was introduced here, ~2 years ago: https://github.com/pavelgj/testacular/commit/27b8d678cdc43f823d2531d25fc548d542dc9078