### PR TITLE
update node support to v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - 4
   - 5
   - 6
+  - 7
 
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "5"
     - nodejs_version: "6"
+    - nodejs_version: "7"
 
 matrix:
   fast_finish: true

--- a/docs/intro/01-installation.md
+++ b/docs/intro/01-installation.md
@@ -5,7 +5,7 @@ Karma runs on [Node.js] and is available as an [NPM] package.
 On Mac or Linux we recommend using [NVM](https://github.com/creationix/nvm). On Windows, download Node.js
 from [the official site](https://nodejs.org/) or use the [NVM PowerShell Module](https://www.powershellgallery.com/packages/nvm).
 
-Note: Karma currently works on Node.js **0.10**, **0.12.x**, **4.x**, **5.x**, and **6.x**. See [FAQ] for more info.
+Note: Karma currently works on Node.js **0.10**, **0.12.x**, **4.x**, **5.x**, **6.x**, and **7.x**. See [FAQ] for more info.
 
 ## Installing Karma and plugins
 

--- a/package.json
+++ b/package.json
@@ -411,7 +411,7 @@
     "karma": "./bin/karma"
   },
   "engines": {
-    "node": "0.10 || 0.12 || 4 || 5 || 6"
+    "node": "0.10 || 0.12 || 4 || 5 || 6 || 7"
   },
   "version": "1.4.1",
   "license": "MIT",


### PR DESCRIPTION
I'm openning this to improve the node support to v7.

- Update `engine` in `package.json` to support Node v7. 
- Update `travis.yml`  to run env Node v7. 
- Update `appveyor.yml`  to run env Node v7. 
- Update `01-installation.md` adding Node  v7. 

It closes the issue #2559 