### PR TITLE
chore(dependencies): update bluebird v.3

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -150,7 +150,7 @@ List.prototype._refresh = function () {
   var self = this
   var buckets = this.buckets
 
-  return Promise.all(this._patterns.map(function (patternObject) {
+  var promise = Promise.map(this._patterns, function (patternObject) {
     var pattern = patternObject.pattern
 
     if (helper.isUrlAbsolute(pattern)) {
@@ -167,7 +167,7 @@ List.prototype._refresh = function () {
       return
     }
 
-    return Promise.all(files.map(function (path) {
+    return Promise.map(files, function (path) {
       if (self._isExcluded(path)) {
         log.debug('Excluded file "%s"', path)
         return Promise.resolve()
@@ -185,7 +185,7 @@ List.prototype._refresh = function () {
       return self._preprocess(file).then(function () {
         return file
       })
-    }))
+    })
     .then(function (files) {
       files = _.compact(files)
 
@@ -195,17 +195,17 @@ List.prototype._refresh = function () {
         buckets.set(pattern, new Set(files))
       }
     })
-  }))
-  .cancellable()
+  })
   .then(function () {
+    if (self._refreshing !== promise) {
+      return self._refreshing
+    }
     self.buckets = buckets
     self._emitModified(true)
     return self.files
   })
-  .catch(Promise.CancellationError, function () {
-    // We were canceled so return the resolution of the new run
-    return self._refreshing
-  })
+
+  return promise
 }
 
 // Public Interface
@@ -245,10 +245,6 @@ Object.defineProperty(List.prototype, 'files', {
 // Returns a promise that is resolved when the refresh
 // is completed.
 List.prototype.refresh = function () {
-  if (this._isRefreshing()) {
-    this._refreshing.cancel()
-  }
-
   this._refreshing = this._refresh()
   return this._refreshing
 }

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
   ],
   "dependencies": {
     "batch": "^0.5.3",
-    "bluebird": "^2.9.27",
+    "bluebird": "^3.3.0",
     "body-parser": "^1.12.4",
     "chokidar": "^1.4.1",
     "colors": "^1.1.0",


### PR DESCRIPTION
Fixes #1859 

I can't see that the cancellation is needed in this case as the promise that is cancelled is a runaway promise anyway. 