### PR TITLE
Feature allow custom browser names

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -10,6 +10,7 @@ var Karma = function (socket, iframe, opener, navigator, location) {
   var self = this
   var queryParams = util.parseQueryParams(location.search)
   var browserId = queryParams.id || util.generateId('manual-')
+  var displayName = queryParams.displayName
   var returnUrl = queryParams['return_url' + ''] || null
 
   var resultsBufferLimit = 50
@@ -233,11 +234,14 @@ var Karma = function (socket, iframe, opener, navigator, location) {
     socket.io.engine.on('upgrade', function () {
       resultsBufferLimit = 1
     })
-
-    socket.emit('register', {
+    var info = {
       name: navigator.userAgent,
       id: browserId
-    })
+    }
+    if (displayName) {
+      info.displayName = displayName
+    }
+    socket.emit('register', info)
   })
 }
 

--- a/docs/config/03-browsers.md
+++ b/docs/config/03-browsers.md
@@ -77,6 +77,20 @@ customLaunchers: {
 }
 ```
 
+A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
+user agent. E.g. defining
+
+```javascript
+customLaunchers: {
+  chrome_without_security: {
+    base: 'Chrome',
+    flags: ['--disable-web-security'],
+    displayName: 'Chrome w/o security'
+  }
+}
+```
+
+the browser will figure as `Chrome w/o security` in logs and reports.
 
 ## Correct path to browser binary
 Each plugin has some default paths where to find the browser binary on particular OS.

--- a/lib/config.js
+++ b/lib/config.js
@@ -195,7 +195,11 @@ var normalizeConfig = function (config, configFilePath) {
       }
 
       module[type + ':' + name] = ['factory', function (injector) {
-        return injector.createChild([locals], [token]).get(token)
+        var plugin = injector.createChild([locals], [token]).get(token)
+        if (type === 'launcher' && helper.isDefined(definition.displayName)) {
+          plugin.displayName = definition.displayName
+        }
+        return plugin
       }]
       hasSomeInlinedPlugin = true
     })

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -1,6 +1,7 @@
 var Promise = require('bluebird')
 var Batch = require('batch')
 
+var helper = require('./helper')
 var log = require('./logger').create('launcher')
 
 var baseDecorator = require('./launchers/base').decoratorFactory
@@ -88,7 +89,7 @@ var Launcher = function (emitter, injector) {
       }
 
       batch.push(function (done) {
-        log.info('Starting browser %s', browser.name)
+        log.info('Starting browser %s', helper.isDefined(browser.displayName) ? browser.displayName : browser.name)
 
         browser.start(url)
         browser.on('browser_process_failure', function () {

--- a/lib/launchers/base.js
+++ b/lib/launchers/base.js
@@ -3,6 +3,7 @@ var EventEmitter = require('events').EventEmitter
 var Promise = require('bluebird')
 
 var log = require('../logger').create('launcher')
+var helper = require('../helper')
 
 var BEING_CAPTURED = 1
 var CAPTURED = 2
@@ -38,7 +39,7 @@ var BaseLauncher = function (id, emitter) {
 
     this.error = null
     this.state = BEING_CAPTURED
-    this.emit('start', url + '?id=' + this.id)
+    this.emit('start', url + '?id=' + this.id + (helper.isDefined(self.displayName) ? '&displayName=' + encodeURIComponent(self.displayName) : ''))
   }
 
   this.kill = function () {

--- a/lib/server.js
+++ b/lib/server.js
@@ -224,7 +224,7 @@ Server.prototype._start = function (config, launcher, preprocess, fileList, webS
       } else {
         newBrowser = self._injector.createChild([{
           id: ['value', info.id || null],
-          fullName: ['value', info.name],
+          fullName: ['value', (helper.isDefined(info.displayName) ? info.displayName : info.name)],
           socket: ['value', socket]
         }]).instantiate(Browser)
 

--- a/test/e2e/displayname.feature
+++ b/test/e2e/displayname.feature
@@ -1,0 +1,27 @@
+Feature: Custom Display-name
+  In order to use Karma
+  As a person who wants to write great tests
+  I want to Karma to send custom display-name.
+
+  Scenario: Execute a test in PhantomJS
+    Given a configuration with:
+      """
+      files = ['basic/plus.js', 'basic/test.js'];
+      browsers = ['customPhantom'];
+      plugins = [
+        'karma-jasmine',
+        'karma-phantomjs-launcher'
+      ];
+      customLaunchers = {
+        customPhantom: {
+          base: 'PhantomJS',
+          displayName: '42'
+        }
+      };
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      ..
+      42
+      """


### PR DESCRIPTION
Custom browser-names can now be defined as described in the docs. Furthermore, as a side-effect, browser-names can also be defined when testing manually. This is done by adding the argument `displayName=<displayName>` to the query-string.