### PR TITLE
fix(file-list): Ensure duplicate files are handled properly

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -233,7 +233,7 @@ Object.defineProperty(List.prototype, 'files', {
       var bucket = expandPattern(p)
       bucket.forEach(function (file) {
         var other = lookup[file.path]
-        if (other && other.compare(p) < 0) return
+        if (other && byPath(other, p) < 0) return
         lookup[file.path] = p
         if (p.included) {
           included[file.path] = file


### PR DESCRIPTION
Previously, if file patterns amounted to duplicate files, the pattern resolution function would fail and Karma would continue on with an empty files list, namely "included". This led to confusing, generic adapter errors. This commit fixes that by replacing the offending code with a (likely) equivalent. 
To replicate issue, include patterns that amount to duplicate files.
To see the error, wrap the following statement `if (other && other.compare(p) < 0) return` (contained inside `file-list.js`) in a `try {} catch () {}` block. In essence, `other.compare` does not exist.

Might be related to issue #2194 

