### PR TITLE
fix(middleware): update Buffer usage

### DIFF
--- a/lib/middleware/common.js
+++ b/lib/middleware/common.js
@@ -5,6 +5,7 @@
 var mime = require('mime')
 var _ = require('lodash')
 var parseRange = require('range-parser')
+var Buffer = require('safe-buffer').Buffer
 
 var log = require('../logger').create('web-server')
 
@@ -40,10 +41,10 @@ var createServeFile = function (fs, directory, config) {
         return 200
       } else if (range === -1) {
         // unsatisfiable range
-        responseData = new Buffer(0)
+        responseData = Buffer.alloc(0)
         return 416
       } else if (range.type === 'bytes') {
-        responseData = new Buffer(responseData)
+        responseData = Buffer.from(responseData)
         if (range.length === 1) {
           var start = range[0].start
           var end = range[0].end

--- a/package.json
+++ b/package.json
@@ -320,6 +320,7 @@
     "qjobs": "^1.1.4",
     "range-parser": "^1.2.0",
     "rimraf": "^2.3.3",
+    "safe-buffer": "^5.0.1",
     "socket.io": "1.7.1",
     "source-map": "^0.5.3",
     "tmp": "0.0.28",


### PR DESCRIPTION
- Update Buffer usage to non-deprecated methods of creating a Buffer

Note that this does not fully fix #2429, as there is a plugin that needs to be looked into. However, it should be noted that these methods were only added in Node 5.10.0, which means that this is a breaking change in order to satisfy Node 7. This should probably be bundled with a major version bump when this is chosen to be merged.