### PR TITLE
Remove console.log

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -137,7 +137,6 @@ var BaseReporter = function (formatError, reportSlow, useColors, browserConsoleL
 }
 
 BaseReporter.decoratorFactory = function (formatError, reportSlow, useColors, browserConsoleLogOptions) {
-  console.log('decorator', arguments)
   return function (self) {
     BaseReporter.call(self, formatError, reportSlow, useColors, browserConsoleLogOptions)
   }


### PR DESCRIPTION
This was introduced by https://github.com/karma-runner/karma/commit/d1f924c7#diff-5c8a5788ecd4b4af2a29bc27ac4ae986R140 and is thus printed in every test run.