### PR TITLE
Modified note on config languages to include TypeScript

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -6,7 +6,7 @@ is by using the `karma init` command. This page lists all of the available confi
 Note: Most of the framework adapters, reporters, preprocessors and launchers needs to be loaded as [plugins].
 
 
-The Karma configuration file can be written in JavaScript or CoffeeScript and is loaded as a regular Node.js module.
+The Karma configuration file can be written in JavaScript, CoffeeScript, or TypeScript and is loaded as a regular Node.js module.
 
 Unless provided as argument, the Karma CLI will look for a configuration file at
 


### PR DESCRIPTION
The list of files showing how Karma finds configuration lists TypeScript, but the note preceding it did not. Small change, nothing crazy.