### PR TITLE
fix(preprocessor): retry if fs.readFile fails

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -86,7 +86,7 @@ var createPreprocessor = function (config, basePath, injector) {
           fs.readFile(file.originalPath, handleFile)
           return
         } else {
-          done()
+          throw err
         }
       }
 

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -75,10 +75,19 @@ var createPreprocessor = function (config, basePath, injector) {
 
   return function preprocess (file, done) {
     patterns = Object.keys(config)
-
-    return fs.readFile(file.originalPath, function (err, buffer) {
+    var retryCount = 0
+    var maxRetries = 3
+    function handleFile (err, buffer) {
       if (err) {
-        throw err
+        log.warn(err)
+        if (retryCount < maxRetries) {
+          retryCount++
+          log.warn('retrying ' + retryCount)
+          fs.readFile(file.originalPath, handleFile)
+          return
+        } else {
+          done()
+        }
       }
 
       isBinaryFile(buffer, buffer.length, function (err, thisFileIsBinary) {
@@ -121,7 +130,8 @@ var createPreprocessor = function (config, basePath, injector) {
 
         nextPreprocessor(null, thisFileIsBinary ? buffer : buffer.toString())
       })
-    })
+    }
+    return fs.readFile(file.originalPath, handleFile)
   }
 }
 createPreprocessor.$inject = ['config.preprocessors', 'config.basePath', 'injector']

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -77,13 +77,13 @@ var createPreprocessor = function (config, basePath, injector) {
     patterns = Object.keys(config)
     var retryCount = 0
     var maxRetries = 3
-    function handleFile (err, buffer) {
+    function readFileCallback (err, buffer) {
       if (err) {
         log.warn(err)
         if (retryCount < maxRetries) {
           retryCount++
           log.warn('retrying ' + retryCount)
-          fs.readFile(file.originalPath, handleFile)
+          fs.readFile(file.originalPath, readFileCallback)
           return
         } else {
           throw err
@@ -131,7 +131,7 @@ var createPreprocessor = function (config, basePath, injector) {
         nextPreprocessor(null, thisFileIsBinary ? buffer : buffer.toString())
       })
     }
-    return fs.readFile(file.originalPath, handleFile)
+    return fs.readFile(file.originalPath, readFileCallback)
   }
 }
 createPreprocessor.$inject = ['config.preprocessors', 'config.basePath', 'injector']

--- a/test/unit/preprocessor.spec.js
+++ b/test/unit/preprocessor.spec.js
@@ -261,19 +261,19 @@ describe('preprocessor', () => {
       thirdCallback('error')
     })
 
-    it('should abort after 3 retries', (done) => {
+    it('should tbrow after 3 retries', (done) => {
       var injector = new di.Injector([{}, emitterSetting])
 
       var pp = m.createPreprocessor({'**/*.js': []}, null, injector)
 
-      pp(file, () => {
-        done()
-      })
+      pp(file, () => { })
 
       getReadFileCallback(0)('error')
       getReadFileCallback(1)('error')
       getReadFileCallback(2)('error')
-      getReadFileCallback(3)('error')
+
+      expect(() => getReadFileCallback(0)('error')).to.throw('error')
+      done()
     })
   })
 


### PR DESCRIPTION
When saving a file in IDEs like Visual Studio, Atom, a dozen operations including read/write/delete/rename are performed on the file. When aggressive antivirus like McAfee is running it could make it even worse, there are nearly 50% chance karma will crash because the file is locked

There were multiple issues raised because of this

#1397
#1213
#959

The solution is retry reading file if fs.readFile fails and throw after 3 failed retries