### PR TITLE
feat: upstreamProxy config option to deal with proxies

### DIFF
--- a/client/constants.js
+++ b/client/constants.js
@@ -1,5 +1,6 @@
 module.exports = {
   VERSION: '%KARMA_VERSION%',
   KARMA_URL_ROOT: '%KARMA_URL_ROOT%',
+  KARMA_PROXY_PATH: '%KARMA_PROXY_PATH%',
   CONTEXT_URL: 'context.html'
 }

--- a/client/main.js
+++ b/client/main.js
@@ -5,15 +5,17 @@ require('core-js/es5')
 var Karma = require('./karma')
 var StatusUpdater = require('./updater')
 var util = require('../common/util')
+var constants = require('./constants')
 
-var KARMA_URL_ROOT = require('./constants').KARMA_URL_ROOT
+var KARMA_URL_ROOT = constants.KARMA_URL_ROOT
+var KARMA_PROXY_PATH = constants.KARMA_PROXY_PATH
 
 // Connect to the server using socket.io http://socket.io
 var socket = io(location.host, {
   reconnectionDelay: 500,
   reconnectionDelayMax: Infinity,
   timeout: 2000,
-  path: '/' + KARMA_URL_ROOT.substr(1) + 'socket.io',
+  path: KARMA_PROXY_PATH + KARMA_URL_ROOT.substr(1) + 'socket.io',
   'sync disconnect on unload': true
 })
 

--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -647,6 +647,44 @@ is handed off to [socket.io](http://socket.io/) (which manages the communication
 between browsers and the testing server).
 
 
+## upstreamProxy
+**Type:** Object
+
+**Default:** `undefined`
+
+**Description:** For use when the Karma server needs to be run behind a proxy that changes the base url, etc
+
+If set then the following fields will be defined and can be overriden:
+
+### path
+**Type:** String
+
+**Default:** `'/'`
+
+**Description:** Will be prepended to the base url when launching browsers and prepended to internal urls as loaded by the browsers
+
+### port
+**Type:** Number
+
+**Default:** `9875`
+
+**Description:** Will be used as the port when launching browsers
+
+### hostname
+**Type:** String
+
+**Default:** `'localhost'`
+
+**Description:** Will be used as the hostname when launching browsers
+
+### protocol
+**Type:** String
+
+**Default:** `'http:'`
+
+**Description:** Will be used as the protocol when launching browsers
+
+
 ## urlRoot
 **Type:** String
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -72,22 +72,36 @@ var createPatternObject = function (pattern) {
   return new Pattern(null, false, false, false, false)
 }
 
+var normalizeUrl = function (url) {
+  if (url.charAt(0) !== '/') {
+    url = '/' + url
+  }
+
+  if (url.charAt(url.length - 1) !== '/') {
+    url = url + '/'
+  }
+
+  return url
+}
+
 var normalizeUrlRoot = function (urlRoot) {
-  var normalizedUrlRoot = urlRoot
-
-  if (normalizedUrlRoot.charAt(0) !== '/') {
-    normalizedUrlRoot = '/' + normalizedUrlRoot
-  }
-
-  if (normalizedUrlRoot.charAt(normalizedUrlRoot.length - 1) !== '/') {
-    normalizedUrlRoot = normalizedUrlRoot + '/'
-  }
+  var normalizedUrlRoot = normalizeUrl(urlRoot)
 
   if (normalizedUrlRoot !== urlRoot) {
     log.warn('urlRoot normalized to "%s"', normalizedUrlRoot)
   }
 
   return normalizedUrlRoot
+}
+
+var normalizeProxyPath = function (proxyPath) {
+  var normalizedProxyPath = normalizeUrl(proxyPath)
+
+  if (normalizedProxyPath !== proxyPath) {
+    log.warn('proxyPath normalized to "%s"', normalizedProxyPath)
+  }
+
+  return normalizedProxyPath
 }
 
 var normalizeConfig = function (config, configFilePath) {
@@ -134,6 +148,22 @@ var normalizeConfig = function (config, configFilePath) {
 
   // normalize urlRoot
   config.urlRoot = normalizeUrlRoot(config.urlRoot)
+
+  // normalize and default upstream proxy settings if given
+  if (config.upstreamProxy) {
+    var proxy = config.upstreamProxy
+    proxy.path = _.isUndefined(proxy.path) ? '/' : normalizeProxyPath(proxy.path)
+    proxy.hostname = _.isUndefined(proxy.hostname) ? 'localhost' : proxy.hostname
+    proxy.port = _.isUndefined(proxy.port) ? 9875 : proxy.port
+
+    // force protocol to end with ':'
+    proxy.protocol = (proxy.protocol || 'http').split(':')[0] + ':'
+    if (proxy.protocol.match(/https?:/) === null) {
+      log.warn('"%s" is not a supported upstream proxy protocol, defaulting to "http:"',
+        proxy.protocol)
+      proxy.protocol = 'http:'
+    }
+  }
 
   // force protocol to end with ':'
   config.protocol = (config.protocol || 'http').split(':')[0] + ':'
@@ -276,6 +306,7 @@ var Config = function () {
   this.proxyValidateSSL = true
   this.preprocessors = {}
   this.urlRoot = '/'
+  this.upstreamProxy = undefined
   this.reportSlowerThan = 0
   this.loggers = [constant.CONSOLE_APPENDER]
   this.transports = ['polling', 'websocket']

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -39,9 +39,15 @@ var Launcher = function (server, emitter, injector) {
     return null
   }
 
-  this.launchSingle = function (protocol, hostname, port, urlRoot) {
+  this.launchSingle = function (protocol, hostname, port, urlRoot, upstreamProxy) {
     var self = this
     return function (name) {
+      if (upstreamProxy) {
+        protocol = upstreamProxy.protocol
+        hostname = upstreamProxy.hostname
+        port = upstreamProxy.port
+        urlRoot = upstreamProxy.path + urlRoot.substr(1)
+      }
       var url = protocol + '//' + hostname + ':' + port + urlRoot
 
       var locals = {
@@ -158,7 +164,8 @@ var Launcher = function (server, emitter, injector) {
     'config.protocol',
     'config.hostname',
     'config.port',
-    'config.urlRoot'
+    'config.urlRoot',
+    'config.upstreamProxy'
   ]
 
   this.kill = function (id, callback) {

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -35,12 +35,12 @@ var SCRIPT_TYPE = {
   '.dart': 'application/dart'
 }
 
-var filePathToUrlPath = function (filePath, basePath, urlRoot) {
+var filePathToUrlPath = function (filePath, basePath, urlRoot, proxyPath) {
   if (filePath.indexOf(basePath) === 0) {
-    return urlRoot + 'base' + filePath.substr(basePath.length)
+    return proxyPath + urlRoot.substr(1) + 'base' + filePath.substr(basePath.length)
   }
 
-  return urlRoot + 'absolute' + filePath
+  return proxyPath + urlRoot.substr(1) + 'absolute' + filePath
 }
 
 var getXUACompatibleMetaElement = function (url) {
@@ -79,8 +79,10 @@ var createKarmaMiddleware = function (
   serveFile,
   injector,
   basePath,
-  urlRoot
+  urlRoot,
+  upstreamProxy
 ) {
+  var proxyPath = upstreamProxy ? upstreamProxy.path : '/'
   return function (request, response, next) {
     // These config values should be up to date on every request
     var client = injector.get('config.client')
@@ -93,7 +95,7 @@ var createKarmaMiddleware = function (
 
     // redirect /__karma__ to /__karma__ (trailing slash)
     if (requestUrl === urlRoot.substr(0, urlRoot.length - 1)) {
-      response.setHeader('Location', urlRoot)
+      response.setHeader('Location', proxyPath + urlRoot.substr(1))
       response.writeHead(301)
       return response.end('MOVED PERMANENTLY')
     }
@@ -122,6 +124,7 @@ var createKarmaMiddleware = function (
       return serveStaticFile(requestUrl, requestedRangeHeader, response, function (data) {
         return data.replace('%KARMA_URL_ROOT%', urlRoot)
           .replace('%KARMA_VERSION%', VERSION)
+          .replace('%KARMA_PROXY_PATH%', proxyPath)
       })
     }
 
@@ -161,7 +164,7 @@ var createKarmaMiddleware = function (
             var fileExt = path.extname(filePath)
 
             if (!file.isUrl) {
-              filePath = filePathToUrlPath(filePath, basePath, urlRoot)
+              filePath = filePathToUrlPath(filePath, basePath, urlRoot, proxyPath)
 
               if (requestUrl === '/context.html') {
                 filePath += '?' + file.sha
@@ -190,7 +193,7 @@ var createKarmaMiddleware = function (
           // TODO(vojta): don't compute if it's not in the template
           var mappings = files.served.map(function (file) {
             // Windows paths contain backslashes and generate bad IDs if not escaped
-            var filePath = filePathToUrlPath(file.path, basePath, urlRoot).replace(/\\/g, '\\\\')
+            var filePath = filePathToUrlPath(file.path, basePath, urlRoot, proxyPath).replace(/\\/g, '\\\\')
             // Escape single quotes that might be in the filename -
             // double quotes should not be allowed!
             filePath = filePath.replace(/'/g, '\\\'')
@@ -223,7 +226,7 @@ var createKarmaMiddleware = function (
         response.writeHead(200)
         response.end(JSON.stringify({
           files: files.included.map(function (file) {
-            return filePathToUrlPath(file.path + '?' + file.sha, basePath, urlRoot)
+            return filePathToUrlPath(file.path + '?' + file.sha, basePath, urlRoot, proxyPath)
           })
         }))
       })
@@ -239,7 +242,8 @@ createKarmaMiddleware.$inject = [
   'serveFile',
   'injector',
   'config.basePath',
-  'config.urlRoot'
+  'config.urlRoot',
+  'config.upstreamProxy'
 ]
 
 // PUBLIC API

--- a/test/e2e/support/after_hooks.js
+++ b/test/e2e/support/after_hooks.js
@@ -1,10 +1,13 @@
 module.exports = function afterHooks () {
-  this.After(function (callback) {
+  this.After(function (scenario, callback) {
     var running = this.child != null && typeof this.child.kill === 'function'
 
     if (running) {
       this.child.kill()
       this.child = null
     }
+
+    // stop the proxy if it was started
+    this.proxy.stop(callback)
   })
 }

--- a/test/e2e/support/behind-proxy/plus.js
+++ b/test/e2e/support/behind-proxy/plus.js
@@ -1,0 +1,5 @@
+/* eslint-disable no-unused-vars */
+// Some code under test
+function plus (a, b) {
+  return a + b
+}

--- a/test/e2e/support/behind-proxy/test.js
+++ b/test/e2e/support/behind-proxy/test.js
@@ -1,0 +1,10 @@
+/* globals plus */
+describe('plus', function () {
+  it('should pass', function () {
+    expect(true).toBe(true)
+  })
+
+  it('should work', function () {
+    expect(plus(1, 2)).toBe(3)
+  })
+})

--- a/test/e2e/support/proxy.js
+++ b/test/e2e/support/proxy.js
@@ -1,0 +1,43 @@
+var http = require('http')
+var httpProxy = require('http-proxy')
+
+var Proxy = function () {
+  var self = this
+  self.running = false
+
+  self.proxy = httpProxy.createProxyServer({
+    target: 'http://localhost:9876'
+  })
+
+  self.server = http.createServer(function (req, res) {
+    var url = req.url
+    var match = url.match(self.proxyPathRegExp)
+    if (match) {
+      req.url = '/' + match[1]
+      self.proxy.web(req, res)
+    } else {
+      res.statusCode = 404
+      res.statusMessage = 'Not found'
+      res.end()
+    }
+  })
+
+  self.start = function (port, proxyPath, callback) {
+    self.proxyPathRegExp = new RegExp('^' + proxyPath + '(.*)')
+    self.server.listen(port, function (error) {
+      self.running = !error
+      callback(error)
+    })
+  }
+
+  self.stop = function (callback) {
+    if (self.running) {
+      self.running = false
+      self.server.close(callback)
+    } else {
+      callback()
+    }
+  }
+}
+
+module.exports = new Proxy()

--- a/test/e2e/support/world.js
+++ b/test/e2e/support/world.js
@@ -6,6 +6,8 @@ var mkdirp = require('mkdirp')
 var _ = require('lodash')
 
 exports.World = function World () {
+  this.proxy = require('./proxy')
+
   this.template = _.template('module.exports = function (config) {\n  config.set(\n    <%= content %>\n  );\n};')
 
   this.configFile = {

--- a/test/e2e/upstream-proxy.feature
+++ b/test/e2e/upstream-proxy.feature
@@ -1,0 +1,25 @@
+Feature: UpstreamProxy
+  In order to use Karma
+  As a person who wants to write great tests
+  I want to Karma to to work when it is behind a proxy that prepends to the base path.
+
+  Scenario: UpstreamProxy
+    Given a configuration with:
+      """
+      files = ['behind-proxy/plus.js', 'behind-proxy/test.js'];
+      browsers = ['PhantomJS'];
+      plugins = [
+        'karma-jasmine',
+        'karma-phantomjs-launcher'
+      ];
+      urlRoot = '/__karma__/';
+      upstreamProxy = {
+        path: '/__proxy__/'
+      };
+      """
+    When I start Karma behind a proxy on port 9875 that prepends '/__proxy__/' to the base path
+    Then it passes with:
+      """
+      ..
+      PhantomJS
+      """

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -12,6 +12,7 @@ describe('config', () => {
 
   var normalizeConfigWithDefaults = (cfg) => {
     if (!cfg.urlRoot) cfg.urlRoot = ''
+    if (!cfg.proxyPath) cfg.proxyPath = ''
     if (!cfg.files) cfg.files = []
     if (!cfg.exclude) cfg.exclude = []
     if (!cfg.junitReporter) cfg.junitReporter = {}
@@ -186,6 +187,35 @@ describe('config', () => {
 
       config = normalizeConfigWithDefaults({urlRoot: 'some/thing'})
       expect(config.urlRoot).to.equal('/some/thing/')
+    })
+
+    it('should normalize upstream proxy config', () => {
+      var config = normalizeConfigWithDefaults({})
+      expect(config.upstreamProxy).to.be.undefined
+
+      config = normalizeConfigWithDefaults({upstreamProxy: {}})
+      expect(config.upstreamProxy.path).to.equal('/')
+      expect(config.upstreamProxy.hostname).to.equal('localhost')
+      expect(config.upstreamProxy.port).to.equal(9875)
+      expect(config.upstreamProxy.protocol).to.equal('http:')
+
+      config = normalizeConfigWithDefaults({upstreamProxy: {protocol: 'http'}})
+      expect(config.upstreamProxy.protocol).to.equal('http:')
+
+      config = normalizeConfigWithDefaults({upstreamProxy: {protocol: 'https'}})
+      expect(config.upstreamProxy.protocol).to.equal('https:')
+
+      config = normalizeConfigWithDefaults({upstreamProxy: {protocol: 'unknown'}})
+      expect(config.upstreamProxy.protocol).to.equal('http:')
+
+      config = normalizeConfigWithDefaults({upstreamProxy: {path: '/a/b'}})
+      expect(config.upstreamProxy.path).to.equal('/a/b/')
+
+      config = normalizeConfigWithDefaults({upstreamProxy: {path: 'a/'}})
+      expect(config.upstreamProxy.path).to.equal('/a/')
+
+      config = normalizeConfigWithDefaults({upstreamProxy: {path: 'some/thing'}})
+      expect(config.upstreamProxy.path).to.equal('/some/thing/')
     })
 
     it('should change autoWatch to false if singleRun', () => {

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -24,7 +24,7 @@ describe('middleware.karma', () => {
         'client.html': mocks.fs.file(0, 'CLIENT HTML\n%X_UA_COMPATIBLE%%X_UA_COMPATIBLE_URL%'),
         'context.html': mocks.fs.file(0, 'CONTEXT\n%SCRIPTS%'),
         'debug.html': mocks.fs.file(0, 'DEBUG\n%SCRIPTS%\n%X_UA_COMPATIBLE%'),
-        'karma.js': mocks.fs.file(0, 'root: %KARMA_URL_ROOT%, v: %KARMA_VERSION%')
+        'karma.js': mocks.fs.file(0, 'root: %KARMA_URL_ROOT%, proxy: %KARMA_PROXY_PATH%, v: %KARMA_VERSION%')
       }
     }
   })
@@ -57,7 +57,8 @@ describe('middleware.karma', () => {
       null,
       injector,
       '/base/path',
-      '/__karma__/'
+      '/__karma__/',
+      {path: '/__proxy__/'}
     )
   })
 
@@ -85,7 +86,7 @@ describe('middleware.karma', () => {
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
       expect(response).to.beServedAs(301, 'MOVED PERMANENTLY')
-      expect(response._headers['Location']).to.equal('/__karma__/')
+      expect(response._headers['Location']).to.equal('/__proxy__/__karma__/')
       done()
     })
 
@@ -181,7 +182,7 @@ describe('middleware.karma', () => {
   it('should serve karma.js with version and urlRoot variables', (done) => {
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'root: /__karma__/, v: ' + constants.VERSION)
+      expect(response).to.beServedAs(200, 'root: /__karma__/, proxy: /__proxy__/, v: ' + constants.VERSION)
       expect(response._headers['Content-Type']).to.equal('application/javascript')
       done()
     })
@@ -197,7 +198,7 @@ describe('middleware.karma', () => {
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="/__karma__/absolute/first.js?sha123" crossorigin="anonymous"></script>\n<script type="application/dart" src="/__karma__/absolute/second.dart?sha456" crossorigin="anonymous"></script>')
+      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="/__proxy__/__karma__/absolute/first.js?sha123" crossorigin="anonymous"></script>\n<script type="application/dart" src="/__proxy__/__karma__/absolute/second.dart?sha456" crossorigin="anonymous"></script>')
       done()
     })
 
@@ -212,7 +213,7 @@ describe('middleware.karma', () => {
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'CONTEXT\n<link type="text/css" href="/__karma__/absolute/first.css?sha007" rel="stylesheet">\n<link href="/__karma__/absolute/second.html?sha678" rel="import">')
+      expect(response).to.beServedAs(200, 'CONTEXT\n<link type="text/css" href="/__proxy__/__karma__/absolute/first.css?sha007" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/second.html?sha678" rel="import">')
       done()
     })
 
@@ -227,7 +228,7 @@ describe('middleware.karma', () => {
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="/__karma__/absolute/some/abc/a.js?sha" crossorigin="anonymous"></script>\n<script type="text/javascript" src="/__karma__/base/b.js?shaaa" crossorigin="anonymous"></script>')
+      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="/__proxy__/__karma__/absolute/some/abc/a.js?sha" crossorigin="anonymous"></script>\n<script type="text/javascript" src="/__proxy__/__karma__/base/b.js?shaaa" crossorigin="anonymous"></script>')
       done()
     })
 
@@ -244,7 +245,7 @@ describe('middleware.karma', () => {
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'CONTEXT\n<link type="text/css" href="/__karma__/absolute/some/abc/a.css?sha1" rel="stylesheet">\n<link type="text/css" href="/__karma__/base/b.css?sha2" rel="stylesheet">\n<link href="/__karma__/absolute/some/abc/c.html?sha3" rel="import">\n<link href="/__karma__/base/d.html?sha4" rel="import">')
+      expect(response).to.beServedAs(200, 'CONTEXT\n<link type="text/css" href="/__proxy__/__karma__/absolute/some/abc/a.css?sha1" rel="stylesheet">\n<link type="text/css" href="/__proxy__/__karma__/base/b.css?sha2" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/some/abc/c.html?sha3" rel="import">\n<link href="/__proxy__/__karma__/base/d.html?sha4" rel="import">')
       done()
     })
 
@@ -263,10 +264,10 @@ describe('middleware.karma', () => {
       expect(nextSpy).not.to.have.been.called
       expect(response).to.beServedAs(200, JSON.stringify({
         files: [
-          '/__karma__/absolute/some/abc/a.css?sha1',
-          '/__karma__/base/b.css?sha2',
-          '/__karma__/absolute/some/abc/c.html?sha3',
-          '/__karma__/base/d.html?sha4'
+          '/__proxy__/__karma__/absolute/some/abc/a.css?sha1',
+          '/__proxy__/__karma__/base/b.css?sha2',
+          '/__proxy__/__karma__/absolute/some/abc/c.html?sha3',
+          '/__proxy__/__karma__/base/d.html?sha4'
         ]
       }))
       done()
@@ -314,7 +315,7 @@ describe('middleware.karma', () => {
     ])
 
     response.once('end', () => {
-      expect(response).to.beServedAs(200, "window.__karma__.files = {\n  '/__karma__/absolute/some/abc/a.js': 'sha_a',\n  '/__karma__/base/b.js': 'sha_b',\n  '/__karma__/absolute\\\\windows\\\\path\\\\uuu\\\\c.js': 'sha_c'\n};\n")
+      expect(response).to.beServedAs(200, "window.__karma__.files = {\n  '/__proxy__/__karma__/absolute/some/abc/a.js': 'sha_a',\n  '/__proxy__/__karma__/base/b.js': 'sha_b',\n  '/__proxy__/__karma__/absolute\\\\windows\\\\path\\\\uuu\\\\c.js': 'sha_c'\n};\n")
       done()
     })
 
@@ -329,7 +330,7 @@ describe('middleware.karma', () => {
     ])
 
     response.once('end', () => {
-      expect(response).to.beServedAs(200, 'window.__karma__.files = {\n  \'/__karma__/absolute/some/abc/a\\\'b.js\': \'sha_a\',\n  \'/__karma__/base/ba.js\': \'sha_b\'\n};\n')
+      expect(response).to.beServedAs(200, 'window.__karma__.files = {\n  \'/__proxy__/__karma__/absolute/some/abc/a\\\'b.js\': \'sha_a\',\n  \'/__proxy__/__karma__/base/ba.js\': \'sha_b\'\n};\n')
       done()
     })
 
@@ -344,7 +345,7 @@ describe('middleware.karma', () => {
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'DEBUG\n<script type="text/javascript" src="/__karma__/absolute/first.js" crossorigin="anonymous"></script>\n<script type="text/javascript" src="/__karma__/base/b.js" crossorigin="anonymous"></script>')
+      expect(response).to.beServedAs(200, 'DEBUG\n<script type="text/javascript" src="/__proxy__/__karma__/absolute/first.js" crossorigin="anonymous"></script>\n<script type="text/javascript" src="/__proxy__/__karma__/base/b.js" crossorigin="anonymous"></script>')
       done()
     })
 
@@ -361,7 +362,7 @@ describe('middleware.karma', () => {
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'DEBUG\n<link type="text/css" href="/__karma__/absolute/first.css" rel="stylesheet">\n<link type="text/css" href="/__karma__/base/b.css" rel="stylesheet">\n<link href="/__karma__/absolute/second.html" rel="import">\n<link href="/__karma__/base/d.html" rel="import">')
+      expect(response).to.beServedAs(200, 'DEBUG\n<link type="text/css" href="/__proxy__/__karma__/absolute/first.css" rel="stylesheet">\n<link type="text/css" href="/__proxy__/__karma__/base/b.css" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/second.html" rel="import">\n<link href="/__proxy__/__karma__/base/d.html" rel="import">')
       done()
     })
 
@@ -412,7 +413,8 @@ describe('middleware.karma', () => {
         }
       },
       '/base/path',
-      '/__karma__/'
+      '/__karma__/',
+      {path: '/__proxy__/'}
     )
 
     includedFiles([


### PR DESCRIPTION
I have a use case where I can only load content via a web proxy that I don't control. This web proxy prepends a directory to the front of URLs which breaks the internal urls inserted by the Karma middleware.

This pull request adds an `upstreamProxy` option that allows the additional proxy path to be configured and used in URLs. To complete the use cases and implement e2e tests I also added `hostname`, `port` and `protocol` fields to use in launchers to point them at the proxy.

This is my first contribution here so please be gentle ;)