### PR TITLE
docs: Add '--' to 'no-single-run' documentation

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -580,7 +580,7 @@ a browser before giving up.
 
 **Default:** `false`
 
-**CLI:** `--single-run`, `no-single-run`
+**CLI:** `--single-run`, `--no-single-run`
 
 **Description:** Continuous Integration mode.
 


### PR DESCRIPTION
Before this change, the documentation for singleRun stated that the CLI
commands were "--single-run, no-single-run". "no-single-run" requires
the double dash in order be used.  This commit adds the "--" prefix.