### PR TITLE
Stop core-js from polluting the global environment

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -7,7 +7,6 @@
 // Dependencies
 // ------------
 
-require('core-js')
 var from = require('core-js/library/fn/array/from')
 var Promise = require('bluebird')
 var mm = require('minimatch')


### PR DESCRIPTION
If using Karma programatically, core-js will poison the global environment with it's polyfills.

Is there a reason this was included? It looks like legacy code as core-js is included afterwards in a non-polluting way.