### PR TITLE
chore: upgrade socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
     "qjobs": "^1.1.4",
     "range-parser": "^1.2.0",
     "rimraf": "^2.3.3",
-    "socket.io": "1.4.7",
+    "socket.io": "1.7.1",
     "source-map": "^0.5.3",
     "tmp": "0.0.28",
     "useragent": "^2.1.9"


### PR DESCRIPTION
- Upgrade socket.io to v1.7.1, which contains fix for the Uint8Array regression in IE9

This should adequately address #2190.