### PR TITLE
Update minimatch dependency to avoid DoS

### DIFF
--- a/package.json
+++ b/package.json
@@ -335,7 +335,7 @@
     "lodash": "^3.8.0",
     "log4js": "^0.6.31",
     "mime": "^1.3.4",
-    "minimatch": "^3.0.0",
+    "minimatch": "^3.0.2",
     "optimist": "^0.6.1",
     "qjobs": "^1.1.4",
     "range-parser": "^1.2.0",


### PR DESCRIPTION
> npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

The current version constraint for minimatch (as a production dependency) allows a version that's vulnerable to a denial of service.

https://nodesecurity.io/advisories/minimatch_regular-expression-denial-of-service