### PR TITLE
fix(reporter): Disable source maps for URLs without line number

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -49,7 +49,7 @@ var createErrorFormatter = function (basePath, emitter, SourceMapConsumer) {
 
       var file = findFile(path)
 
-      if (file && file.sourceMap) {
+      if (file && file.sourceMap && line) {
         line = parseInt(line || '0', 10)
 
         column = parseInt(column, 10)


### PR DESCRIPTION
There is no way to resolve source maps in this case anyway. Fixes #1274.