### PR TITLE
chore: relocate console.log test file into test/e2e and ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tmp/*
 docs/_build
 *.swp
 *.swo
+test/e2e/console.log
 test/e2e/coverage/coverage
 test/e2e/coverageQunit/coverage
 test/e2e/coverageRequirejs/coverage

--- a/console.log
+++ b/console.log
@@ -1,5 +1,0 @@
-PhantomJS 2.1.1 (Mac OS X 0.0.0)
-PhantomJS 2.1.1 (Mac OS X 0.0.0)
-PhantomJS 2.1.1 (Mac OS X 0.0.0)
-PhantomJS 2.1.1 (Mac OS X 0.0.0)
-PhantomJS 2.1.1 (Mac OS X 0.0.0)

--- a/test/e2e/browser_console.feature
+++ b/test/e2e/browser_console.feature
@@ -53,12 +53,12 @@ Feature: Browser Console Configuration
         'karma-phantomjs-launcher'
       ];
       browserConsoleLogOptions = {
-        path: 'console.log',
+        path: 'test/e2e/console.log',
         format: '%t:%m'
       };
       """
     When I start Karma
-    Then the file at console.log contains:
+    Then the file at test/e2e/console.log contains:
       """
       log:'foo'
       debug:'bar'
@@ -77,12 +77,12 @@ Feature: Browser Console Configuration
         'karma-phantomjs-launcher'
       ];
       browserConsoleLogOptions = {
-        path: 'console.log',
+        path: 'test/e2e/console.log',
         format: '%t:%T:%m'
       };
       """
     When I start Karma
-    Then the file at console.log contains:
+    Then the file at test/e2e/console.log contains:
       """
       log:LOG:'foo'
       debug:DEBUG:'bar'
@@ -101,13 +101,13 @@ Feature: Browser Console Configuration
         'karma-phantomjs-launcher'
       ];
       browserConsoleLogOptions = {
-        path: 'console.log',
+        path: 'test/e2e/console.log',
         format: '%t:%T:%m',
         level: 'warn'
       };
       """
     When I start Karma
-    Then the file at console.log contains:
+    Then the file at test/e2e/console.log contains:
       """
       log:LOG:'foo'
       warn:WARN:'foobar'
@@ -124,12 +124,12 @@ Feature: Browser Console Configuration
         'karma-phantomjs-launcher'
       ];
       browserConsoleLogOptions = {
-        path: 'console.log',
+        path: 'test/e2e/console.log',
         format: '%b'
       };
       """
     When I start Karma
-    Then the file at console.log contains:
+    Then the file at test/e2e/console.log contains:
       """
       Phantom
       """
@@ -144,7 +144,7 @@ Feature: Browser Console Configuration
         'karma-phantomjs-launcher'
       ];
       browserConsoleLogOptions = {
-        path: 'console.log',
+        path: 'test/e2e/console.log',
         format: '%b',
         terminal: false
       };


### PR DESCRIPTION
During my recent Karma contribution, I started getting a persistent one-off change in a `console.log` file which got annoying to avoid via `git add -p`:

```diff
$ git diff
diff --git a/console.log b/console.log
index 10d33cb..029f6fe 100644
--- a/console.log
+++ b/console.log
@@ -1,5 +1,5 @@
-PhantomJS 2.1.1 (Mac OS X 0.0.0)
-PhantomJS 2.1.1 (Mac OS X 0.0.0)
-PhantomJS 2.1.1 (Mac OS X 0.0.0)
-PhantomJS 2.1.1 (Mac OS X 0.0.0)
-PhantomJS 2.1.1 (Mac OS X 0.0.0)
+PhantomJS 2.1.1 (Linux 0.0.0)
+PhantomJS 2.1.1 (Linux 0.0.0)
+PhantomJS 2.1.1 (Linux 0.0.0)
+PhantomJS 2.1.1 (Linux 0.0.0)
+PhantomJS 2.1.1 (Linux 0.0.0)
```

This was being caused by a dynamically generated test file that somehow got added to `git`. In this PR:

- Removed `console.log` from `git`
- Relocated `console.log` to `test/e2e` folder where it originates (consistent with `test/unit/test.log` setup)
    - https://github.com/karma-runner/karma/blob/v1.5.0/test/unit/logger.spec.js#L15
    - https://github.com/karma-runner/karma/blob/v1.5.0/.gitignore#L16