### PR TITLE
fix(client): add proxy support to stringify

### DIFF
--- a/common/stringify.js
+++ b/common/stringify.js
@@ -19,7 +19,18 @@ var stringify = function stringify (obj, depth) {
     case 'undefined':
       return 'undefined'
     case 'function':
-      return obj.toString().replace(/\{[\s\S]*\}/, '{ ... }')
+      try {
+        // function abc(a, b, c) { /* code goes here */ }
+        //   -> function abc(a, b, c) { ... }
+        return obj.toString().replace(/\{[\s\S]*\}/, '{ ... }')
+      } catch (err) {
+        if (err instanceof TypeError) {
+          // Proxy(function abc(...) { ... })
+          return 'Proxy(function ' + (obj.name || '') + '(...) { ... })'
+        } else {
+          throw err
+        }
+      }
     case 'boolean':
       return obj ? 'true' : 'false'
     case 'object':

--- a/test/client/stringify.spec.js
+++ b/test/client/stringify.spec.js
@@ -36,6 +36,18 @@ describe('stringify', function () {
     })
   })
 
+  // Conditionally run Proxy tests as it's not supported by all browsers yet
+  //   http://caniuse.com/#feat=proxy
+  if (window.Proxy) {
+    it('should serialize proxied functions', function () {
+      var abcProxy = new Proxy(function abc (a, b, c) { return 'whatever' }, {})
+      var defProxy = new Proxy(function (d, e, f) { return 'whatever' }, {})
+
+      assert.deepEqual(stringify(abcProxy), 'Proxy(function abc(...) { ... })')
+      assert.deepEqual(stringify(defProxy), 'Proxy(function (...) { ... })')
+    })
+  }
+
   it('should serialize arrays', function () {
     assert.deepEqual(stringify(['a', 'b', null, true, false]), "['a', 'b', null, true, false]")
   })


### PR DESCRIPTION
In https://github.com/twolfson/karma-electron/issues/20, we received a bug report with respect to serializing Electron's remote modules. After some digging, it turns out this was being caused by a serialization attempt on `Proxy` wrapped functions:

https://github.com/electron/electron/blob/v1.6.3/lib/renderer/api/remote.js#L170-L190

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString

```js
new Proxy(function x () {}, {}).toString()
// VM594:1 Uncaught TypeError: Function.prototype.toString is not generic
//    at Proxy.toString (<anonymous>)
//    at <anonymous>:1:33
```

Unfortunately, there is no patch/workaround for serializing proxies. Although, they can provide a custom `toString()` function if they want:

```
new Proxy(function x () {}, {get: function () { return function () { return x.toString() }; }}).toString()
// "function x() {}"
```

As a result, we should attempt to serialize normally and fallback if we fail. In this PR:

- Added test for proxy behavior
- Added serialization fallback for proxies

Here's proof of it working with Electron:

```
Object{clipboard: Object{availableFormats: Proxy(function remoteMemberFunction(...) { ... }), has: Proxy(function remoteMemberFunction(...) { ... }), 
```