### PR TITLE
Fixes code block rendering issue in contributing file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,18 +310,21 @@
 
 #### Breaking Changes
 
-* The public api interface has changed to a constructor form. To upgrade
-  change
-  ```javascript
-  var server = require(‘karma’).server
-  server.start(config, done)
-  ```
+* The public api interface has changed to a constructor form. To upgrade change
+
+    ```javascript
+    var server = require(‘karma’).server
+    server.start(config, done)
+    ```
+
   to
-  ```javascript
-  var Server = require(‘karma’).Server
-  var server = new Server(config, done)
-  server.start()
-  ```
+
+    ```javascript
+    var Server = require(‘karma’).Server
+    var server = new Server(config, done)
+    server.start()
+    ```
+    
   Closes #1037, #1482, #1467
   ([82cbbadd](https://github.com/karma-runner/karma/commit/82cbbadd))
 


### PR DESCRIPTION
Fixes issue in which a code block inside a list was mistakenly rendered inline with the language name visible.

It is currently rendered like this:
<img width="836" alt="before" src="https://cloud.githubusercontent.com/assets/1225929/14589573/78412108-04e5-11e6-9298-8e5c3d06b468.png">

Now it's like this:
<img width="830" alt="after" src="https://cloud.githubusercontent.com/assets/1225929/14589572/783ecbf6-04e5-11e6-83e1-c825513d293e.png">

