### PR TITLE
docs(gh): fix typos

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
-### Expected behavior
+### Expected behaviour
 
-### Actual behavior
+### Actual behaviour
 
-### Enviroment Details
+### Environment Details
 
 - Karma version (output of `karma --version`):
 - Relevant part of your `karma.config.js` file


### PR DESCRIPTION
Behavior/behaviour is both correct spelling; changed for consistency.