### PR TITLE
fix(runner): Remove null characters from terminal output

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -10,24 +10,23 @@ var parseExitCode = function (buffer, defaultCode, failOnEmptyTestSuite) {
   var tailPos = buffer.length - Buffer.byteLength(constant.EXIT_CODE) - 2
 
   if (tailPos < 0) {
-    return defaultCode
+    return {exitCode: defaultCode, buffer: buffer}
   }
 
   // tail buffer which might contain the message
   var tail = buffer.slice(tailPos)
   var tailStr = tail.toString()
   if (tailStr.substr(0, tailStr.length - 2) === constant.EXIT_CODE) {
-    tail.fill('\x00')
     var emptyInt = parseInt(tailStr.substr(-2, 1), 10)
     var exitCode = parseInt(tailStr.substr(-1), 10)
     if (failOnEmptyTestSuite === false && emptyInt === 0) {
       log.warn('Test suite was empty.')
-      return 0
+      exitCode = 0
     }
-    return exitCode
+    return {exitCode: exitCode, buffer: buffer.slice(0, tailPos)}
   }
 
-  return defaultCode
+  return {exitCode: defaultCode, buffer: buffer}
 }
 
 // TODO(vojta): read config file (port, host, urlRoot)
@@ -50,8 +49,9 @@ exports.run = function (config, done) {
 
   var request = http.request(options, function (response) {
     response.on('data', function (buffer) {
-      exitCode = parseExitCode(buffer, exitCode, config.failOnEmptyTestSuite)
-      process.stdout.write(buffer)
+      var parsedResult = parseExitCode(buffer, exitCode, config.failOnEmptyTestSuite)
+      exitCode = parsedResult.exitCode
+      process.stdout.write(parsedResult.buffer)
     })
 
     response.on('end', function () {

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -12,23 +12,26 @@ describe('runner', () => {
     var EXIT = constant.EXIT_CODE
 
     it('should return 0 exit code if present in the buffer', () => {
-      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}10`))).to.equal(0)
+      var result = m.parseExitCode(new Buffer(`something\nfake${EXIT}10`))
+      expect(result.exitCode).to.equal(0)
     })
 
-    it('should null the exit code part of the buffer', () => {
+    it('should remove the exit code part of the returned buffer', () => {
       var buffer = new Buffer(`some${EXIT}01`)
-      m.parseExitCode(buffer)
+      var result = m.parseExitCode(buffer)
 
-      expect(buffer.toString()).to.equal('some\0\0\0\0\0\0\0')
+      expect(buffer.toString()).to.equal(`some${EXIT}01`)
+      expect(result.buffer.toString()).to.equal('some')
     })
 
     it('should not touch buffer without exit code and return default', () => {
       var msg = 'some nice \n messgae {}'
       var buffer = new Buffer(msg)
-      var code = m.parseExitCode(buffer, 10)
+      var result = m.parseExitCode(buffer, 10)
 
-      expect(buffer.toString()).to.equal(msg)
-      expect(code).to.equal(10)
+      expect(result.buffer.toString()).to.equal(msg)
+      expect(result.buffer).to.equal(buffer)
+      expect(result.exitCode).to.equal(10)
     })
 
     it('should not slice buffer if smaller than exit code msg', () => {
@@ -40,22 +43,29 @@ describe('runner', () => {
       expect(fakeBuffer.slice).not.to.have.been.called
     })
 
+    it('should return same buffer if smaller than exit code msg', () => {
+      // regression
+      var fakeBuffer = {length: 1, slice: () => null}
+      var result = m.parseExitCode(fakeBuffer, 10)
+      expect(fakeBuffer).to.equal(result.buffer)
+    })
+
     it('should parse any single digit exit code', () => {
-      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}01`))).to.equal(1)
-      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}17`))).to.equal(7)
+      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}01`)).exitCode).to.equal(1)
+      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}17`)).exitCode).to.equal(7)
     })
 
     it('should return exit code 0 if failOnEmptyTestSuite is false and and non-empty int is 0', () => {
-      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}01`), undefined, false)).to.equal(0)
+      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}01`), undefined, false).exitCode).to.equal(0)
     })
 
     it('should return exit code if failOnEmptyTestSuite is true', () => {
-      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}00`), undefined, true)).to.equal(0)
-      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}01`), undefined, true)).to.equal(1)
-      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}07`), undefined, true)).to.equal(7)
-      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}10`), undefined, true)).to.equal(0)
-      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}11`), undefined, true)).to.equal(1)
-      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}17`), undefined, true)).to.equal(7)
+      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}00`), undefined, true).exitCode).to.equal(0)
+      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}01`), undefined, true).exitCode).to.equal(1)
+      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}07`), undefined, true).exitCode).to.equal(7)
+      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}10`), undefined, true).exitCode).to.equal(0)
+      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}11`), undefined, true).exitCode).to.equal(1)
+      expect(m.parseExitCode(new Buffer(`something\nfake${EXIT}17`), undefined, true).exitCode).to.equal(7)
     })
   })
 })


### PR DESCRIPTION
This slices the buffer rather than modifying it. The buffer slice is returned, with the exit code, as an object:

```js
{
  exitCode: int,
  buffer: Buffer
}
```
