### PR TITLE
fix(docs): Fix broken links in documentation

### DIFF
--- a/docs/config/04-preprocessors.md
+++ b/docs/config/04-preprocessors.md
@@ -18,7 +18,7 @@ Note: Most of the preprocessors need to be loaded as [plugins].
 ## Available Preprocessors
 - [coffee]
 - [html2js]
-  - Note any .html files listed in the files section must be referenced at run time as `window.__html__['template.html']`. [Learn more](html2js).
+  - Note any .html files listed in the files section must be referenced at run time as `window.__html__['template.html']`. [Learn more](https://github.com/karma-runner/karma-html2js-preprocessor#how-does-it-work-).
   - If this preprocessor is disabled, included .html files will need `base/` added to beginning of their path reference. See [discussion in issue 788][issue788].
 - [coverage]
 - [ng-html2js]

--- a/docs/dev/01-contributing.md
+++ b/docs/dev/01-contributing.md
@@ -1,7 +1,7 @@
 pageTitle: Contributing to Karma
 
 **Working on your first Pull Request?** You can learn how from this *free* series
-[How to Contribute to an Open Source Project on GitHub](egghead_series)
+[How to Contribute to an Open Source Project on GitHub]
 
 You wanna contribute to Karma? That is truly great!
 Here are some tips to get you started...
@@ -54,4 +54,4 @@ You just do it. There is no test to pass ;-)
 [Stack Overflow]: http://stackoverflow.com/questions/tagged/karma-runner
 [`docs/`]: https://github.com/karma-runner/karma/tree/master/docs
 [Maintaining Karma]: ./maintaining.html
-[egghead_series]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[How to Contribute to an Open Source Project on GitHub]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github


### PR DESCRIPTION
Fix broken links in the documentations at:
- dev\contributing.md
- config\preprocessors.md