### PR TITLE
Fix #2351: Restore scripts from .npmignore to fix karma completion command

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@
 tmp
 test
 tasks
-scripts
 docs
 client
 logo


### PR DESCRIPTION
## Description:

As described in #2351, the `karma completion` command as listed in `karma --help` does not work because the scripts folder is missing from the published npm package.
## Changes Proposed:
- Restore the `scripts` folder to the published npm package by removing it from `.npmignore`

---

Fixes #2351 
