### PR TITLE
fix(reporters): Revert the backwards-incompatible log priority order changes

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,9 +20,9 @@ exports.LOG_PRIORITIES = [
   exports.LOG_DISABLE,
   exports.LOG_ERROR,
   exports.LOG_WARN,
+  exports.LOG_LOG,
   exports.LOG_INFO,
-  exports.LOG_DEBUG,
-  exports.LOG_LOG
+  exports.LOG_DEBUG
 ]
 
 // Default patterns for the pattern layout.

--- a/test/e2e/browser_console.feature
+++ b/test/e2e/browser_console.feature
@@ -11,10 +11,7 @@ Feature: Browser Console Configuration
       plugins = [
         'karma-jasmine',
         'karma-phantomjs-launcher'
-      ],
-      browserConsoleLogOptions = {
-        level: 'log'
-      };
+      ];
       """
     When I start Karma
     Then it passes with like:

--- a/test/unit/reporters/base.spec.js
+++ b/test/unit/reporters/base.spec.js
@@ -104,6 +104,19 @@ describe('reporter', function () {
       var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome']
+      reporter.onBrowserLog('Chrome', 'Message', 'LOG')
+
+      return writeSpy.should.have.not.been.called
+    })
+
+    it('should not log if lower priority than browserConsoleLogOptions "log"', function () {
+      var reporter = new m.BaseReporter(null, null, true, {
+        level: 'log',
+        terminal: true
+      }, adapter)
+      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+
+      reporter._browsers = ['Chrome']
       reporter.onBrowserLog('Chrome', 'Message', 'INFO')
 
       return writeSpy.should.have.not.been.called
@@ -122,9 +135,35 @@ describe('reporter', function () {
       return writeSpy.should.have.not.been.called
     })
 
-    it('should not log if lower priority than browserConsoleLogOptions "debug"', function () {
+    it('should log if higher priority than browserConsoleLogOptions "warn"', function () {
       var reporter = new m.BaseReporter(null, null, true, {
-        level: 'debug',
+        level: 'warn',
+        terminal: true
+      }, adapter)
+      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+
+      reporter._browsers = ['Chrome']
+      reporter.onBrowserLog('Chrome', 'Message', 'ERROR')
+
+      return writeSpy.should.have.been.called
+    })
+
+    it('should log if higher priority than browserConsoleLogOptions "log"', function () {
+      var reporter = new m.BaseReporter(null, null, true, {
+        level: 'log',
+        terminal: true
+      }, adapter)
+      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+
+      reporter._browsers = ['Chrome']
+      reporter.onBrowserLog('Chrome', 'Message', 'WARN')
+
+      return writeSpy.should.have.been.called
+    })
+
+    it('should log if higher priority than browserConsoleLogOptions "info"', function () {
+      var reporter = new m.BaseReporter(null, null, true, {
+        level: 'info',
         terminal: true
       }, adapter)
       var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
@@ -132,7 +171,20 @@ describe('reporter', function () {
       reporter._browsers = ['Chrome']
       reporter.onBrowserLog('Chrome', 'Message', 'LOG')
 
-      return writeSpy.should.have.not.been.called
+      return writeSpy.should.have.been.called
+    })
+
+    it('should log if higher priority than browserConsoleLogOptions "debug"', function () {
+      var reporter = new m.BaseReporter(null, null, true, {
+        level: 'debug',
+        terminal: true
+      }, adapter)
+      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+
+      reporter._browsers = ['Chrome']
+      reporter.onBrowserLog('Chrome', 'Message', 'INFO')
+
+      return writeSpy.should.have.been.called
     })
 
     return it('should format log messages correctly for multi browsers', function () {

--- a/test/unit/reporters/base.spec.js
+++ b/test/unit/reporters/base.spec.js
@@ -85,7 +85,8 @@ describe('reporter', function () {
 
     it('should not log if lower priority than browserConsoleLogOptions "error"', function () {
       var reporter = new m.BaseReporter(null, null, true, {
-        browserConsoleLogOptions: {level: 'error'}
+        level: 'error',
+        terminal: true
       }, adapter)
       var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
@@ -97,7 +98,8 @@ describe('reporter', function () {
 
     it('should not log if lower priority than browserConsoleLogOptions "warn"', function () {
       var reporter = new m.BaseReporter(null, null, true, {
-        browserConsoleLogOptions: {level: 'warn'}
+        level: 'warn',
+        terminal: true
       }, adapter)
       var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
@@ -109,7 +111,8 @@ describe('reporter', function () {
 
     it('should not log if lower priority than browserConsoleLogOptions "info"', function () {
       var reporter = new m.BaseReporter(null, null, true, {
-        browserConsoleLogOptions: {level: 'info'}
+        level: 'info',
+        terminal: true
       }, adapter)
       var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
@@ -121,7 +124,8 @@ describe('reporter', function () {
 
     it('should not log if lower priority than browserConsoleLogOptions "debug"', function () {
       var reporter = new m.BaseReporter(null, null, true, {
-        browserConsoleLogOptions: {level: 'debug'}
+        level: 'debug',
+        terminal: true
       }, adapter)
       var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 


### PR DESCRIPTION
Commit 35965d9 changed the order of log priorities, making lots of
configurations no longer print console.log messages. This was a
backwards-incompatible change which this commit reverts.

Tests were added to ensure the proper order is respected.

Fixes #2582

----
Also, another commit in this PR:

test(reporters): Fix the log suppressing tests

The tests ensuring a lower priority doesn't get logged were written in an
incorrect format so even changing the order in the LOG_PRIORITIES array
would not make them fail.