### PR TITLE
feat(client): capture confirm & prompt

### DIFF
--- a/context/karma.js
+++ b/context/karma.js
@@ -80,8 +80,21 @@ var ContextKarma = function (callParentKarmaMethod) {
       self.log('dump', arguments)
     }
 
+    var _confirm = contextWindow.confirm
+    var _prompt = contextWindow.prompt
+
     contextWindow.alert = function (msg) {
       self.log('alert', [msg])
+    }
+
+    contextWindow.confirm = function (msg) {
+      self.log('confirm', [msg])
+      _confirm(msg)
+    }
+
+    contextWindow.prompt = function (msg, defaultVal) {
+      self.log('prompt', [msg, defaultVal])
+      _prompt(msg, defaultVal)
     }
 
     // If we want to overload our console, then do it

--- a/test/client/karma.spec.js
+++ b/test/client/karma.spec.js
@@ -252,6 +252,38 @@ describe('Karma', function () {
       mockWindow.alert('What?')
       assert(ck.log.calledWith('alert', ['What?']))
     })
+
+    it('should capture confirm', function () {
+      sinon.spy(ck, 'log')
+      var confirmCalled = false
+
+      var mockWindow = {
+        confirm: function () {
+          confirmCalled = true
+        }
+      }
+
+      ck.setupContext(mockWindow)
+      mockWindow.confirm('What?')
+      assert(ck.log.calledWith('confirm', ['What?']))
+      assert.equal(confirmCalled, true)
+    })
+
+    it('should capture prompt', function () {
+      sinon.spy(ck, 'log')
+      var promptCalled = false
+
+      var mockWindow = {
+        prompt: function () {
+          promptCalled = true
+        }
+      }
+
+      ck.setupContext(mockWindow)
+      mockWindow.prompt('What is your favorite color?', 'blue')
+      assert(ck.log.calledWith('prompt', ['What is your favorite color?', 'blue']))
+      assert.equal(promptCalled, true)
+    })
   })
 
   describe('complete', function () {


### PR DESCRIPTION
- Capture `window.confirm` & `window.prompt` usages in client

I think this addresses #694, although it is a little vague as to how it is desired to be done