### PR TITLE
chore: switch from ghooks to husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -351,7 +351,6 @@
     "eslint-plugin-promise": "^1.0.8",
     "eslint-plugin-react": "^6.9.0",
     "eslint-plugin-standard": "^1.3.1",
-    "ghooks": "^1.1.0",
     "grunt": "^1.0.0",
     "grunt-auto-release": "^0.0.7",
     "grunt-browserify": "^5.0.0",
@@ -365,6 +364,7 @@
     "grunt-mocha-test": "^0.12.7",
     "grunt-npm": "0.0.2",
     "http2": "^3.3.6",
+    "husky": "^0.12.0",
     "jasmine-core": "^2.3.4",
     "json3": "^3.3.2",
     "karma-browserify": "^5.0.1",
@@ -424,12 +424,8 @@
     "init": "rm -rf node_modules/karma && cd node_modules && ln -nsf ../ karma && cd ../",
     "init:windows": "(IF EXIST node_modules\\karma (rmdir node_modules\\karma /S /q)) && npm run link",
     "appveyor": "npm run lint && npm run build && npm run test:appveyor",
-    "travis": "npm run lint && npm run build && npm test && npm run test:integration"
-  },
-  "config": {
-    "ghooks": {
-      "pre-commit": "npm run lint",
-      "commit-msg": "validate-commit-msg"
-    }
+    "travis": "npm run lint && npm run build && npm test && npm run test:integration",
+    "commitmsg": "validate-commit-msg",
+    "precommit": "npm run lint"
   }
 }


### PR DESCRIPTION
ghooks is now deprecated in favour of husky. Also requires your local git checkout to be nuked and started from scratch to uninstall the old ghooks