### PR TITLE
feat(index): Expose config on the index file

### DIFF
--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -134,6 +134,20 @@ stopper.stop({port: 9876}, function(exitCode) {
 })
 ```
 
+## karma.config.parseConfig([configFilePath], [cliOptions])
+
+This function will load given config file and return a filled config object. 
+This can be useful if you want to integrate karma into another tool and want to load
+the karma config while honoring the karma defaults. For example, the [stryker-karma-runner](https://github.com/stryker-mutator/stryker-karma-runner)
+uses this to load your karma configuration and use that as stryker configuration.
+
+```javascript
+const cfg = require('karma').config;
+const path = require('path');
+// Read karma.conf.js, but override port with 1337
+const karmaConfig = cfg.parseConfig(path.resolve('./karma.conf.js'), { port: 1337 } ); 
+```
+
 ## Callback function notes
 
 - If there is an error, the error code will be provided as the second parameter to the error callback.

--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -136,10 +136,10 @@ stopper.stop({port: 9876}, function(exitCode) {
 
 ## karma.config.parseConfig([configFilePath], [cliOptions])
 
-This function will load given config file and return a filled config object. 
+This function will load given config file and returns a filled config object. 
 This can be useful if you want to integrate karma into another tool and want to load
 the karma config while honoring the karma defaults. For example, the [stryker-karma-runner](https://github.com/stryker-mutator/stryker-karma-runner)
-uses this to load your karma configuration and use that as stryker configuration.
+uses this to load your karma configuration and use that in the stryker configuration.
 
 ```javascript
 const cfg = require('karma').config;

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,6 @@ module.exports = {
   runner: runner,
   stopper: stopper,
   launcher: launcher,
-  config: cfg,
+  config: { parseConfig: cfg.parseConfig }, // lets start with only opening up the `parseConfig` api
   server: oldServer
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var Server = require('./server')
 var runner = require('./runner')
 var stopper = require('./stopper')
 var launcher = require('./launcher')
+var cfg = require('./config')
 
 // TODO: remove in 1.0
 var oldServer = {
@@ -24,5 +25,6 @@ module.exports = {
   runner: runner,
   stopper: stopper,
   launcher: launcher,
+  config: cfg,
   server: oldServer
 }

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -1,0 +1,9 @@
+var cfg = require('../../lib/config')
+
+describe('index', () => {
+  var index = require('../../lib/index')
+
+  it('should expose the `config` object', () => {
+    expect(index.config).toBe(cfg)
+  })
+})

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -4,6 +4,6 @@ describe('index', () => {
   var index = require('../../lib/index')
 
   it('should expose the `config` object', () => {
-    expect(index.config).toBe(cfg)
+    expect(index.config.parseConfig).to.be.eq(cfg.parseConfig)
   })
 })


### PR DESCRIPTION
I would like to be able to only use the `config` part of karma. Using `require('karma/lib/config')` feels like i'm trashing a private party, i would rather be invited  :cake:.