### PR TITLE
chore(package): add es3 babel preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es3", "es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -342,6 +342,7 @@
     "LiveScript": "^1.3.0",
     "babel": "^6.5.2",
     "babel-preset-es2015": "^6.9.0",
+    "babel-preset-es3": "^1.0.1",
     "babel-register": "^6.9.0",
     "chai": "^3.3.0",
     "chai-as-promised": "^5.0.0",


### PR DESCRIPTION
Adding the es3 babel preset ensures the highest compatibility with
browsers like IE8.
In the babelrc file, the preset comes before the es2015 preset because
the presets are executed in reverse order. So, the es2015 preset will
run before the es3 preset, which is what we want to have happen.