### PR TITLE
Call .resume() on process streams so they don't get blocked

### DIFF
--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -135,7 +135,17 @@ var ProcessLauncher = function (spawn, tempDir, timer) {
 
 ProcessLauncher.decoratorFactory = function (timer) {
   return function (launcher) {
-    ProcessLauncher.call(launcher, require('child_process').spawn, require('../temp_dir'), timer)
+    var spawn = require('child_process').spawn
+
+    var spawnWithoutOutput = function () {
+      var proc = spawn.apply(null, arguments)
+      proc.stdout.resume()
+      proc.stderr.resume()
+
+      return proc
+    }
+
+    ProcessLauncher.call(launcher, spawnWithoutOutput, require('../temp_dir'), timer)
   }
 }
 


### PR DESCRIPTION
If you manage to make chrome emit errors in the console, like we do with webrtc, the node stream buffer for stderr fills up and locks up the browser. This just calls `.resume()` to prevent that.

Here's a tarball of a simplified project that repro's the issue:
https://drive.google.com/file/d/0By71SGpctHHxVzl1bkx6bGg3b2c/view?usp=sharing

Simply run `karma start --browsers ChromeFakeDevices` and chrome should lock up when it's done around 200 of the 1000 identical tests.
