### PR TITLE
Reporter Sourcemap: Do not allow URL domains to span new lines

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -25,7 +25,7 @@ var createErrorFormatter = function (config, emitter, SourceMapConsumer) {
     return null
   }
 
-  var URL_REGEXP = new RegExp('(?:https?:\\/\\/[^\\/]*)?\\/?' +
+  var URL_REGEXP = new RegExp('(?:https?:\\/\\/[^\\/\\n]*)?\\/?' +
     '(base/|absolute)' + // prefix, including slash for base/ to create relative paths.
     '((?:[A-z]\\:)?[^\\?\\s\\:]*)' + // path
     '(\\?\\w*)?' + // sha

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -25,7 +25,7 @@ var createErrorFormatter = function (config, emitter, SourceMapConsumer) {
     return null
   }
 
-  var URL_REGEXP = new RegExp('(?:https?:\\/\\/[^\\/\\n]*)?\\/?' +
+  var URL_REGEXP = new RegExp('(?:https?:\\/\\/[^\\/\\s]*)?\\/?' +
     '(base/|absolute)' + // prefix, including slash for base/ to create relative paths.
     '((?:[A-z]\\:)?[^\\?\\s\\:]*)' + // path
     '(\\?\\w*)?' + // sha

--- a/test/unit/reporter.spec.js
+++ b/test/unit/reporter.spec.js
@@ -245,6 +245,21 @@ describe('reporter', () => {
         })
       })
 
+      it('should not try to match domains with spaces', (done) => {
+        formatError = m.createErrorFormatter({ basePath: '/some/base' }, emitter, MockSourceMapConsumer)
+        var servedFiles = [new File('/some/base/a.js'), new File('/some/base/b.js')]
+        servedFiles[0].sourceMap = {content: 'SOURCE MAP a.js'}
+        servedFiles[1].sourceMap = {content: 'SOURCE MAP b.js'}
+
+        emitter.emit('file_list_modified', {served: servedFiles})
+
+        _.defer(() => {
+          var ERROR = '"http://localhost:9876"\n at /base/b.js:2:6'
+          expect(formatError(ERROR)).to.equal('"http://localhost:9876"\n at /original/b.js:4:8 <- b.js:2:6\n')
+          done()
+        })
+      })
+
       describe('Windows', () => {
         formatError = null
         var servedFiles = null


### PR DESCRIPTION
This was causing some excruciating error logs with the default format of cross-domain iframe errors:

```
Error: Blocked a frame with origin "http://localhost:9876" from accessing a cross-origin frame.
    at Error (native)
    at Function.method.restore (absolute/var/folders/8m/vg2kf8h50bj9gy5r9gwn20dw00_y0z/T/fa96dc8102e4c5416f4cd38061107a08.browserify?f4458f57b50ae627f718945da619dae7c682b4a0:60376:28)
    at each (absolute/var/folders/8m/vg2kf8h50bj9gy5r9gwn20dw00_y0z/T/fa96dc8102e4c5416f4cd38061107a08.browserify?f4458f57b50ae627f718945da619dae7c682b4a0:57875:33)
...
```

The old regex would find that `https://` then include everything that wasn't a slash, which included the next two lines into the `/absolute`. The output would be similar to:

```
    Error: Blocked a frame with origin "/var/folders/8m/vg2kf8h50bj9gy5r9gwn20dw00_y0z/T/afde9a0a28f71236ac3340462d6ca94e.browserify:60376:28 <- node_modules/sinon/lib/sinon/util/core.js:154:0)
        at each (/var/folders/8m/vg2kf8h50bj9gy5r9gwn20dw00_y0z/T/afde9a0a28f71236ac3340462d6ca94e.browserify:57875:33 <- node_modules/sinon/lib/sinon/collection.js:34:0)
...
```

With this, we prevent the domain from spanning the newline character, and now the output is:

```
    Error: Blocked a frame with origin "http://localhost:9876" from accessing a cross-origin frame.
        at Error (native)
        at Function.method.restore (/var/folders/8m/vg2kf8h50bj9gy5r9gwn20dw00_y0z/T/6c039bf5162f620e4d2667e56f143a02.browserify:60376:28 <- node_modules/sinon/lib/sinon/util/core.js:154:0)
        at each (/var/folders/8m/vg2kf8h50bj9gy5r9gwn20dw00_y0z/T/6c039bf5162f620e4d2667e56f143a02.browserify:57875:33 <- node_modules/sinon/lib/sinon/collection.js:34:0)
...
```
