### PR TITLE
Allow browserDisconnectTolerance to be set in non-singleRun mode.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -145,11 +145,6 @@ var normalizeConfig = function (config, configFilePath) {
     config.autoWatch = false
   }
 
-  if (!config.singleRun && config.browserDisconnectTolerance) {
-    log.debug('browserDisconnectTolerance set to 0, because of singleRun')
-    config.browserDisconnectTolerance = 0
-  }
-
   if (helper.isString(config.reporters)) {
     config.reporters = config.reporters.split(',')
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -292,26 +292,34 @@ Server.prototype._start = function (config, launcher, preprocess, fileList, webS
     }
   }
 
-  if (config.singleRun) {
-    self.on('browser_complete', function (completedBrowser) {
-      if (completedBrowser.lastResult.disconnected &&
-        completedBrowser.disconnectsCount <= config.browserDisconnectTolerance) {
-        self.log.info('Restarting %s (%d of %d attempts)', completedBrowser.name,
-          completedBrowser.disconnectsCount, config.browserDisconnectTolerance)
-        if (!launcher.restart(completedBrowser.id)) {
-          singleRunDoneBrowsers[completedBrowser.id] = true
-          emitRunCompleteIfAllBrowsersDone()
-        }
-      } else {
-        singleRunDoneBrowsers[completedBrowser.id] = true
+  self.on('browser_complete', function (completedBrowser) {
+    if (completedBrowser.lastResult.disconnected &&
+      completedBrowser.disconnectsCount <= config.browserDisconnectTolerance) {
+      self.log.info('Restarting %s (%d of %d attempts)', completedBrowser.name,
+        completedBrowser.disconnectsCount, config.browserDisconnectTolerance)
 
-        if (launcher.kill(completedBrowser.id)) {
-          // workaround to supress "disconnect" warning
-          completedBrowser.state = Browser.STATE_DISCONNECTED
-        }
-
-        emitRunCompleteIfAllBrowsersDone()
+      if (!launcher.restart(completedBrowser.id)) {
+        self.emit('browser_restart_failure', completedBrowser)
       }
+    } else {
+      self.emit('browser_complete_with_no_more_retries', completedBrowser)
+    }
+  })
+
+  if (config.singleRun) {
+    self.on('browser_restart_failure', function (completedBrowser) {
+      singleRunDoneBrowsers[completedBrowser.id] = true
+      emitRunCompleteIfAllBrowsersDone()
+    })
+    self.on('browser_complete_with_no_more_retries', function (completedBrowser) {
+      singleRunDoneBrowsers[completedBrowser.id] = true
+
+      if (launcher.kill(completedBrowser.id)) {
+        // workaround to supress "disconnect" warning
+        completedBrowser.state = Browser.STATE_DISCONNECTED
+      }
+
+      emitRunCompleteIfAllBrowsersDone()
     })
 
     self.on('browser_process_failure', function (browserLauncher) {


### PR DESCRIPTION
We’re encountering a problem where sometimes Karma just disconnects and stops running tests until we restart Karma manually.

We found that some of our JavaScript code intermittently gets stuck when running tests — that Karma considers it a time out. One such example is an infinite loop in the code.

Looking at other issues (https://github.com/karma-runner/karma/issues/598, https://github.com/karma-runner/karma/issues/1514) suggests adding `browserDisconnectTolerance`. I’ve tried that and several other options to no avail.

From further source code inspection, in 19590e1f66fd6c3b0d3fc9e90000c705198e0e70 it turns out that __`browserDisconnectTolerance` is only active in `singleRun` mode.__ This pull request makes `browserDisconnectTolerance` work in non-singleRun mode.

## Test case

Here’s a test case to verify that my patch works:

### test.js

This test will get stuck in an infinite loop with 75% chance.

```js
describe('example', function () {
  it('ok1', function () { })
  it('ok2', function () { })
  it('bad1', function () {
    if (Math.random() > 0.5) for (;;) ;
  })
  it('bad2', function () {
    if (Math.random() > 0.5) for (;;) ;
  })
  it('ok3', function () { })
})
```

### karma.conf.js

Sets a ridiculously high amount of retries.

```js
module.exports = function (config) {
  config.set({
    basePath: '',
    frameworks: ['mocha'],
    files: [
      'test.js'
    ],
    reporters: [ 'progress' ],
    port: 9988,
    colors: true,
    logLevel: config.LOG_INFO,
    autoWatch: true,
    browsers: [ 'PhantomJS' ],
    browserDisconnectTolerance: 99999999999999999999999999999999999999999999999,
    retryLimit: 999999999999999999999999999999999999999999999999999999999999999,
    plugins: [
      'karma-mocha',
      'karma-phantomjs-launcher',
    ],
    singleRun: false,
  })
}
```
