### PR TITLE
fix(middleware): change to use vanilla for loop

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -174,7 +174,7 @@ var createKarmaMiddleware = function (
 
           var scriptTags = []
           var scriptUrls = []
-          for (var i in files.included) {
+          for (var i = 0; i < files.included.length; i++) {
             var file = files.included[i]
             var filePath = file.path
             var fileExt = path.extname(filePath)


### PR DESCRIPTION
- Change use of for..in to plain for loop due to issues where array prototype is modified

Fixes #2671