### PR TITLE
feat(runner): Buffer stdout and stderr for output when errors occur

### DIFF
--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -6,6 +6,11 @@ var ProcessLauncher = function (spawn, tempDir, timer, processKillTimeout) {
   var self = this
   var onExitCallback
   var killTimeout = processKillTimeout || 2000
+  // Will hold output from the spawned child process
+  var streamedOutputs = {
+    stdout: '',
+    stderr: ''
+  }
 
   this._tempDir = tempDir.getPath('/karma-' + this.id.toString())
 
@@ -46,6 +51,14 @@ var ProcessLauncher = function (spawn, tempDir, timer, processKillTimeout) {
     return path.normalize(cmd)
   }
 
+  this._onStdout = function (data) {
+    streamedOutputs.stdout += data
+  }
+
+  this._onStderr = function (data) {
+    streamedOutputs.stderr += data
+  }
+
   this._execCommand = function (cmd, args) {
     if (!cmd) {
       log.error('No binary for %s browser on your platform.\n  ' +
@@ -61,8 +74,11 @@ var ProcessLauncher = function (spawn, tempDir, timer, processKillTimeout) {
 
     log.debug(cmd + ' ' + args.join(' '))
     self._process = spawn(cmd, args)
-
     var errorOutput = ''
+
+    self._process.stdout.on('data', self._onStdout)
+
+    self._process.stderr.on('data', self._onStderr)
 
     self._process.on('exit', function (code) {
       self._onProcessExit(code, errorOutput)
@@ -98,7 +114,14 @@ var ProcessLauncher = function (spawn, tempDir, timer, processKillTimeout) {
       error = 'crashed'
     }
 
+    if (error) {
+      log.error('%s stdout: %s', self.name, streamedOutputs.stdout)
+      log.error('%s stderr: %s', self.name, streamedOutputs.stderr)
+    }
+
     self._process = null
+    streamedOutputs.stdout = ''
+    streamedOutputs.stderr = ''
     if (self._killTimer) {
       timer.clearTimeout(self._killTimer)
       self._killTimer = null


### PR DESCRIPTION
When it is determined that an error occured during the run of a launch
it's useful to have output from the process.
We just need to know what was going on in order to debug (if necessary)

Related to karma-runner/karma#2663 Complete browser log output when process isn't started

# Example output for a failing browser:

![lamb sauce1](https://cloud.githubusercontent.com/assets/2829538/25085658/9d9d963c-2363-11e7-8199-a4ae52a10251.png)

Achieved with 

```bash
# Be in the project's root folder
folder=/tmp/karma-test
scriptName=faulty-browser.bash
script=$folder/$scriptName
mkdir -p $folder
echo '#!/usr/bin/env bash

echo "Starting..."
sleep 1
>&2 echo "An error was encountered"

exit 1
' > $script

chmod u+x $script

export PATH=$folder:$PATH
export CHROME_BIN=$scriptName
grunt test:client
```