### PR TITLE
Add bail on load errors

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -411,6 +411,7 @@ Server.prototype._setUpLoadErrorListener = function () {
   self.on('load_error', function (type, name) {
     self.log.debug('Registered a load error of type %s with name %s', type, name)
     self.loadErrors.push([type, name])
+    throw new Error('Error loading ' + type + ' with name ' + name)
   })
 }
 


### PR DESCRIPTION
# Problem description

If Karma receives an error during the load of one of the plugins it currently swallows that error and continues running other plugins and exits with a zero error code.

I discovered this by investigating a successful build that didn't run any test on CircleCI. Turns out CI servers need a non-zero exit code to mark a build as failed.

Webpack 1.0 had a similar issue and they introduced a bail option that is turned on by default in 2.0 with a workaround npm package for 1.0 called [webpack-fail-plugin](https://github.com/TiddoLangerak/webpack-fail-plugin). It would catch errors in plugins like babel that are used to compile the assets. A syntax error in the source code would cause babel plugin to fail and webpack would swallow the exception unless the bail option is on or fail plugin is present. See: https://github.com/webpack/webpack/issues/708

In the case of Karma the failure was in the PhantomJS npm package, where it could not locate the binary. It should have been a show stopper and reported a failure, but proceeded to load and execute the next plugins. See: https://github.com/karma-runner/karma-phantomjs-launcher/issues/120

This is my first attempt at looking at Karma, so please forgive my ignorance. This PR is a suggested solution and will need adjustments with your help.

# Outstanding questions:

1. Should we fail by default?
2. Should we also introduce a bail option that is on by default? Or perhaps use another option?
3. Is this the right place to handle errors like this?

# TODOs (would love help):

- [ ] Write a test for a plugin load error

Other related: https://github.com/webpack-contrib/karma-webpack/issues/66