### PR TITLE
chore(package): update eslint-config-standard to version 7.0.0

### DIFF
--- a/lib/middleware/common.js
+++ b/lib/middleware/common.js
@@ -89,7 +89,7 @@ var createServeFile = function (fs, directory, config) {
       response.setHeader('Content-Type', mime.lookup(filepath, 'text/plain'))
 
       // call custom transform fn to transform the data
-      responseData = transform && transform(content) || content
+      responseData = (transform && transform(content)) || content
 
       if (rangeHeader) {
         var code = convertForRangeRequest()
@@ -114,7 +114,7 @@ var createServeFile = function (fs, directory, config) {
       response.setHeader('Content-Type', mime.lookup(filepath, 'text/plain'))
 
       // call custom transform fn to transform the data
-      responseData = transform && transform(data.toString()) || data
+      responseData = (transform && transform(data.toString())) || data
 
       if (rangeHeader) {
         var code = convertForRangeRequest()

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -63,10 +63,10 @@ var parseProxyConfig = function (proxies, config) {
     })
 
     ;['proxyReq', 'proxyRes'].forEach(function (name) {
-        var callback = proxyDetails[name] || config[name]
-        if (callback) {
-          proxy.on(name, callback)
-        }
+      var callback = proxyDetails[name] || config[name]
+      if (callback) {
+        proxy.on(name, callback)
+      }
     })
 
     proxy.on('error', function proxyError (err, req, res) {

--- a/package.json
+++ b/package.json
@@ -357,7 +357,7 @@
     "coffee-script": "^1.12.4",
     "cucumber": "^1.2.0",
     "eslint": "^3.15.0",
-    "eslint-config-standard": "^6.2.1",
+    "eslint-config-standard": "^7.0.0",
     "eslint-plugin-promise": "^3.4.2",
     "eslint-plugin-react": "^6.10.0",
     "eslint-plugin-standard": "^2.0.1",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -6,5 +6,8 @@
     "expect": true,
     "sinon": true,
     "scheduleNextTick": true
+  },
+  "rules": {
+    "no-unused-expressions": "off"
   }
 }


### PR DESCRIPTION
I had to turn off 'no-unused-expressions' in the test directory since a lot of the mocha expectations look something like:

```javascript
expect(spyRegister).to.have.been.called
```

which eslint thinks has no effect.