### PR TITLE
Remove debug message which shows location of config file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -357,7 +357,6 @@ var CONFIG_SYNTAX_HELP = '  module.exports = function(config) {\n' +
 var parseConfig = function (configFilePath, cliOptions) {
   var configModule
   if (configFilePath) {
-    log.debug('Loading config %s', configFilePath)
 
     try {
       configModule = require(configFilePath)


### PR DESCRIPTION
I was using `config.LOG_DISABLE` and noticed this message was still being outputted to the console. I figured this message is not actually needed unless an error is thrown, and that case is already catered for in the code.