### PR TITLE
feat(config): allow config to be a default export

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -342,6 +342,9 @@ var parseConfig = function (configFilePath, cliOptions) {
 
     try {
       configModule = require(configFilePath)
+      if (typeof configModule === 'object' && typeof configModule.default !== 'undefined') {
+        configModule = configModule.default
+      }
     } catch (e) {
       if (e.code === 'MODULE_NOT_FOUND' && e.message.indexOf(configFilePath) !== -1) {
         log.error('File %s does not exist!', configFilePath)

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -45,7 +45,8 @@ describe('config', () => {
       '/conf/exclude.js': wrapCfg({exclude: ['one.js', 'sub/two.js']}),
       '/conf/absolute.js': wrapCfg({files: ['http://some.com', 'https://more.org/file.js']}),
       '/conf/both.js': wrapCfg({files: ['one.js', 'two.js'], exclude: ['third.js']}),
-      '/conf/coffee.coffee': wrapCfg({files: ['one.js', 'two.js']})
+      '/conf/coffee.coffee': wrapCfg({files: ['one.js', 'two.js']}),
+      '/conf/default-export.js': {default: wrapCfg({files: ['one.js', 'two.js']})}
     }
 
     // load file under test
@@ -293,6 +294,11 @@ describe('config', () => {
 
       config = normalizeConfigWithDefaults({ protocol: 'unsupported:' })
       expect(config.protocol).to.equal('http:')
+    })
+
+    it('should allow the config to be set of the default export', () => {
+      var config = e.parseConfig('/conf/default-export.js', {})
+      expect(config.autoWatch).to.equal(true)
     })
   })
 


### PR DESCRIPTION
This allows folks using typescript karma config files to do
```
// karma.conf.ts
export default function(config) {
  config.set({
    basePath: './'
  })
}
```