### PR TITLE
fix(reporter): keep users exact formatError result

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -652,11 +652,11 @@ Note: Just about all additional reporters in Karma (other than progress) require
 
 **Arguments:**
 
-  * `msg` - The entire assertion error and stack trace as a string.
+  * `msg` - A single line of the assertion error and stack trace (called for each line).
 
-**Returns:** A new error message string.
+**Returns:** A new error message line.
 
-**Description:** Format assertion errors and stack traces.  Useful for removing vendors and compiled sources.
+**Description:** Format assertion errors and stack traces.  Useful for removing vendors and compiled sources.  Return an empty line `''` to remove it.
 
 The CLI option should be a path to a file that exports the format function.  This can be a function exported at the root of the module or an export named `formatError`.
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -96,7 +96,7 @@ var createErrorFormatter = function (config, emitter, SourceMapConsumer) {
 
     // allow the user to format the error
     if (config.formatError) {
-      msg = config.formatError(msg)
+      return config.formatError(msg)
     }
 
     return msg + '\n'

--- a/test/unit/reporter.spec.js
+++ b/test/unit/reporter.spec.js
@@ -48,11 +48,11 @@ describe('reporter', () => {
       expect(spy.firstCall.args[0]).to.equal(ERROR)
     })
 
-    it('should display the error returned by config.formatError', () => {
+    it('should display the exact error returned by config.formatError', () => {
       var formattedError = 'A new error'
       formatError = m.createErrorFormatter({ basePath: '', formatError: () => formattedError }, emitter)
 
-      expect(formatError('Something', '\t')).to.equal(formattedError + '\n')
+      expect(formatError('Something', '\t')).to.equal(formattedError)
     })
 
     it('should indent', () => {


### PR DESCRIPTION
I wrote this feature originally and haven't had time to come back and address this issue until now. See https://github.com/karma-runner/karma/issues/2119#issuecomment-248404728.
***
Fixes #2626 

The main purpose of the `formatError` function, per the docs, is to trim down the stack trace.  However, no matter the return value configured, a new line is always appended.  This means even when lines are removed a blank new line is still added.  This results in large, blank, stack traces:

![image](https://cloud.githubusercontent.com/assets/5067638/24320729/1d2859ec-10f8-11e7-9994-e1ff35c51c30.png)

This PR simply returns the _exact_ value the user has configured in their `formatError` function, without appending a newline to it.  This allows for removing lines from the stack trace:

![image](https://cloud.githubusercontent.com/assets/5067638/24320813/452f4db8-10fa-11e7-8b5e-1030b9b93252.png)
