### PR TITLE
chore(lint): repaired lint error on master

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -63,10 +63,10 @@ var parseProxyConfig = function (proxies, config) {
     })
 
     ;['proxyReq', 'proxyRes'].forEach(function (name) {
-        var callback = proxyDetails[name] || config[name]
-        if (callback) {
-          proxy.on(name, callback)
-        }
+      var callback = proxyDetails[name] || config[name]
+      if (callback) {
+        proxy.on(name, callback)
+      }
     })
 
     proxy.on('error', function proxyError (err, req, res) {


### PR DESCRIPTION
In my recent PR #2639, I saw that Travis CI was failing due to a lint error on `master`. I also saw that nobody had opened a PR to repair it yet so here's one. In this PR:

- Repaired lint error on `master`
