### PR TITLE
All browsers in config require external plugins

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -171,9 +171,9 @@ If, during test execution, Karma does not receive any message from a browser wit
 
 **Possible Values:**
 
-  * `Chrome` (launcher comes installed with Karma)
-  * `ChromeCanary` (launcher comes installed with Karma)
-  * `PhantomJS` (launcher comes installed with Karma)
+  * `Chrome` (launcher requires karma-chrome-launcher plugin)
+  * `ChromeCanary` (launcher requires karma-chrome-launcher plugin)
+  * `PhantomJS` (launcher requires karma-phantomjs-launcher plugin)
   * `Firefox` (launcher requires karma-firefox-launcher plugin)
   * `Opera` (launcher requires karma-opera-launcher plugin)
   * `IE` (launcher requires karma-ie-launcher plugin)


### PR DESCRIPTION
I'm getting the following error when I try to use karma (version 1.3.0) without installing all required plugins for browsers:

```
14 10 2016 00:05:46.171:INFO [launcher]: Launching browser PhantomJS with unlimited concurrency
14 10 2016 00:05:46.173:ERROR [launcher]: Cannot load browser "PhantomJS": it is not registered! Perhaps you are missing some plugin?
14 10 2016 00:05:46.173:ERROR [karma]: Found 1 load error
```

Update documentation based on the required plugins for each browser.
