### PR TITLE
Better string representation of errors

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -136,6 +136,10 @@ var Karma = function (socket, iframe, opener, navigator, location) {
       message += '\n\n' + error.stack
     }
 
+    // create an object with the string representation of the message to ensure all its content is properly
+    // transferred to the console log
+    message = {message: message, str: message.toString()}
+
     socket.emit('karma_error', message)
     this.complete()
     return false


### PR DESCRIPTION
Resolves #2711

Before:
```
Chrome 59.0.3071 (Mac OS X 10.12.3) ERROR
 {
      "originalErr": {},
      "__zone_symbol__currentTask": {
        "type": "microTask",
        "state": "notScheduled",
        "source": "Promise.then",
        "zone": "<root>",
        "cancelFn": null,
        "runCount": 0
      }
  }
Chrome 59.0.3071 (Mac OS X 10.12.3): Executed 0 of 0 ERROR (1.348 secs / 0 secs)
```

After:
```
Chrome 59.0.3071 (Mac OS X 10.12.3) ERROR
 {
    "message": {
      "originalErr": {},
      "__zone_symbol__currentTask": {
        "type": "microTask",
        "state": "notScheduled",
        "source": "Promise.then",
        "zone": "<root>",
        "cancelFn": null,
        "runCount": 0
      }
    },
    "str": [
      "Error: (SystemJS) Object prototype may only be an Object or null: undefined",
      "    TypeError: Object prototype may only be an Object or null: undefined",
      "        at setPrototypeOf (<anonymous>)",
      "        at __extends$1 (dist/bundles/my-bundle.umd.js:2258:9)",
    ]
  }
Chrome 59.0.3071 (Mac OS X 10.12.3): Executed 0 of 0 ERROR (1.348 secs / 0 secs)
```
