### PR TITLE
feat(config): Add configuration for adding javascript version.

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -610,6 +610,18 @@ All of Karma's urls get prefixed with the `urlRoot`. This is helpful when using 
 sometimes you might want to proxy a url that is already taken by Karma.
 
 
+## jsVersion
+**Type:** Number
+
+**Default:** `0`
+
+**Description:** The JavaScript version to use in the Firefox browser.
+
+If `> 0`, Karma will add a JavaScript version tag to the included JavaScript files.
+
+Note: This will only be applied to the Firefox browser. It is currently the only browser that supports the version tag.
+
+
 [plugins]: plugins.html
 [config/files]: files.html
 [config/browsers]: browsers.html

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -14,6 +14,7 @@
 var path = require('path')
 var util = require('util')
 var url = require('url')
+var useragent = require('useragent')
 
 var log = require('../logger').create('middleware:karma')
 
@@ -61,6 +62,17 @@ var getXUACompatibleUrl = function (url) {
   return value
 }
 
+var isFirefox = function (req) {
+  if (!(req && req.headers)) {
+    return false
+  }
+
+  // Browser check
+  var firefox = useragent.is(req.headers['user-agent']).firefox
+
+  return firefox
+}
+
 var createKarmaMiddleware = function (
   filesPromise,
   serveStaticFile,
@@ -74,6 +86,7 @@ var createKarmaMiddleware = function (
     var client = injector.get('config.client')
     var customContextFile = injector.get('config.customContextFile')
     var customDebugFile = injector.get('config.customDebugFile')
+    var jsVersion = injector.get('config.jsVersion')
 
     var requestUrl = request.normalizedUrl.replace(/\?.*/, '')
 
@@ -160,7 +173,15 @@ var createKarmaMiddleware = function (
               return util.format(LINK_TAG_HTML, filePath)
             }
 
-            return util.format(SCRIPT_TAG, SCRIPT_TYPE[fileExt] || 'text/javascript', filePath)
+            // The script tag to be placed
+            var scriptType = (SCRIPT_TYPE[fileExt] || 'text/javascript')
+
+            // In case there is a JavaScript version specified and this is a Firefox browser
+            if (jsVersion && jsVersion > 0 && isFirefox(request)) {
+              scriptType += ';version=' + jsVersion
+            }
+
+            return util.format(SCRIPT_TAG, scriptType, filePath)
           })
 
           // TODO(vojta): don't compute if it's not in the template

--- a/test/client/karma.conf.js
+++ b/test/client/karma.conf.js
@@ -156,6 +156,8 @@ module.exports = function (config) {
 
     forceJSONP: true,
 
+    jsVersion: 0,
+
     browserStack: {
       project: 'Karma'
     }

--- a/test/e2e/support/tag/tag.js
+++ b/test/e2e/support/tag/tag.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-unused-vars */
+var isFirefox = function () {
+  return typeof InstallTrigger !== 'undefined'
+}
+
+var containsJsTag = function () {
+  var scripts = document.getElementsByTagName('script')
+  for (var i = 0; i < scripts.length; i++) {
+    if (scripts[i].type.indexOf(';version=') > -1) {
+      return true
+    }
+  }
+  return false
+}

--- a/test/e2e/support/tag/test-with-version.js
+++ b/test/e2e/support/tag/test-with-version.js
@@ -1,0 +1,6 @@
+/* globals containsJsTag, isFirefox */
+describe('JavaScript version tag', function () {
+  it('should add the version tag, if Firefox is used', function () {
+    expect(containsJsTag()).toBe(isFirefox())
+  })
+})

--- a/test/e2e/support/tag/test-without-version.js
+++ b/test/e2e/support/tag/test-without-version.js
@@ -1,0 +1,6 @@
+/* globals containsJsTag */
+describe('JavaScript version tag', function () {
+  it('should not add the version tag for every browser', function () {
+    expect(containsJsTag()).toBe(false)
+  })
+})

--- a/test/e2e/tag.feature
+++ b/test/e2e/tag.feature
@@ -1,0 +1,75 @@
+Feature: JavaScript Tag
+  In order to use Karma
+  As a person who wants to write great tests
+  I want to add a JavaScript version tag in Firefox only.
+
+  Scenario: Execute a test in Firefox with version, with JavaScript tag
+    Given a configuration with:
+      """
+      files = ['tag/tag.js', 'tag/test-with-version.js'];
+      browsers = ['Firefox']
+      jsVersion = 1.8
+      plugins = [
+        'karma-jasmine',
+        'karma-firefox-launcher'
+      ]
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      Firefox
+      """
+  @not-jenkins
+  Scenario: Execute a test in Chrome with version, without JavaScript tag
+    Given a configuration with:
+      """
+      files = ['tag/tag.js', 'tag/test-with-version.js'];
+      browsers = ['Chrome'];
+      jsVersion = 1.8;
+      plugins = [
+        'karma-jasmine',
+        'karma-chrome-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      Chrome
+      """
+
+  Scenario: Execute a test in Firefox without version, without JavaScript tag
+    Given a configuration with:
+      """
+      files = ['tag/tag.js', 'tag/test-without-version.js'];
+      browsers = ['Firefox']
+      plugins = [
+        'karma-jasmine',
+        'karma-firefox-launcher'
+      ]
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      Firefox
+      """
+  @not-jenkins
+  Scenario: Execute a test in Chrome without version, without JavaScript tag
+    Given a configuration with:
+      """
+      files = ['tag/tag.js', 'tag/test-without-version.js'];
+      browsers = ['Chrome'];
+      plugins = [
+        'karma-jasmine',
+        'karma-chrome-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      Chrome
+      """
+      


### PR DESCRIPTION
Add the configuration to add a javascript version tag to the loaded scripts. Only applied when the Firefox browser is run.

Closes #1719.