### PR TITLE
Ywong/fix crash on read file error

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -86,7 +86,7 @@ var createPreprocessor = function (config, basePath, injector) {
           fs.readFile(file.originalPath, handleFile)
           return
         } else {
-          throw err
+          done()
         }
       }
 

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -75,10 +75,19 @@ var createPreprocessor = function (config, basePath, injector) {
 
   return function preprocess (file, done) {
     patterns = Object.keys(config)
-
-    return fs.readFile(file.originalPath, function (err, buffer) {
+    var retryCount = 0
+    var maxRetries = 3
+    function handleFile (err, buffer) {
       if (err) {
-        throw err
+        log.warn(err)
+        if (retryCount < maxRetries) {
+          retryCount++
+          log.warn('retrying ' + retryCount)
+          fs.readFile(file.originalPath, handleFile)
+          return
+        } else {
+          throw err
+        }
       }
 
       isBinaryFile(buffer, buffer.length, function (err, thisFileIsBinary) {
@@ -121,7 +130,8 @@ var createPreprocessor = function (config, basePath, injector) {
 
         nextPreprocessor(null, thisFileIsBinary ? buffer : buffer.toString())
       })
-    })
+    }
+    return fs.readFile(file.originalPath, handleFile)
   }
 }
 createPreprocessor.$inject = ['config.preprocessors', 'config.basePath', 'injector']

--- a/test/unit/preprocessor.spec.js
+++ b/test/unit/preprocessor.spec.js
@@ -229,6 +229,54 @@ describe('preprocessor', () => {
     })
   })
 
+  describe('when fs.readFile fails', () => {
+    var file = {originalPath: '/some/a.js', path: 'path'}
+    var getReadFileCallback = (nthCall) => {
+      return mockFs.readFile.args[nthCall][1]
+    }
+
+    beforeEach(() => {
+      sinon.stub(mockFs, 'readFile')
+    })
+
+    it('should retry up to 3 times', (done) => {
+      var fakePreprocessor = sinon.spy((content, file, done) => {
+        done(null, content)
+      })
+
+      var injector = new di.Injector([{
+        'preprocessor:fake': ['factory', () => fakePreprocessor]
+      }, emitterSetting])
+
+      var pp = m.createPreprocessor({'**/*.js': ['fake']}, null, injector)
+
+      pp(file, () => {
+        expect(fakePreprocessor).to.have.been.called
+        done()
+      })
+      getReadFileCallback(0)('error')
+      getReadFileCallback(1)('error')
+      var thirdCallback = getReadFileCallback(2)
+      mockFs.readFile.restore()
+      thirdCallback('error')
+    })
+
+    it('should tbrow after 3 retries', (done) => {
+      var injector = new di.Injector([{}, emitterSetting])
+
+      var pp = m.createPreprocessor({'**/*.js': []}, null, injector)
+
+      pp(file, () => { })
+
+      getReadFileCallback(0)('error')
+      getReadFileCallback(1)('error')
+      getReadFileCallback(2)('error')
+
+      expect(() => getReadFileCallback(0)('error')).to.throw('error')
+      done()
+    })
+  })
+
   it('should not preprocess binary files', (done) => {
     var fakePreprocessor = sinon.spy((content, file, done) => {
       done(null, content)

--- a/test/unit/preprocessor.spec.js
+++ b/test/unit/preprocessor.spec.js
@@ -261,19 +261,19 @@ describe('preprocessor', () => {
       thirdCallback('error')
     })
 
-    it('should tbrow after 3 retries', (done) => {
+    it('should abort after 3 retries', (done) => {
       var injector = new di.Injector([{}, emitterSetting])
 
       var pp = m.createPreprocessor({'**/*.js': []}, null, injector)
 
-      pp(file, () => { })
+      pp(file, () => {
+        done()
+      })
 
       getReadFileCallback(0)('error')
       getReadFileCallback(1)('error')
       getReadFileCallback(2)('error')
-
-      expect(() => getReadFileCallback(0)('error')).to.throw('error')
-      done()
+      getReadFileCallback(3)('error')
     })
   })
 


### PR DESCRIPTION
When saving a file in IDEs like Visual Studio, Atom, a dozen operations including read/write/delete/rename are performed on the file, there are nearly 50% chance karma will crash because the file is locked

There werer multiple issues raised because of this

https://github.com/karma-runner/karma/issues/1397
https://github.com/karma-runner/karma/issues/1213
https://github.com/karma-runner/karma/issues/959

The solution is retry reading file if fs.readFile fails and abort after 3 retries