### PR TITLE
fix(test): Throw the expected exception

### DIFF
--- a/test/unit/reporter.spec.js
+++ b/test/unit/reporter.spec.js
@@ -144,8 +144,8 @@ describe('reporter', () => {
       it('should fall back to non-source-map format if originalPositionFor throws', done => {
         formatError = m.createErrorFormatter('/some/base', emitter, MockSourceMapConsumer)
         var servedFiles = [new File('/some/base/a.js'), new File('/some/base/b.js')]
-        servedFiles[0].sourceMap = 'SOURCE MAP a.js'
-        servedFiles[1].sourceMap = 'SOURCE MAP b.js'
+        servedFiles[0].sourceMap = {content: 'SOURCE MAP a.js'}
+        servedFiles[1].sourceMap = {content: 'SOURCE MAP b.js'}
 
         emitter.emit('file_list_modified', {served: servedFiles})
 


### PR DESCRIPTION
Before, the exception was thrown in MockSourceMapConsumer's
constructor and not in its originalPositionFor() function,
which however was the expected thing to happen.

While this is practice the same behavior, it was misleading when reading the test.