### PR TITLE
docs(config): add reminder about relation between `runInParent` and watch mode

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -233,7 +233,7 @@ iFrame and may need a new window to run.
 
 **Description:** Run the tests on the same window as the client, without using iframe or a new window
 
-If true, Karma runs the tests inside the original window without using iframe. It will load the test scripts dynamically.
+If true, Karma runs the tests inside the original window without using iframe. It will load the test scripts dynamically. If false, watching of files won't work as the server will terminate immediately on test code completion.
 
 ## client.captureConsole
 **Type:** Boolean


### PR DESCRIPTION
Learned the hard way that running the tests in the same window as the client prevents the server from persisting and re-running on file change. Makes sense on a top-level because it requires a separate window or iframe to do the watch, but figure it be a good place to be redundant about this tip.