### PR TITLE
Does not work with Mootools

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -179,6 +179,10 @@ var createKarmaMiddleware = function (
             var filePath = file.path
             var fileExt = path.extname(filePath)
 
+            if (!files.included.hasOwnProperty(i)) {
+              continue
+            }
+
             if (!file.isUrl) {
               filePath = filePathToUrlPath(filePath, basePath, urlRoot, proxyPath)
 


### PR DESCRIPTION
The for..in loop was not working with mootools because mootools  adds functions to the array prototype.

checking for own property