### PR TITLE
feat: adding support for before middleware

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -459,6 +459,14 @@ mime: {
 ```
 
 
+## beforeMiddleware
+**Type:** Array
+
+**Default:** `[]`
+
+**Description:** This is the same as middleware except that these middleware will be run before karma's own middleware.
+
+
 ## plugins
 **Type:** Array
 

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -57,16 +57,23 @@ var createWebServer = function (injector, emitter, fileList) {
 
   log.debug('Instantiating middleware')
   var handler = connect()
-    .use(injector.invoke(runnerMiddleware.create))
-    .use(injector.invoke(stopperMiddleware.create))
-    .use(injector.invoke(stripHostMiddleware.create))
-    .use(injector.invoke(karmaMiddleware.create))
-    .use(injector.invoke(sourceFilesMiddleware.create))
-    // TODO(vojta): extract the proxy into a plugin
-    .use(proxyMiddlewareInstance)
-    // TODO(vojta): remove, this is only here because of karma-dart
-    // we need a better way of custom handlers
-    .use(injector.invoke(createCustomHandler))
+
+  if (config.beforeMiddleware) {
+    config.beforeMiddleware.forEach(function (middleware) {
+      handler.use(injector.get('middleware:' + middleware))
+    })
+  }
+
+  handler.use(injector.invoke(runnerMiddleware.create))
+  handler.use(injector.invoke(stopperMiddleware.create))
+  handler.use(injector.invoke(stripHostMiddleware.create))
+  handler.use(injector.invoke(karmaMiddleware.create))
+  handler.use(injector.invoke(sourceFilesMiddleware.create))
+  // TODO(vojta): extract the proxy into a plugin
+  handler.use(proxyMiddlewareInstance)
+  // TODO(vojta): remove, this is only here because of karma-dart
+  // we need a better way of custom handlers
+  handler.use(injector.invoke(createCustomHandler))
 
   if (config.middleware) {
     config.middleware.forEach(function (middleware) {


### PR DESCRIPTION
This adds a `beforeMiddleware` option to the config. This allows the user to inject middleware before karma's middleware are ran. My use case is blocking the tests on refresh while the tests are recompiling (to prevent old test files from being served).