### PR TITLE
Fix #2207: Fix markdown syntax(broken link) for CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ submitting an issue to our [GitHub Repository][github_newissue]. Even better you
 with a fix.
 
 **Working on your first Pull Request?** You can learn how from this *free* series
-[How to Contribute to an Open Source Project on GitHub](egghead_series)
+[How to Contribute to an Open Source Project on GitHub][egghead_series]
 
 [docs_contributing]: http://karma-runner.github.io/0.13/dev/contributing.html
 [gitter]: https://gitter.im/karma-runner/karma


### PR DESCRIPTION
There is a broken link in CONTRIBUTING.md, due to an incorrect reference to the `[egghead_series]` link written as:
```
[How to Contribute to an Open Source Project on GitHub](egghead_series)
...
...
[egghead_series]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
```
which _incorrectly links to_: https://github.com/karma-runner/karma/blob/master/egghead_series and not https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github

The surrounding parentheses should be **square brackets** in order to correctly use the reference-style link ( See this markdown cheat sheet for more info: https://blueskyworkshop.com/tools/markdown/markdown-cheatsheet.html#Links )

**Proposed change:**
```
[How to Contribute to an Open Source Project on GitHub][egghead_series]
```

====
Fixes #2207 
