### PR TITLE
fix(web-server): Allow karma to run in project which path contains HTML URL encoded characters

### DIFF
--- a/lib/middleware/source_files.js
+++ b/lib/middleware/source_files.js
@@ -13,14 +13,20 @@ var findByPath = function (files, path) {
   })
 }
 
+var composeUrl = function (url, basePath, urlRoot, mustEscape) {
+  return (mustEscape ? querystring.unescape(url) : url)
+            .replace(urlRoot, '/')
+            .replace(/\?.*$/, '')
+            .replace(/^\/absolute/, '')
+            .replace(/^\/base/, basePath)
+}
+
 // Source Files middleware is responsible for serving all the source files under the test.
 var createSourceFilesMiddleware = function (filesPromise, serveFile, basePath, urlRoot) {
   return function (request, response, next) {
-    var requestedFilePath = querystring.unescape(request.url)
-      .replace(urlRoot, '/')
-      .replace(/\?.*$/, '')
-      .replace(/^\/absolute/, '')
-      .replace(/^\/base/, basePath)
+    var requestedFilePath = composeUrl(request.url, basePath, urlRoot, true)
+    // When a path contains HTML-encoded characters (e.g %2F used by Jenkins for branches with /)
+    var requestedFilePathUnescaped = composeUrl(request.url, basePath, urlRoot, false)
 
     request.pause()
 
@@ -29,7 +35,8 @@ var createSourceFilesMiddleware = function (filesPromise, serveFile, basePath, u
 
     return filesPromise.then(function (files) {
       // TODO(vojta): change served to be a map rather then an array
-      var file = findByPath(files.served, requestedFilePath)
+      var file = findByPath(files.served, requestedFilePath) ||
+                 findByPath(files.served, requestedFilePathUnescaped)
       var rangeHeader = request.headers['range']
 
       if (file) {

--- a/test/unit/middleware/source_files.spec.js
+++ b/test/unit/middleware/source_files.spec.js
@@ -23,6 +23,9 @@ describe('middleware.source_files', function () {
     },
     'utf8ášč': {
       'some.js': mocks.fs.file(0, 'utf8-file')
+    },
+    'jenkins%2Fbranch': {
+      'some.js': mocks.fs.file(0, 'utf8-file')
     }
   })
 
@@ -202,6 +205,22 @@ describe('middleware.source_files', function () {
 
     return request(server)
       .get('/base/some.js')
+      .expect(200, 'utf8-file')
+      .then(function () {
+        return expect(next).not.to.have.been.called
+      }
+    )
+  })
+
+  it('should serve js source file from paths containing HTML URL encoded chars', function () {
+    servedFiles([
+      new File('/jenkins%2Fbranch/some.js')
+    ])
+
+    server = createServer(files, serveFile, '')
+
+    return request(server)
+      .get('/base/jenkins%2Fbranch/some.js')
       .expect(200, 'utf8-file')
       .then(function () {
         return expect(next).not.to.have.been.called


### PR DESCRIPTION
Karma fails on Jenkins (standard "Multibranch pipeline" project) when it checks out branches containing '/' as it replaces '/' by '%2F' in the folder name.

Alternatively, if the project parent folder contains %2F in its name, karma will not execute properly.

Fixes errors seen on #1751, #61.