### PR TITLE
Fix Log Levels in Docs

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -409,11 +409,11 @@ httpsServerOptions: {
 
 **Possible values:**
 
-  * `config.LOG_DISABLE`
-  * `config.LOG_ERROR`
-  * `config.LOG_WARN`
-  * `config.LOG_INFO`
-  * `config.LOG_DEBUG`
+  * `config.OFF`
+  * `config.ERROR`
+  * `config.WARN`
+  * `config.INFO`
+  * `config.DEBUG`
 
 **Description:** Level of logging.
 


### PR DESCRIPTION
The `log4js-node` [docs](https://github.com/nomiddlename/log4js-node/wiki/Category-levels) list different log level constants. When switching over to these, `logLevel` configuration option starts working. 