### PR TITLE
Update 04-public-api.md

### DIFF
--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -14,6 +14,8 @@ var server = new Server({port: 9876}, function(exitCode) {
 })
 ```
 
+Notice the capital 'S' on  `require('karma').Server`.
+
 ### **server.start()**
 
 Equivalent of `karma start`.


### PR DESCRIPTION
Wondering why other exposed functions use lowercase, and Server uses upper. It seems inconsistent. Users receive a TypeError otherwise. 