### PR TITLE
fix(context): Updated postMessage listener to stop validating non-Karma messages

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -35,12 +35,14 @@ var Karma = function (socket, iframe, opener, navigator, location) {
       }
 
       // Take action based on the message type
-      var method = evt.data.method
-      if (!self[method]) {
-        self.error('Received `postMessage` for "' + method + '" but the method doesn\'t exist')
-        return
+      var method = evt.data.__karmaMethod
+      if (method) {
+        if (!self[method]) {
+          self.error('Received `postMessage` for "' + method + '" but the method doesn\'t exist')
+          return
+        }
+        self[method].apply(self, evt.data.__karmaArguments)
       }
-      self[method].apply(self, evt.data.arguments)
     }, false)
   }
 

--- a/context/karma.js
+++ b/context/karma.js
@@ -130,7 +130,7 @@ ContextKarma.getDirectCallParentKarmaMethod = function (parentWindow) {
 }
 ContextKarma.getPostMessageCallParentKarmaMethod = function (parentWindow) {
   return function postMessageCallParentKarmaMethod (method, args) {
-    parentWindow.postMessage({method: method, arguments: args}, window.location.origin)
+    parentWindow.postMessage({__karmaMethod: method, __karmaArguments: args}, window.location.origin)
   }
 }
 


### PR DESCRIPTION
As reported in #2239, our current `postMessage` hook is looking at all post messages, not only the ones for Karma. In this PR:

- Moved to namespaced `postMessage` variable checks
- Updated `postMessage` logic to only assert if a truthy method was given
- Fixes #2239 

/cc @dignifiedquire 