### PR TITLE
feat(server): add 'listening' event with port number

### DIFF
--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -40,6 +40,13 @@ server.on('browser_register', function (browser) {
 })
 ```
 
+### `listening`
+**Arguments:**
+
+* `port`: Port number
+
+Begin accepting connections on the specified port.
+
 ### `browser_register`
 **Arguments:**
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -160,6 +160,8 @@ Server.prototype._start = function (config, launcher, preprocess, fileList, webS
       self.log.info('Karma v%s server started at %s//%s:%s%s', constant.VERSION,
         config.protocol, config.hostname, config.port, config.urlRoot)
 
+      self.emit('listening', config.port)
+
       if (config.browsers && config.browsers.length) {
         self._injector.invoke(launcher.launch, launcher).forEach(function (browserLauncher) {
           singleRunDoneBrowsers[browserLauncher.id] = false

--- a/test/unit/server.spec.js
+++ b/test/unit/server.spec.js
@@ -149,6 +149,19 @@ describe('server', () => {
       expect(mockConfig.port).to.be.equal(9877)
     })
 
+    it('should emit a listening event once server begin accepting connections', () => {
+      server._start(mockConfig, mockLauncher, null, mockFileList, mockWebServer, browserCollection, mockSocketServer, mockExecutor, doneSpy)
+
+      var listening = sinon.spy()
+      server.on('listening', listening)
+
+      expect(listening).not.to.have.been.called
+
+      fileListOnResolve()
+
+      expect(listening).to.have.been.calledWith(9876)
+    })
+
     it('should emit a browsers_ready event once all the browsers are captured', () => {
       server._start(mockConfig, mockLauncher, null, mockFileList, mockWebServer, browserCollection, mockSocketServer, mockExecutor, doneSpy)
 


### PR DESCRIPTION
Sometimes, when you want to use karma port programatically (e.g. to send manually browser to karma localhost:<port> address), you face problem with not knowing exact port number.

Port number might be different from one set in config as sometimes you run more than one instances of karma. Below image show such situation:
![Karma port changed](https://www.dropbox.com/s/bga0o4gq4b5hp4k/karma_port.png?dl=1)

This PR adds 'listening' event to karma. After this event you are sure that you have correct karma port number.

You may use it like this:
```
let server = new Server(karmaConfig, done);
server.once('listening', function (e, port) {
    console.log(port); //port number from event
    console.log(server.get('config').port); // also correct value
});
```