### PR TITLE
fix(helper): Patched replaceWinPath from choking on `null` values

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -131,7 +131,7 @@ exports.formatTimeInterval = function (time) {
 }
 
 var replaceWinPath = function (path) {
-  return exports.isDefined(path) ? path.replace(/\\/g, '/') : path
+  return _.isString(path) ? path.replace(/\\/g, '/') : path
 }
 
 exports.normalizeWinPath = process.platform === 'win32' ? replaceWinPath : _.identity


### PR DESCRIPTION
As reported in #2000, the current `master` is failing on Windows due to `customContextFile` being `null`. In this PR:

- Updated `replaceWinPath` to check for value being a string rather than not being undefined
- Fixes #2000

Here's AppVeyor failing on the current `master` and passing with our patched branch:

https://ci.appveyor.com/project/twolfson/karma-electron-launcher/build/94/job/dpsv7d5nv0sxcj6a

https://ci.appveyor.com/project/twolfson/karma-electron-launcher/build/95/job/vjt895wok3qwgvo3
