### PR TITLE
fix: invalid characters in the headers on Node 5.6.0

### DIFF
--- a/lib/middleware/common.js
+++ b/lib/middleware/common.js
@@ -87,7 +87,7 @@ var createServeFile = function (fs, directory, config) {
 var setNoCacheHeaders = function (response) {
   response.setHeader('Cache-Control', 'no-cache')
   response.setHeader('Pragma', 'no-cache')
-  response.setHeader('Expires', (new Date(0)).toString())
+  response.setHeader('Expires', (new Date(0)).toUTCString())
 }
 
 var setHeavyCacheHeaders = function (response) {

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -250,7 +250,7 @@ describe('middleware.karma', () => {
   })
 
   it('should send non-caching headers for context.html', (done) => {
-    var ZERO_DATE = (new Date(0)).toString()
+    var ZERO_DATE = (new Date(0)).toUTCString()
 
     includedFiles([])
 

--- a/test/unit/middleware/source_files.spec.js
+++ b/test/unit/middleware/source_files.spec.js
@@ -110,7 +110,7 @@ describe('middleware.source_files', function () {
   })
 
   it('should send no-caching headers for js source files without timestamps', function () {
-    var ZERO_DATE = new RegExp(new Date(0).toString().substring(0, 33).replace(/\+/, '\\+'))
+    var ZERO_DATE = new RegExp(new Date(0).toUTCString())
 
     servedFiles([
       new File('/src/some.js')


### PR DESCRIPTION
On Node 5.6.0, Karma stopped working with the following error message: `The header content contains invalid characters`. It's caused by the fact that the dates put by Karma to the `Expires` headers contain the time zone name, which might look like `Thu Jan 01 1970 02:00:00 GMT+0200 (Иксанија)` if a Cyrillic locale is used. While Node <5.6 allowed Cyrillics in the HTTP headers, the version 5.6.0 is much stricter. See the changelog https://github.com/nodejs/node/blob/v5.6.0/CHANGELOG.md