### PR TITLE
refactor(context): Future-proofed context.html and debug.html for modularity

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -76,6 +76,8 @@ module.exports = function (grunt) {
         '<%= files.grunt %>',
         '<%= files.scripts %>',
         '<%= files.client %>',
+        'static/context.js',
+        'static/debug.js',
         'test/**/*.js',
         'gruntfile.js'
       ]

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -114,8 +114,10 @@ var createKarmaMiddleware = function (
       })
     }
 
-    // serve karma.js
-    if (requestUrl === '/karma.js') {
+    // serve karma.js, context.js, and debug.js
+    var jsFiles = ['/karma.js', '/context.js', '/debug.js']
+    var isRequestingJsFile = jsFiles.indexOf(requestUrl) !== -1
+    if (isRequestingJsFile) {
       return serveStaticFile(requestUrl, response, function (data) {
         return data.replace('%KARMA_URL_ROOT%', urlRoot)
           .replace('%KARMA_VERSION%', VERSION)
@@ -195,11 +197,7 @@ var createKarmaMiddleware = function (
             return util.format("  '%s': '%s'", filePath, file.sha)
           })
 
-          var clientConfig = ''
-
-          if (requestUrl === '/debug.html') {
-            clientConfig = 'window.__karma__.config = ' + JSON.stringify(client) + ';\n'
-          }
+          var clientConfig = 'window.__karma__.config = ' + JSON.stringify(client) + ';\n'
 
           mappings = 'window.__karma__.files = {\n' + mappings.join(',\n') + '\n};\n'
 

--- a/static/context.html
+++ b/static/context.html
@@ -15,14 +15,11 @@ Reloaded before every execution run.
        to have already been created so they can insert their magic into it. For example, if loaded
        before body, Angular Scenario test framework fails to find the body and crashes and burns in
        an epic manner. -->
+  <script src="context.js"></script>
   <script type="text/javascript">
-    // sets window.__karma__ and overrides console and error handling
-    // Use window.opener if this was opened by someone else - in a new window
-    if (window.opener) {
-      window.opener.karma.setupContext(window);
-    } else {
-      window.parent.karma.setupContext(window);
-    }
+    // Configure our Karma and set up bindings
+    %CLIENT_CONFIG%
+    window.__karma__.setupContext(window);
 
     // All served files with the latest timestamps
     %MAPPINGS%

--- a/static/context.js
+++ b/static/context.js
@@ -1,0 +1,13 @@
+// Define a placeholder for Karma to be defined via the parent window
+// DEV: This is a placeholder change for upcoming edits in https://github.com/karma-runner/karma/pull/1984
+window.__karma__ = {
+  setupContext: function (contextWindow) {
+    // sets window.__karma__ and overrides console and error handling
+    // Use window.opener if this was opened by someone else - in a new window
+    if (contextWindow.opener) {
+      contextWindow.opener.karma.setupContext(contextWindow)
+    } else {
+      contextWindow.parent.karma.setupContext(contextWindow)
+    }
+  }
+}

--- a/static/debug.html
+++ b/static/debug.html
@@ -17,38 +17,10 @@ just for immediate execution, without reporting to Karma server.
    (Angular Scenario, for example) need the body to be loaded so that it can insert its magic
    into it. If it is before body, then it fails to find the body and crashes and burns in an epic
    manner. -->
+  <script src="context.js"></script>
+  <script src="debug.js"></script>
   <script type="text/javascript">
-    window.__karma__ = {
-      info: function(info) {
-        if (info.dump && window.console) window.console.log(info.dump);
-      },
-      complete: function() {
-        if (window.console) window.console.log('Skipped ' + this.skipped + ' tests');
-      },
-      store: function() {},
-      skipped: 0,
-      result: window.console ? function(result) {
-        if (result.skipped) {
-          this.skipped++;
-          return;
-        }
-        var msg = result.success ? 'SUCCESS ' : 'FAILED ';
-        window.console.log(msg + result.suite.join(' ') + ' ' + result.description);
-
-        for (var i = 0; i < result.log.length; i++) {
-          //throwing error without loosing stack trace
-          (function (err) {
-            setTimeout(function() {
-              throw err;
-            });
-          })(result.log[i])
-        }
-      } : function() {},
-      loaded: function() {
-        this.start();
-      }
-    };
-
+    // Configure our Karma
     %CLIENT_CONFIG%
 
     // All served files with the latest timestamps

--- a/static/debug.js
+++ b/static/debug.js
@@ -1,0 +1,29 @@
+// Override the Karma setup for local debugging
+window.__karma__.info = function (info) {
+  if (info.dump && window.console) window.console.log(info.dump)
+}
+window.__karma__.complete = function () {
+  if (window.console) window.console.log('Skipped ' + this.skipped + ' tests')
+}
+window.__karma__.store = function () {}
+window.__karma__.skipped = 0
+window.__karma__.result = window.console ? function (result) {
+  if (result.skipped) {
+    this.skipped++
+    return
+  }
+  var msg = result.success ? 'SUCCESS ' : 'FAILED '
+  window.console.log(msg + result.suite.join(' ') + ' ' + result.description)
+
+  for (var i = 0; i < result.log.length; i++) {
+    // Throwing error without losing stack trace
+    (function (err) {
+      setTimeout(function () {
+        throw err
+      })
+    })(result.log[i])
+  }
+} : function () {}
+window.__karma__.loaded = function () {
+  this.start()
+}

--- a/test/e2e/support/context/context2.html
+++ b/test/e2e/support/context/context2.html
@@ -16,14 +16,11 @@ Reloaded before every execution run.
        before body, Angular Scenario test framework fails to find the body and crashes and burns in
        an epic manner. -->
   <div id="custom-context"></div>
+  <script src="context.js"></script>
   <script type="text/javascript">
-    // sets window.__karma__ and overrides console and error handling
-    // Use window.opener if this was opened by someone else - in a new window
-    if (window.opener) {
-      window.opener.karma.setupContext(window);
-    } else {
-      window.parent.karma.setupContext(window);
-    }
+    // Configure our Karma and set up bindings
+    %CLIENT_CONFIG%
+    window.__karma__.setupContext(window);
 
     // All served files with the latest timestamps
     %MAPPINGS%


### PR DESCRIPTION
In #1984, we will update `context.html` and `debug.html` to centralize the majority Karma's and their logic into scripts. In the next Karma release, we are planning on adding `customContextFile` and `customDebugFile`. Since any existing custom context files would be incompatible with this centralization, it would be a breaking change.

To avoid the breaking change/another major release, we want to future-proof `context.html` and `debug.html`. In this PR:

- Relocated `window.opener`/`window.parent` logic for `context.html` into `context.js`
- Relocated `window.__karma__` definitions in `debug.html` to `context-debug.html`
- Updated `debug.html's JS` to be override on `window.__karma__` rather than define it
    - This will give us leverage if we want something like `window.__karma__.stringify` to be defined without needing to compile a new `context-debug.js`

**Screenshot of debug.html working:**

![selection_012](https://cloud.githubusercontent.com/assets/902488/14026538/494c4850-f1c1-11e5-8fdd-47fd58956bde.png)
