### PR TITLE
fix(runner): Merge config.client.args with client.args provided by run

### DIFF
--- a/lib/middleware/runner.js
+++ b/lib/middleware/runner.js
@@ -4,6 +4,7 @@
  * It basically triggers a test run and streams stdout back.
  */
 
+var _ = require('lodash')
 var path = require('path')
 var helper = require('../helper')
 var log = require('../logger').create()
@@ -47,8 +48,16 @@ var createRunnerMiddleware = function (emitter, fileList, capturedBrowsers, repo
         })
       })
 
-      log.debug('Setting client.args to ', data.args)
-      config.client.args = data.args
+      if (_.isEmpty(data.args)) {
+        log.debug('Ignoring empty client.args from run command')
+      } else if ((_.isArray(data.args) && _.isArray(config.client.args)) ||
+        (_.isPlainObject(data.args) && _.isPlainObject(config.client.args))) {
+        log.debug('Merging client.args with ', data.args)
+        config.client.args = _.merge(config.client.args, data.args)
+      } else {
+        log.warn('Replacing client.args with ', data.args, ' as their types do not match.')
+        config.client.args = data.args
+      }
 
       var fullRefresh = true
 


### PR DESCRIPTION
Before this change, calling `karma run` would overwrite any value in config.client.args with the value provided in the `karma run` request, even if that value was an empty array. This commit does a _.merge to merge the two values together.

Fixes #1746