### PR TITLE
filter browser logging by level of LOG

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -286,7 +286,7 @@ var Config = function () {
   this.basePath = ''
   this.files = []
   this.browserConsoleLogOptions = {
-    level: 'log',
+    level: 'debug',
     format: '%b %T: %m',
     terminal: true
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -286,7 +286,7 @@ var Config = function () {
   this.basePath = ''
   this.files = []
   this.browserConsoleLogOptions = {
-    level: 'debug',
+    level: 'log',
     format: '%b %T: %m',
     terminal: true
   }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -15,13 +15,14 @@ exports.LOG_ERROR = 'ERROR'
 exports.LOG_WARN = 'WARN'
 exports.LOG_INFO = 'INFO'
 exports.LOG_DEBUG = 'DEBUG'
+exports.LOG_LOG = 'LOG'
 exports.LOG_PRIORITIES = [
   exports.LOG_DISABLE,
   exports.LOG_ERROR,
   exports.LOG_WARN,
   exports.LOG_INFO,
   exports.LOG_DEBUG,
-  exports.LOG_DISABLE
+  exports.LOG_LOG
 ]
 
 // Default patterns for the pattern layout.

--- a/test/e2e/browser_console.feature
+++ b/test/e2e/browser_console.feature
@@ -54,8 +54,7 @@ Feature: Browser Console Configuration
       ];
       browserConsoleLogOptions = {
         path: 'console.log',
-        format: '%t:%m',
-        level: 'log'
+        format: '%t:%m'
       };
       """
     When I start Karma
@@ -79,8 +78,7 @@ Feature: Browser Console Configuration
       ];
       browserConsoleLogOptions = {
         path: 'console.log',
-        format: '%t:%T:%m',
-        level: 'log'
+        format: '%t:%T:%m'
       };
       """
     When I start Karma

--- a/test/e2e/browser_console.feature
+++ b/test/e2e/browser_console.feature
@@ -11,7 +11,10 @@ Feature: Browser Console Configuration
       plugins = [
         'karma-jasmine',
         'karma-phantomjs-launcher'
-      ];
+      ],
+      browserConsoleLogOptions = {
+        level: 'log'
+      };
       """
     When I start Karma
     Then it passes with like:

--- a/test/e2e/browser_console.feature
+++ b/test/e2e/browser_console.feature
@@ -54,7 +54,8 @@ Feature: Browser Console Configuration
       ];
       browserConsoleLogOptions = {
         path: 'console.log',
-        format: '%t:%m'
+        format: '%t:%m',
+        level: 'log'
       };
       """
     When I start Karma
@@ -78,7 +79,8 @@ Feature: Browser Console Configuration
       ];
       browserConsoleLogOptions = {
         path: 'console.log',
-        format: '%t:%T:%m'
+        format: '%t:%T:%m',
+        level: 'log'
       };
       """
     When I start Karma

--- a/test/unit/reporters/base.spec.js
+++ b/test/unit/reporters/base.spec.js
@@ -83,9 +83,45 @@ describe('reporter', function () {
       return expect(writeSpy).to.have.been.calledWith('LOG: Message\n')
     })
 
-    it('should not log if lower priority than browserConsoleLogOptions.level', function () {
+    it('should not log if lower priority than browserConsoleLogOptions "error"', function () {
       var reporter = new m.BaseReporter(null, null, true, {
-        browserConsoleLogOptions: {level: 'ERROR'}
+        browserConsoleLogOptions: {level: 'error'}
+      }, adapter)
+      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+
+      reporter._browsers = ['Chrome']
+      reporter.onBrowserLog('Chrome', 'Message', 'WARN')
+
+      return writeSpy.should.have.not.been.called
+    })
+    
+    it('should not log if lower priority than browserConsoleLogOptions "warn"', function () {
+      var reporter = new m.BaseReporter(null, null, true, {
+        browserConsoleLogOptions: {level: 'warn'}
+      }, adapter)
+      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+
+      reporter._browsers = ['Chrome']
+      reporter.onBrowserLog('Chrome', 'Message', 'INFO')
+
+      return writeSpy.should.have.not.been.called
+    })
+    
+    it('should not log if lower priority than browserConsoleLogOptions "info"', function () {
+      var reporter = new m.BaseReporter(null, null, true, {
+        browserConsoleLogOptions: {level: 'info'}
+      }, adapter)
+      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+
+      reporter._browsers = ['Chrome']
+      reporter.onBrowserLog('Chrome', 'Message', 'DEBUG')
+
+      return writeSpy.should.have.not.been.called
+    })    
+
+    it('should not log if lower priority than browserConsoleLogOptions "debug"', function () {
+      var reporter = new m.BaseReporter(null, null, true, {
+        browserConsoleLogOptions: {level: 'debug'}
       }, adapter)
       var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 

--- a/test/unit/reporters/base.spec.js
+++ b/test/unit/reporters/base.spec.js
@@ -94,7 +94,7 @@ describe('reporter', function () {
 
       return writeSpy.should.have.not.been.called
     })
-    
+
     it('should not log if lower priority than browserConsoleLogOptions "warn"', function () {
       var reporter = new m.BaseReporter(null, null, true, {
         browserConsoleLogOptions: {level: 'warn'}
@@ -106,7 +106,7 @@ describe('reporter', function () {
 
       return writeSpy.should.have.not.been.called
     })
-    
+
     it('should not log if lower priority than browserConsoleLogOptions "info"', function () {
       var reporter = new m.BaseReporter(null, null, true, {
         browserConsoleLogOptions: {level: 'info'}
@@ -117,7 +117,7 @@ describe('reporter', function () {
       reporter.onBrowserLog('Chrome', 'Message', 'DEBUG')
 
       return writeSpy.should.have.not.been.called
-    })    
+    })
 
     it('should not log if lower priority than browserConsoleLogOptions "debug"', function () {
       var reporter = new m.BaseReporter(null, null, true, {


### PR DESCRIPTION
Additional fix to the next bug:
filter browser logging by level  ([35965d9](https://github.com/karma-runner/karma/commit/35965d9)), closes [#2228](https://github.com/karma-runner/karma/issues/2228)
otherwise `console.log` ignore doesn't work with 
```
browserConsoleLogOptions: {
        level: 'debug',
        terminal: true
    }
```