### PR TITLE
fix(client): does not throws an error for non DOM object that has `ta…

### DIFF
--- a/client/stringify.js
+++ b/client/stringify.js
@@ -1,5 +1,8 @@
 var serialize = require('dom-serialize')
 var instanceOf = require('./util').instanceOf
+var isNode = function (obj) {
+  return (obj.tagName || obj.nodeName) && obj.nodeType
+}
 
 var stringify = function stringify (obj, depth) {
   if (depth === 0) {
@@ -38,7 +41,7 @@ var stringify = function stringify (obj, depth) {
         return '<!--' + obj.nodeValue + '-->'
       } else if (obj.outerHTML) {
         return obj.outerHTML
-      } else if (obj.tagName || obj.nodeName) {
+      } else if (isNode(obj)) {
         return serialize(obj)
       } else {
         var constructor = 'Object'

--- a/test/client/stringify.spec.js
+++ b/test/client/stringify.spec.js
@@ -89,4 +89,8 @@ describe('stringify', function () {
 
     assert.deepEqual(__karma__.stringify([1, 2]), '[1, 2]')
   })
+
+  it('should stringify object with property tagName as Object', function () {
+    assert(stringify({tagName: 'a'}).indexOf("{tagName: 'a'}") > -1)
+  })
 })


### PR DESCRIPTION
…gName` property

fixes #2139