### PR TITLE
Added '--' to no-single-run documentation

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -580,7 +580,7 @@ a browser before giving up.
 
 **Default:** `false`
 
-**CLI:** `--single-run`, `no-single-run`
+**CLI:** `--single-run`, `--no-single-run`
 
 **Description:** Continuous Integration mode.
 


### PR DESCRIPTION
In the configuration docs "no-single-run" was missing the "--" before it. This PR adds it.