### PR TITLE
fix: return result of confirm and prompt

### DIFF
--- a/context/karma.js
+++ b/context/karma.js
@@ -89,12 +89,12 @@ var ContextKarma = function (callParentKarmaMethod) {
 
     contextWindow.confirm = function (msg) {
       self.log('confirm', [msg])
-      _confirm(msg)
+      return _confirm(msg)
     }
 
     contextWindow.prompt = function (msg, defaultVal) {
       self.log('prompt', [msg, defaultVal])
-      _prompt(msg, defaultVal)
+      return _prompt(msg, defaultVal)
     }
 
     // If we want to overload our console, then do it

--- a/test/client/karma.spec.js
+++ b/test/client/karma.spec.js
@@ -261,13 +261,15 @@ describe('Karma', function () {
       var mockWindow = {
         confirm: function () {
           confirmCalled = true
+          return true
         }
       }
 
       ck.setupContext(mockWindow)
-      mockWindow.confirm('What?')
+      var confirmResult = mockWindow.confirm('What?')
       assert(ck.log.calledWith('confirm', ['What?']))
       assert.equal(confirmCalled, true)
+      assert.equal(confirmResult, true)
     })
 
     it('should capture prompt', function () {
@@ -277,13 +279,15 @@ describe('Karma', function () {
       var mockWindow = {
         prompt: function () {
           promptCalled = true
+          return 'user-input'
         }
       }
 
       ck.setupContext(mockWindow)
-      mockWindow.prompt('What is your favorite color?', 'blue')
+      var promptResult = mockWindow.prompt('What is your favorite color?', 'blue')
       assert(ck.log.calledWith('prompt', ['What is your favorite color?', 'blue']))
       assert.equal(promptCalled, true)
+      assert.equal(promptResult, 'user-input')
     })
   })
 


### PR DESCRIPTION
When confirm and prompt were wrapped here https://github.com/karma-runner/karma/commit/3a618b3ce51f7fb8da94636562ba2ed785da0579, returning the results of these methods was forgotten. This fixes that.