### PR TITLE
fix: Add crossorigin attribute to script HTML tags

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -27,7 +27,7 @@ var urlparse = function (urlStr) {
 var common = require('./common')
 
 var VERSION = require('../constants').VERSION
-var SCRIPT_TAG = '<script type="%s" src="%s"></script>'
+var SCRIPT_TAG = '<script type="%s" src="%s" crossorigin="anonymous"></script>'
 var LINK_TAG_CSS = '<link type="text/css" href="%s" rel="stylesheet">'
 var LINK_TAG_HTML = '<link href="%s" rel="import">'
 var SCRIPT_TYPE = {

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -197,7 +197,7 @@ describe('middleware.karma', () => {
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="/__karma__/absolute/first.js?sha123"></script>\n<script type="application/dart" src="/__karma__/absolute/second.dart?sha456"></script>')
+      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="/__karma__/absolute/first.js?sha123" crossorigin="anonymous"></script>\n<script type="application/dart" src="/__karma__/absolute/second.dart?sha456" crossorigin="anonymous"></script>')
       done()
     })
 
@@ -227,7 +227,7 @@ describe('middleware.karma', () => {
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="/__karma__/absolute/some/abc/a.js?sha"></script>\n<script type="text/javascript" src="/__karma__/base/b.js?shaaa"></script>')
+      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="/__karma__/absolute/some/abc/a.js?sha" crossorigin="anonymous"></script>\n<script type="text/javascript" src="/__karma__/base/b.js?shaaa" crossorigin="anonymous"></script>')
       done()
     })
 
@@ -281,7 +281,7 @@ describe('middleware.karma', () => {
     ])
 
     response.once('end', () => {
-      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="http://some.url.com/whatever"></script>')
+      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="http://some.url.com/whatever" crossorigin="anonymous"></script>')
       done()
     })
 
@@ -344,7 +344,7 @@ describe('middleware.karma', () => {
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'DEBUG\n<script type="text/javascript" src="/__karma__/absolute/first.js"></script>\n<script type="text/javascript" src="/__karma__/base/b.js"></script>')
+      expect(response).to.beServedAs(200, 'DEBUG\n<script type="text/javascript" src="/__karma__/absolute/first.js" crossorigin="anonymous"></script>\n<script type="text/javascript" src="/__karma__/base/b.js" crossorigin="anonymous"></script>')
       done()
     })
 


### PR DESCRIPTION
**The Problem**
When an error occurs in a script that is not served by the
default server spawned by karma, the stack trace gets lost and
only the message `"Script Error"` is captured and reported back.
This makes it hard to pin-point where the error originated from.

**The Solution**
Add `crossorigin` attribute to generated script tags.

Solution is inspired by this article:
https://blog.getsentry.com/2016/05/17/what-is-script-error.html