### PR TITLE
fix(file-list): Stop polluting global environment with core-js

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -7,7 +7,8 @@
 // Dependencies
 // ------------
 
-require('core-js')
+var Map = require('core-js/library/fn/map')
+var Set = require('core-js/library/fn/set')
 var from = require('core-js/library/fn/array/from')
 var Promise = require('bluebird')
 var mm = require('minimatch')


### PR DESCRIPTION
When using Karma programatically I came across issues which were due to core-js polluting the environment. It turns out that all Karma needs from core-js (whilst karma supports node 0.x versions) is `Map` and `Set`, switching to the file includes for these minimises the amount of core-js being used :-)