### PR TITLE
fix(files): Ignore included:false pattern

### DIFF
--- a/docs/config/02-files.md
+++ b/docs/config/02-files.md
@@ -35,6 +35,17 @@ Each pattern is either a simple string or an object with four properties:
 * **Description.** Should the files be included in the browser using
     `<script>` tag? Use `false` if you want to load them manually, eg.
     using [Require.js](../plus/requirejs.html).
+    
+    If a file is covered by multiple patterns with different `include` properties, the most specific pattern takes
+    precedence over the other.
+    
+    The specificity of the pattern is defined as a six-tuple, where larger tuple implies lesser specificity: 
+    *(n<sub>glob parts</sub>, n<sub>glob star</sub>, n<sub>star</sub>, n<sub>ext glob</sub>, n<sub>range</sub>, n<sub>optional</sub>)*.
+    Tuples are compared lexicographically. 
+    
+    The *n<sub>glob parts</sub>* is the number of patterns after the bracket sections are expanded. E.g. the 
+    the pattern *{0...9}* will yield *n<sub>glob parts</sub>=10*. The rest of the tuple is decided as the least
+    specific of each expanded pattern. 
 
 ### `served`
 * **Type.** Boolean

--- a/lib/config.js
+++ b/lib/config.js
@@ -28,6 +28,11 @@ var Pattern = function (pattern, served, included, watched, nocache) {
   this.included = helper.isDefined(included) ? included : true
   this.watched = helper.isDefined(watched) ? watched : true
   this.nocache = helper.isDefined(nocache) ? nocache : false
+  this.weight = helper.mmPatternWeight(pattern)
+}
+
+Pattern.prototype.compare = function (other) {
+  return helper.mmComparePatternWeights(this.weight, other.weight)
 }
 
 var UrlPattern = function (url) {

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -214,28 +214,38 @@ List.prototype._refresh = function () {
 Object.defineProperty(List.prototype, 'files', {
   get: function () {
     var self = this
+    var uniqueFlat = function (list) {
+      return _.uniq(_.flatten(list), 'path')
+    }
+
+    var expandPattern = function (p) {
+      return from(self.buckets.get(p.pattern) || []).sort(byPath)
+    }
 
     var served = this._patterns.filter(function (pattern) {
       return pattern.served
     })
-    .map(function (p) {
-      return from(self.buckets.get(p.pattern) || []).sort(byPath)
-    })
+    .map(expandPattern)
 
-    var included = this._patterns.filter(function (pattern) {
-      return pattern.included
+    var lookup = {}
+    var included = {}
+    this._patterns.forEach(function (p) {
+      var bucket = expandPattern(p)
+      bucket.forEach(function (file) {
+        var other = lookup[file.path]
+        if (other && other.compare(p) < 0) return
+        lookup[file.path] = p
+        if (p.included) {
+          included[file.path] = file
+        } else {
+          delete included[file.path]
+        }
+      })
     })
-    .map(function (p) {
-      return from(self.buckets.get(p.pattern) || []).sort(byPath)
-    })
-
-    var uniqFlat = function (list) {
-      return _.uniq(_.flatten(list), 'path')
-    }
 
     return {
-      served: uniqFlat(served),
-      included: uniqFlat(included)
+      served: uniqueFlat(served),
+      included: _.values(included)
     }
   }
 })

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -3,6 +3,7 @@ var path = require('path')
 var _ = require('lodash')
 var useragent = require('useragent')
 var Promise = require('bluebird')
+var mm = require('minimatch')
 
 exports.browserFullNameToShort = function (fullName) {
   var agent = useragent.parse(fullName)
@@ -12,6 +13,67 @@ exports.browserFullNameToShort = function (fullName) {
 
 exports.isDefined = function (value) {
   return !_.isUndefined(value)
+}
+var parser = function (pattern, out) {
+  if (pattern.length === 0) return out
+  var p = /^(\[[^\]]*\]|[\*\+@\?]\((.+?)\))/g
+  var matches = p.exec(pattern)
+  if (!matches) {
+    var c = pattern[0]
+    var t = 'word'
+    if (c === '*') {
+      t = 'star'
+    } else if (c === '?') {
+      t = 'optional'
+    }
+    out[t]++
+    return parser(pattern.substring(1), out)
+  }
+  if (matches[2] !== undefined) {
+    out.ext_glob++
+    parser(matches[2], out)
+    return parser(pattern.substring(matches[0].length), out)
+  }
+  out.range++
+  return parser(pattern.substring(matches[0].length), out)
+}
+
+var gs_parser = function (pattern, out) {
+  if (pattern === '**') {
+    out.glob_star++
+    return out
+  }
+  return parser(pattern, out)
+}
+
+var compare_weight_object = function (w1, w2) {
+  return exports.mmComparePatternWeights(
+    [w1.glob_star, w1.star, w1.ext_glob, w1.range, w1.optional],
+    [w2.glob_star, w2.star, w2.ext_glob, w2.range, w2.optional]
+  )
+}
+
+exports.mmPatternWeight = function (pattern) {
+  var m = new mm.Minimatch(pattern)
+  if (!m.globParts) return [0, 0, 0, 0, 0, 0]
+  var result = m.globParts.reduce(function (prev, p) {
+    var r = p.reduce(function (prev, p) {
+      return gs_parser(p, prev)
+    }, {glob_star: 0, ext_glob: 0, word: 0, star: 0, optional: 0, range: 0})
+    if (prev === undefined) return r
+    return compare_weight_object(r, prev) > 0 ? r : prev
+  }, undefined)
+  result.glob_sets = m.set.length
+  return [result.glob_sets, result.glob_star, result.star, result.ext_glob, result.range, result.optional]
+}
+
+exports.mmComparePatternWeights = function (weight1, weight2) {
+  var n1, n2, diff
+  n1 = weight1[0]
+  n2 = weight2[0]
+  diff = n1 - n2
+  if (diff !== 0) return diff / Math.abs(diff)
+  return weight1.length > 1 ? exports.mmComparePatternWeights(weight1.slice(1), weight2.slice(1)) : 0
 }
 
 exports.isFunction = _.isFunction

--- a/test/e2e/files.feature
+++ b/test/e2e/files.feature
@@ -1,0 +1,153 @@
+Feature: Including files
+  In order to use Karma
+  As a person who wants to write great tests
+  I want to be able to include and exclude files
+
+  Scenario: Execute a test excluding a file
+    Given a configuration with:
+      """
+      files = [
+        {pattern: 'files/log_foo.js', included: false},
+        'files/*.js'
+       ];
+      browsers = ['PhantomJS'];
+      plugins = [
+        'karma-jasmine',
+        'karma-phantomjs-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      PhantomJS
+      """
+
+  Scenario: Execute a test excluding an explicitly included file
+    Given a configuration with:
+      """
+      files = [
+        {pattern: 'files/log_foo.js', included: true},
+        {pattern: 'files/log_foo.js', included: false},
+        'files/*.js'
+       ];
+      browsers = ['PhantomJS'];
+      plugins = [
+        'karma-jasmine',
+        'karma-phantomjs-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      PhantomJS
+      """
+
+  Scenario: Execute a test excluding an explicitly included file in another order
+    Given a configuration with:
+      """
+      files = [
+        'files/*.js',
+        {pattern: 'files/log_foo.js', included: true},
+        {pattern: 'files/log_foo.js', included: false}
+       ];
+      browsers = ['PhantomJS'];
+      plugins = [
+        'karma-jasmine',
+        'karma-phantomjs-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      PhantomJS
+      """
+
+  Scenario: Execute a test excluding an file included with brackets patterns
+    Given a configuration with:
+      """
+      files = [
+        'files/test.js',
+        {pattern: 'files/log_foo.js', included: false},
+        {pattern: 'files/{log,bug}_foo.js', included: true}
+       ];
+      browsers = ['PhantomJS'];
+      plugins = [
+        'karma-jasmine',
+        'karma-phantomjs-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      PhantomJS
+      """
+
+  Scenario: Execute a test excluding an file included with wildcard
+    Given a configuration with:
+      """
+      files = [
+        'files/test.js',
+        {pattern: 'files/+(log|bug)_foo.js', included: false},
+        {pattern: 'files/*.js', included: true}
+       ];
+      browsers = ['PhantomJS'];
+      plugins = [
+        'karma-jasmine',
+        'karma-phantomjs-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      PhantomJS
+      """
+
+  Scenario: Execute a test excluding an file included with glob-star
+    Given a configuration with:
+      """
+      files = [
+        'files/test.js',
+        {pattern: 'files/*.js', included: false},
+        {pattern: 'files/**', included: true}
+       ];
+      browsers = ['PhantomJS'];
+      plugins = [
+        'karma-jasmine',
+        'karma-phantomjs-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      PhantomJS
+      """
+
+
+  Scenario: Execute a test excluding an file included with ext. glob patterns
+    Given a configuration with:
+      """
+      files = [
+        'files/test.js',
+        {pattern: 'files/+(log|bug)_foo.js', included: false},
+        {pattern: 'files/{log,bug}_foo.js', included: true}
+
+       ];
+      browsers = ['PhantomJS'];
+      plugins = [
+        'karma-jasmine',
+        'karma-phantomjs-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      PhantomJS
+      """
+

--- a/test/e2e/support/files/log_foo.js
+++ b/test/e2e/support/files/log_foo.js
@@ -1,0 +1,2 @@
+
+console.log('foo')

--- a/test/e2e/support/files/test.js
+++ b/test/e2e/support/files/test.js
@@ -1,0 +1,5 @@
+describe('plus', function () {
+  it('should pass', function () {
+    expect(true).toBe(true)
+  })
+})

--- a/test/unit/helper.spec.js
+++ b/test/unit/helper.spec.js
@@ -12,7 +12,7 @@ describe('helper', () => {
         'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 ' +
         '(KHTML, like Gecko) Version/6.0 Mobile/10A403 Safari/8536.25'
       )
-      .to.be.equal('Mobile Safari 6.0.0 (iOS 6.0.0)')
+        .to.be.equal('Mobile Safari 6.0.0 (iOS 6.0.0)')
     })
 
     it('should parse Linux', () => {
@@ -20,7 +20,7 @@ describe('helper', () => {
         'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1.19) Gecko/20081216 ' +
         'Ubuntu/8.04 (hardy) Firefox/2.0.0.19'
       )
-      .to.be.equal('Firefox 2.0.0 (Ubuntu 8.04.0)')
+        .to.be.equal('Firefox 2.0.0 (Ubuntu 8.04.0)')
     })
 
     it('should degrade gracefully when OS not recognized', () => {
@@ -35,13 +35,13 @@ describe('helper', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/535.7 ' +
         '(KHTML, like Gecko) Chrome/16.0.912.63 Safari/535.7'
       )
-      .to.be.equal('Chrome 16.0.912 (Mac OS X 10.6.8)')
+        .to.be.equal('Chrome 16.0.912 (Mac OS X 10.6.8)')
 
       expecting(
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/535.15 ' +
         '(KHTML, like Gecko) Chrome/18.0.985.0 Safari/535.15'
       )
-      .to.be.equal('Chrome 18.0.985 (Mac OS X 10.6.8)')
+        .to.be.equal('Chrome 18.0.985 (Mac OS X 10.6.8)')
     })
 
     it('should parse Firefox', () => {
@@ -49,7 +49,7 @@ describe('helper', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:7.0.1) Gecko/20100101 ' +
         'Firefox/7.0.1'
       )
-      .to.be.equal('Firefox 7.0.1 (Mac OS X 10.6.0)')
+        .to.be.equal('Firefox 7.0.1 (Mac OS X 10.6.0)')
     })
 
     it('should parse Opera', () => {
@@ -57,7 +57,7 @@ describe('helper', () => {
         'Opera/9.80 (Macintosh; Intel Mac OS X 10.6.8; U; en) Presto/2.9.168 ' +
         'Version/11.52'
       )
-      .to.be.equal('Opera 11.52.0 (Mac OS X 10.6.8)')
+        .to.be.equal('Opera 11.52.0 (Mac OS X 10.6.8)')
     })
 
     it('should parse Safari', () => {
@@ -65,7 +65,7 @@ describe('helper', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.52.7 ' +
         '(KHTML, like Gecko) Version/5.1.2 Safari/534.52.7'
       )
-      .to.be.equal('Safari 5.1.2 (Mac OS X 10.6.8)')
+        .to.be.equal('Safari 5.1.2 (Mac OS X 10.6.8)')
     })
 
     it('should parse IE7', () => {
@@ -73,7 +73,7 @@ describe('helper', () => {
         'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; WOW64; SLCC1; ' +
         '.NET CLR 2.0.50727; .NET4.0C; .NET4.0E)'
       )
-      .to.be.equal('IE 7.0.0 (Windows Vista 0.0.0)')
+        .to.be.equal('IE 7.0.0 (Windows Vista 0.0.0)')
     })
 
     it('should parse IE8', () => {
@@ -81,7 +81,7 @@ describe('helper', () => {
         'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; ' +
         'SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E; InfoPath.3)"'
       )
-      .to.be.equal('IE 8.0.0 (Windows 7 0.0.0)')
+        .to.be.equal('IE 8.0.0 (Windows 7 0.0.0)')
     })
 
     it('should parse IE9', () => {
@@ -89,7 +89,7 @@ describe('helper', () => {
         'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0; ' +
         '.NET CLR 2.0.50727; SLCC2; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)'
       )
-      .to.be.equal('IE 9.0.0 (Windows 7 0.0.0)')
+        .to.be.equal('IE 9.0.0 (Windows 7 0.0.0)')
     })
 
     it('should parse IE10', () => {
@@ -97,7 +97,7 @@ describe('helper', () => {
         'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0; ' +
         '.NET4.0E; .NET4.0C)'
       )
-      .to.be.equal('IE 10.0.0 (Windows 8 0.0.0)')
+        .to.be.equal('IE 10.0.0 (Windows 8 0.0.0)')
     })
 
     it('should parse PhantomJS', () => {
@@ -105,7 +105,7 @@ describe('helper', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/534.34 (KHTML, like Gecko) ' +
         'PhantomJS/1.6.0 Safari/534.34'
       )
-      .to.be.equal('PhantomJS 1.6.0 (Mac OS X 0.0.0)')
+        .to.be.equal('PhantomJS 1.6.0 (Mac OS X 0.0.0)')
     })
 
     // Fix for #318
@@ -114,7 +114,7 @@ describe('helper', () => {
         'Mozilla/5.0 (Linux; U; Android 4.2; en-us; sdk Build/JB_MR1) ' +
         'AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
       )
-      .to.be.equal('Android 4.2.0 (Android 4.2.0)')
+        .to.be.equal('Android 4.2.0 (Android 4.2.0)')
     })
   })
 
@@ -243,6 +243,68 @@ describe('helper', () => {
         expect(stat.isDirectory()).to.equal(true)
         done()
       })
+    })
+  })
+
+  describe('mmComparePatternWeights', () => {
+    var helper = require('../../lib/helper')
+    it('should compare right on equal', () => {
+      helper.mmComparePatternWeights([1, 2, 3], [1, 2, 3]).should.be.equal(0)
+    })
+
+    it('should compare right on less', () => {
+      helper.mmComparePatternWeights([1, 2, 3], [1, 2, 5]).should.be.equal(-1)
+    })
+
+    it('should compare right on greater than', () => {
+      helper.mmComparePatternWeights([1, 3, 3], [1, 2, 5]).should.be.equal(1)
+    })
+
+    it('should compare right on larger size', () => {
+      helper.mmComparePatternWeights([1, 2, 3, 4], [1, 2, 3, 4]).should.be.equal(0)
+    })
+  })
+
+  describe('mmPatternWeight', () => {
+    var helper = require('../../lib/helper')
+    it('should calculate right weight of empty', () => {
+      helper.mmPatternWeight('').should.be.deep.equal([0, 0, 0, 0, 0, 0])
+    })
+    it('should calculate right weight of pattern with no magic', () => {
+      helper.mmPatternWeight('foo').should.be.deep.equal([1, 0, 0, 0, 0, 0])
+    })
+    it('should calculate right weight of pattern with optional', () => {
+      helper.mmPatternWeight('foo?').should.be.deep.equal([1, 0, 0, 0, 0, 1])
+    })
+    it('should calculate right weight of pattern with range', () => {
+      helper.mmPatternWeight('[fo]').should.be.deep.equal([1, 0, 0, 0, 1, 0])
+    })
+    it('should calculate right weight of pattern with glob sets', () => {
+      helper.mmPatternWeight('{0..9}').should.be.deep.equal([10, 0, 0, 0, 0, 0])
+    })
+    it('should calculate right weight of pattern with two glob sets', () => {
+      helper.mmPatternWeight('{a,b}').should.be.deep.equal([2, 0, 0, 0, 0, 0])
+    })
+    it('should calculate right weight of pattern with ext glob', () => {
+      helper.mmPatternWeight('+(a|b)').should.be.deep.equal([1, 0, 0, 1, 0, 0])
+    })
+    it('should calculate right weight of pattern with ext glob misuse', () => {
+      helper.mmPatternWeight('(a|b)').should.be.deep.equal([1, 0, 0, 0, 0, 0])
+    })
+    it('should calculate right weight of pattern with star', () => {
+      helper.mmPatternWeight('*').should.be.deep.equal([1, 0, 1, 0, 0, 0])
+    })
+    it('should calculate right weight of pattern with glob star', () => {
+      helper.mmPatternWeight('**/a').should.be.deep.equal([1, 1, 0, 0, 0, 0])
+    })
+    it('should calculate right weight of pattern with misused glob star', () => {
+      helper.mmPatternWeight('***/a').should.be.deep.equal([1, 0, 3, 0, 0, 0])
+    })
+    it('should calculate right weight of pattern with more magic', () => {
+      helper.mmPatternWeight('{0..9}/?(a|b)c/[abc]/**/*.jsx?').should.be.deep.equal([10, 1, 1, 1, 1, 1])
+    })
+    it('should calculate right weight of pattern as worst glob set', () => {
+      helper.mmPatternWeight('{**,*}').should.be.deep.equal([2, 1, 0, 0, 0, 0])
     })
   })
 })


### PR DESCRIPTION
Do not include a file, when `include=false`.
Give `include=false` precedence over `include=true`.

Closes #1530