### PR TITLE
fix(docs): fix stopper.stop wrong variable name. closes #2244

### DIFF
--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -126,7 +126,7 @@ This function will signal a running server to stop.  The equivalent of `karma st
 
 ```javascript
 var stopper = require('karma').stopper
-runner.stop({port: 9876}, function(exitCode) {
+stopper.stop({port: 9876}, function(exitCode) {
   if (exitCode === 0) {
     console.log('Server stop as initiated')
   }


### PR DESCRIPTION
Was:

```js
var stopper = require('karma').stopper
runner.stop({port: 9876}, function(exitCode) {
```

Changed to :

```js
var stopper = require('karma').stopper
stopper.stop({port: 9876}, function(exitCode) {
```