### PR TITLE
feat(reporter): improve source map handling and reporting.

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,4 +1,5 @@
 var util = require('util')
+var resolve = require('url').resolve
 var log = require('./logger').create('reporter')
 var MultiReporter = require('./reporters/multi')
 var baseReporterDecoratorFactory = require('./reporters/base').decoratorFactory
@@ -23,7 +24,7 @@ var createErrorFormatter = function (basePath, emitter, SourceMapConsumer) {
   }
 
   var URL_REGEXP = new RegExp('(?:https?:\\/\\/[^\\/]*)?\\/?' +
-    '(base|absolute)' + // prefix
+    '(base/|absolute)' + // prefix, including slash for base/ to create relative paths.
     '((?:[A-z]\\:)?[^\\?\\s\\:]*)' + // path
     '(\\?\\w*)?' + // sha
     '(\\:(\\d+))?' + // line
@@ -53,11 +54,8 @@ var createErrorFormatter = function (basePath, emitter, SourceMapConsumer) {
     // remove domain and timestamp from source files
     // and resolve base path / absolute path urls into absolute path
     var msg = input.replace(URL_REGEXP, function (_, prefix, path, __, ___, line, ____, column) {
-      if (prefix === 'base') {
-        path = basePath + path
-      }
-
-      var file = findFile(path)
+      // Find the file using basePath + path, but use the more readable path down below.
+      var file = findFile(prefix === 'base/' ? basePath + '/' + path : path)
 
       if (file && file.sourceMap && line) {
         line = parseInt(line || '0', 10)
@@ -72,9 +70,12 @@ var createErrorFormatter = function (basePath, emitter, SourceMapConsumer) {
           var original = getSourceMapConsumer(file.sourceMap)
             .originalPositionFor({line: line, column: (column || 0), bias: bias})
 
+          // Source maps often only have a local file name, resolve to turn into a full path if
+          // the path is not absolute yet.
+          var sourcePath = resolve(path, original.source)
           var formattedColumn = column ? util.format(':%s', column) : ''
-          return util.format('%s:%d%s <- %s:%d:%d', path, line, formattedColumn, original.source,
-            original.line, original.column)
+          return util.format('%s:%d:%d <- %s:%d%s', sourcePath, original.line, original.column,
+              path, line, formattedColumn)
         } catch (e) {
           log.warn('SourceMap position not found for trace: %s', msg)
           // Fall back to non-source-mapped formatting.


### PR DESCRIPTION
- Avoid prepending basepath to every file path.
  The original path is usually relative to the project, and much more meaningful
  than basepath + path, which is usually a long, absolute path.
- Format as [mapped location] <- [original location]
  The mapped location is the more important part for users, it's the source
  file they are working on.
- Resolve source map file paths relative to the original file path.
  It's common for tools that generate a source map to not have a complete
  understanding of what paths they should generate, in which case they just use
  the local path. An example tool is TypeScript.
  Resolving the path against the original file path makes these paths
  unambiguous in the project.