### PR TITLE
fix(launcher): send sigkill on timeout when force killing

### DIFF
--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -113,7 +113,7 @@ var ProcessLauncher = function (spawn, tempDir, timer) {
   }
 
   this._onKillTimeout = function () {
-    if (self.state !== self.STATE_BEING_KILLED) {
+    if (self.state !== self.STATE_BEING_KILLED && self.state !== self.STATE_BEING_FORCE_KILLED) {
       return
     }
 


### PR DESCRIPTION
@dignifiedquire This is in response to bug we are seeing where karma hangs because it is unable to force kill chrome, possibly https://github.com/karma-runner/karma/issues/24#issuecomment-216249098