### PR TITLE
feat(launcher): output stderr for failing launchers

### DIFF
--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -77,6 +77,10 @@ var ProcessLauncher = function (spawn, tempDir, timer, processKillTimeout) {
         errorOutput += err.toString()
       }
     })
+
+    self._process.stderr.on('data', function (errBuff) {
+      errorOutput += errBuff.toString()
+    })
   }
 
   this._onProcessExit = function (code, errorOutput) {

--- a/test/e2e/launcher-error.feature
+++ b/test/e2e/launcher-error.feature
@@ -1,0 +1,20 @@
+Feature: Launcher error
+  In order to use Karma
+  As a person who wants to write great tests
+  I want Karma to output stderr if a browser fails to connect.
+
+  Scenario: Broken Browser
+    Given a configuration with:
+      """
+      files = ['launcher-error/specs.js'];
+      browsers = [__dirname + '/launcher-error/fake-browser.sh'];
+      plugins = [
+        'karma-jasmine',
+        'karma-script-launcher'
+      ];
+      """
+    When I run Karma
+    Then it fails with like:
+      """
+      Missing fake dependency
+      """

--- a/test/e2e/support/launcher-error/fake-browser.sh
+++ b/test/e2e/support/launcher-error/fake-browser.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Missing fake dependency" 1>&2
+exit 1

--- a/test/e2e/support/launcher-error/specs.js
+++ b/test/e2e/support/launcher-error/specs.js
@@ -1,0 +1,5 @@
+describe('something', function () {
+  it('should never happen anyway', function () {
+    expect(true).toBe(true)
+  })
+})


### PR DESCRIPTION
In https://github.com/twolfson/karma-electron/issues/17, https://github.com/twolfson/karma-electron/issues/22, and personal experience, there's been scenarios when we're setting up Karma in CI and it's erroring out with no useful feedback. Typically this is due to a system dependency (e.g. missed an `apt-get` step).

This PR aims to resolve that by adding `stderr` to the output of failing launchers. In this PR:

- Added `stderr` output to launcher `errorOutput`
    - We didn't know if we wanted to be clever and indent everything so we went the simple route for now

**Before:**

```
30 03 2017 04:00:46.897:INFO [karma]: Karma v1.5.0 server started at http://0.0.0.0:9876/
30 03 2017 04:00:46.899:INFO [launcher]: Launching browser Firefox with unlimited concurrency
30 03 2017 04:00:46.906:INFO [launcher]: Starting browser Firefox
30 03 2017 04:00:46.922:ERROR [launcher]: Cannot start Firefox
	
30 03 2017 04:00:46.929:INFO [launcher]: Trying to start Firefox again (1/2).
30 03 2017 04:00:46.936:ERROR [launcher]: Cannot start Firefox
	
30 03 2017 04:00:46.940:INFO [launcher]: Trying to start Firefox again (2/2).
30 03 2017 04:00:46.949:ERROR [launcher]: Cannot start Firefox
	
30 03 2017 04:00:46.952:ERROR [launcher]: Firefox failed 2 times (cannot start). Giving up.
npm ERR! Test failed.  See above for more details.
```

**After:**

```
> gist-karma-launcher-fail@1.0.0 test /docker
> FIREFOX_BIN=$PWD/vendor/firefox/firefox karma start

30 03 2017 04:27:58.879:INFO [karma]: Karma v1.5.0 server started at http://0.0.0.0:9876/
30 03 2017 04:27:58.881:INFO [launcher]: Launching browser Firefox with unlimited concurrency
30 03 2017 04:27:58.888:INFO [launcher]: Starting browser Firefox
30 03 2017 04:27:58.925:ERROR [launcher]: Cannot start Firefox
	XPCOMGlueLoad error for file /docker/vendor/firefox/libmozgtk.so:
libgtk-3.so.0: cannot open shared object file: No such file or directory
Couldn't load XPCOM.

30 03 2017 04:27:58.930:INFO [launcher]: Trying to start Firefox again (1/2).
30 03 2017 04:27:58.941:ERROR [launcher]: Cannot start Firefox
	XPCOMGlueLoad error for file /docker/vendor/firefox/libmozgtk.so:
libgtk-3.so.0: cannot open shared object file: No such file or directory
Couldn't load XPCOM.

30 03 2017 04:27:58.943:INFO [launcher]: Trying to start Firefox again (2/2).
30 03 2017 04:27:58.959:ERROR [launcher]: Cannot start Firefox
	XPCOMGlueLoad error for file /docker/vendor/firefox/libmozgtk.so:
libgtk-3.so.0: cannot open shared object file: No such file or directory
Couldn't load XPCOM.

30 03 2017 04:27:58.964:ERROR [launcher]: Firefox failed 2 times (cannot start). Giving up.
npm ERR! Test failed.  See above for more details.
```

Here's a relevant gist to explore this for yourself:

https://gist.github.com/twolfson/f099e18cf5eb9cc55384e7a0582fbe10

https://github.com/twolfson/karma-electron/issues/22#issuecomment-290296817