### PR TITLE
feat(proxy): add proxy events to config

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -702,6 +702,43 @@ is handed off to [socket.io](http://socket.io/) (which manages the communication
 between browsers and the testing server).
 
 
+## proxyReq
+**Type:** Function
+
+**Default:** `undefined`
+
+**Description:** Called when requesting Proxy.
+
+Details about this can be found in the [node-http-proxy](https://github.com/nodejitsu/node-http-proxy). An example of overwriting the HTTP header is shown below.
+
+**Example:**
+```javascript
+proxyReq: function(proxyReq, req, res, options) {
+  proxyReq.setHeader('Referer', 'https://www.example.com/');
+}
+```
+
+## proxyRes
+**Type:** Function
+
+**Default:** `undefined`
+
+**Description:** Called when respnsing Proxy.
+
+Details about this can be found in the [node-http-proxy](https://github.com/nodejitsu/node-http-proxy). An example of overwriting the HTTP header is shown below.
+
+**Example:**
+```javascript
+proxyRes: function(proxyRes, req, res) {
+  if (proxyRes.headers['set-cookie']) {
+    proxyRes.headers['set-cookie'] = proxyRes.headers['set-cookie'].map(function (cookie) {
+      return cookie.replace(/\s*secure;?/i, '');
+    })
+  }
+}
+```
+
+
 ## upstreamProxy
 **Type:** Object
 

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -62,6 +62,13 @@ var parseProxyConfig = function (proxies, config) {
       secure: config.proxyValidateSSL
     })
 
+    ;['proxyReq', 'proxyRes'].forEach(function (name) {
+        var callback = proxyDetails[name] || config[name]
+        if (callback) {
+          proxy.on(name, callback)
+        }
+    })
+
     proxy.on('error', function proxyError (err, req, res) {
       if (err.code === 'ECONNRESET' && req.socket.destroyed) {
         log.debug('failed to proxy %s (browser hung up the socket)', req.url)

--- a/test/unit/middleware/proxy.spec.js
+++ b/test/unit/middleware/proxy.spec.js
@@ -338,6 +338,15 @@ describe('middleware.proxy', () => {
     expect(parsedProxyConfig[0].proxy).to.exist
   })
 
+  it('should bind proxy event', () => {
+    var proxy = {'/base/': 'http://localhost:8000/'}
+    var config = {proxyReq: function proxyReq() {}, proxyRes: function proxyRes() {}}
+    var parsedProxyConfig = m.parseProxyConfig(proxy, config)
+    expect(parsedProxyConfig).to.have.length(1)
+    expect(parsedProxyConfig[0].proxy.listeners('proxyReq', true)).to.equal(true)
+    expect(parsedProxyConfig[0].proxy.listeners('proxyRes', true)).to.equal(true)
+  })
+
   it('should handle empty proxy config', () => {
     expect(m.parseProxyConfig({})).to.deep.equal([])
   })


### PR DESCRIPTION
Add a new user configurable property proxy event
[nodejitsu/node\-http\-proxy: A full\-featured http proxy for node\.js](https://github.com/nodejitsu/node-http-proxy#listening-for-proxy-events)