### PR TITLE
chore: upgrade glob to 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "di": "^0.0.1",
     "dom-serialize": "^2.2.0",
     "expand-braces": "^0.1.1",
-    "glob": "^7.0.3",
+    "glob": "^7.1.1",
     "graceful-fs": "^4.1.2",
     "http-proxy": "^1.13.0",
     "isbinaryfile": "^3.0.0",


### PR DESCRIPTION
- Upgrade glob to an up to date version to avoid regression

This should sufficiently fix #2325.