### PR TITLE
files.included is not an array, keys might not be an index

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -175,10 +175,10 @@ var createKarmaMiddleware = function (
           var scriptTags = []
           var scriptUrls = []
           for (var i in files.included) {
-            if ( ! files.included.hasOwnProperty(i) ) {
+            if (!files.included.hasOwnProperty(i)) {
                 // files.included is not an array
                 // keys might not be an index
-                break;
+              break
             }
             var file = files.included[i]
             var filePath = file.path

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -175,6 +175,11 @@ var createKarmaMiddleware = function (
           var scriptTags = []
           var scriptUrls = []
           for (var i in files.included) {
+            if ( ! files.included.hasOwnProperty(i) ) {
+                // files.included is not an array
+                // keys might not be an index
+                break;
+            }
             var file = files.included[i]
             var filePath = file.path
             var fileExt = path.extname(filePath)


### PR DESCRIPTION
Our test-suite failed with karma 1.5.0 as the array of filePathes always contained an undefined object.