### PR TITLE
Repaired AppVeyor for Node.js@0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -367,8 +367,10 @@
     "build": "grunt build",
     "test:appveyor": "grunt test-appveyor",
     "test:integration": "./scripts/integration-tests.sh",
+    "link": "node --eval \"path=require('path'); require('fs').symlinkSync(path.resolve(__dirname), path.resolve(__dirname, 'node_modules', 'karma'), 'junction')\"",
+    "unlink": "node --eval \"require('fs').unlinkSync(require('path').resolve(__dirname, 'node_modules', 'karma'))\"",
     "init": "rm -rf node_modules/karma && cd node_modules && ln -nsf ../ karma && cd ../",
-    "init:windows": "cd .. && xcopy karma __karma /E /I && move /Y __karma karma\\node_modules\\karma && cd karma",
+    "init:windows": "(IF EXIST node_modules\\karma (rmdir node_modules\\karma /S /q)) && npm run link",
     "appveyor": "npm run lint && npm run build && npm run test:appveyor",
     "travis": "npm run lint && npm run build && npm test && npm run test:integration"
   },


### PR DESCRIPTION
As explained in #2002, we thought Node.js@0.12 wouldn't have issues since we had Node.js@5.0 running. Unfortunately, our `xcopy` methodology was space intensive and didn't work for `npm@2` (which is what Node.js@0.12 uses).

We got this repaired via an `npm` upgrade but found out that our previous attempt at symlinks was invalid. Now that we got it working, it's a much better approach than `xcopy`. In this PR:

- Moved from `xcopy` to symlinks for `node_modules/karma`
- Repairs failing AppVeyor builds on `master`

**Passing builds:**

https://ci.appveyor.com/project/twolfson/karma/build/31