### PR TITLE
Added commit message validation to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
   - SAUCE_USERNAME: karmarunnerbot
   - secure: "bRVY+hYZwMf1SqVnMyZRJTLD0gN1hLx9/MwO8MM/qBiu3YNjXy49XElfMdzMKN6cZeKTmhcnjmZonbJuI1PQ2t+utGkyjnlVLJ/OlWptreKLzIlcbt4hrdPoTcjmUTwDWq9Ex9cVoYX8AzCasETttpczp3P+s3+vmOUj8z25JyU="
   - CXX=g++-4.8
+  include:
+  - node_js: "5"
+    env: VALIDATE_COMMIT_MSG=TRUE
 
 # Make sure we have a new npm on Node 0.10. npm >= 2 should work so by not updating them
 # here we have proper version coverage, especially that most people use the npm version
@@ -36,4 +39,4 @@ before_script:
   - export $(openssl aes-256-cbc -pass env:CREDENTIALS_PASS -d -in credentials)
 
 script:
-  - npm run travis
+  - 'if [ "${VALIDATE_COMMIT_MSG}" != "TRUE" ]; then npm run travis; else ./scripts/validate-commit-msg.sh "${TRAVIS_COMMIT}"; fi'

--- a/scripts/validate-commit-msg.sh
+++ b/scripts/validate-commit-msg.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Validate commit message matches our expected format
+#
+# Arguments:
+#   <commit> Commit revision to validate
+#
+# Example:
+# ./validate-commit-msg.sh abcdef0
+
+# Exit on first error
+set -e
+
+# If we didn't receive a commit, then error out
+# DEV: If want the HEAD commit, then use `git rev-parse HEAD`
+COMMIT_REV="$1"
+if [ -z "$COMMIT_REV" ]; then
+  echo "Expected a commit revision to validate but received nothing" 1>&2
+  exit 1
+fi
+
+# Resolve our file for output
+# DEV: We use `.git` to avoid cluttering the working directory
+GIT_DIR="$(git rev-parse --git-dir)"
+TARGET_FILE="$GIT_DIR/VALIDATE_COMMIT_MSG"
+
+# Output our log message to a file
+# DEV: We use `--no-merges` to skip merge commits introduced by GitHub
+git log --no-merges --format=format:"%s" -n 1 "$COMMIT_REV" > "$TARGET_FILE"
+
+# Validate our message
+./node_modules/.bin/validate-commit-msg "$TARGET_FILE"


### PR DESCRIPTION
When working on a repo, I like to commit frequently in a working branch. The `ghooks` were getting on my nerves so I removed them.

However, I have realized that I was able to open #1984 with a bad commit message format as a result. To remedy that, I'm adding the commit message validation to Travis CI.

In this PR:

- Added `validate-commit-msg` to `npm run travis` to enable non-local message validation