### PR TITLE
feat(config): add appendsha option for files

### DIFF
--- a/docs/config/02-files.md
+++ b/docs/config/02-files.md
@@ -35,17 +35,17 @@ Each pattern is either a simple string or an object with four properties:
 * **Description.** Should the files be included in the browser using
     `<script>` tag? Use `false` if you want to load them manually, eg.
     using [Require.js](../plus/requirejs.html).
-    
+
     If a file is covered by multiple patterns with different `include` properties, the most specific pattern takes
     precedence over the other.
-    
-    The specificity of the pattern is defined as a six-tuple, where larger tuple implies lesser specificity: 
+
+    The specificity of the pattern is defined as a six-tuple, where larger tuple implies lesser specificity:
     *(n<sub>glob parts</sub>, n<sub>glob star</sub>, n<sub>star</sub>, n<sub>ext glob</sub>, n<sub>range</sub>, n<sub>optional</sub>)*.
-    Tuples are compared lexicographically. 
-    
-    The *n<sub>glob parts</sub>* is the number of patterns after the bracket sections are expanded. E.g. the 
+    Tuples are compared lexicographically.
+
+    The *n<sub>glob parts</sub>* is the number of patterns after the bracket sections are expanded. E.g. the
     the pattern *{0...9}* will yield *n<sub>glob parts</sub>=10*. The rest of the tuple is decided as the least
-    specific of each expanded pattern. 
+    specific of each expanded pattern.
 
 ### `served`
 * **Type.** Boolean
@@ -56,6 +56,11 @@ Each pattern is either a simple string or an object with four properties:
 * **Type.** Boolean
 * **Default.** `false`
 * **Description.** Should the files be served from disk on each request by Karma's webserver?
+
+### `appendsha`
+* **Type.** Boolean
+* **Default.** `true`
+* **Description.** Should the files be served with a query string of the file's SHA?
 
 
 ## Preprocessor transformations
@@ -86,6 +91,9 @@ files: [
 
   // this file will be served on demand from disk and will be ignored by the watcher
   {pattern: 'compiled/app.js.map', included: false, served: true, watched: false, nocache: true}
+
+  // these files will be included without a cache-busting query string appended to them
+  {pattern: 'compiled/app.js.map', included: true, served: true, appendsha: false}
 ],
 ```
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -30,12 +30,13 @@ try {
   TYPE_SCRIPT_AVAILABLE = true
 } catch (e) {}
 
-var Pattern = function (pattern, served, included, watched, nocache) {
+var Pattern = function (pattern, served, included, watched, nocache, appendsha) {
   this.pattern = pattern
   this.served = helper.isDefined(served) ? served : true
   this.included = helper.isDefined(included) ? included : true
   this.watched = helper.isDefined(watched) ? watched : true
   this.nocache = helper.isDefined(nocache) ? nocache : false
+  this.appendsha = helper.isDefined(appendsha) ? appendsha : true
   this.weight = helper.mmPatternWeight(pattern)
 }
 
@@ -44,7 +45,7 @@ Pattern.prototype.compare = function (other) {
 }
 
 var UrlPattern = function (url) {
-  Pattern.call(this, url, false, true, false, false)
+  Pattern.call(this, url, false, true, false, false, true)
 }
 
 var createPatternObject = function (pattern) {
@@ -65,11 +66,11 @@ var createPatternObject = function (pattern) {
     }
 
     log.warn('Invalid pattern %s!\n\tObject is missing "pattern" property.', pattern)
-    return new Pattern(null, false, false, false, false)
+    return new Pattern(null, false, false, false, false, false)
   }
 
   log.warn('Invalid pattern %s!\n\tExpected string or object with "pattern" property.', pattern)
-  return new Pattern(null, false, false, false, false)
+  return new Pattern(null, false, false, false, false, false)
 }
 
 var normalizeUrl = function (url) {

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -184,7 +184,8 @@ List.prototype._refresh = function () {
 
       var mtime = mg.statCache[path].mtime
       var doNotCache = patternObject.nocache
-      var file = new File(path, mtime, doNotCache)
+      var appendSha = patternObject.appendsha
+      var file = new File(path, mtime, doNotCache, appendSha)
 
       if (file.doNotCache) {
         log.debug('Not preprocessing "%s" due to nocache')

--- a/lib/file.js
+++ b/lib/file.js
@@ -9,7 +9,7 @@
 var _ = require('lodash')
 
 // Constructor
-var File = function (path, mtime, doNotCache) {
+var File = function (path, mtime, doNotCache, appendSha) {
   // used for serving (processed path, eg some/file.coffee -> some/file.coffee.js)
   this.path = path
 
@@ -23,6 +23,7 @@ var File = function (path, mtime, doNotCache) {
   this.isUrl = false
 
   this.doNotCache = _.isUndefined(doNotCache) ? false : doNotCache
+  this.appendSha = _.isUndefined(appendSha) ? true : appendSha
 }
 
 File.prototype.toString = function () {

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -186,7 +186,7 @@ var createKarmaMiddleware = function (
             if (!file.isUrl) {
               filePath = filePathToUrlPath(filePath, basePath, urlRoot, proxyPath)
 
-              if (requestUrl === '/context.html') {
+              if (isRequestingContextFile && file.appendSha) {
                 filePath += '?' + file.sha
               }
             }

--- a/test/unit/file-list.spec.js
+++ b/test/unit/file-list.spec.js
@@ -136,6 +136,27 @@ describe('FileList', () => {
       })
     })
 
+    it('marks append SHA files', () => {
+      var files = [
+        new config.Pattern('/a.*'),        // appendsha: true
+        new config.Pattern('/some/*.js', true, true, true, true, false) // appendsha: false
+      ]
+
+      list = new List(files, [], emitter, preprocess)
+
+      return list.refresh().then(() => {
+        expect(pathsFrom(list.files.served)).to.deep.equal([
+          '/a.txt',
+          '/some/a.js',
+          '/some/b.js'
+        ])
+        expect(preprocess).to.have.been.calledOnce
+        expect(list.files.served[0].appendSha).to.be.true
+        expect(list.files.served[1].appendSha).to.be.false
+        expect(list.files.served[2].appendSha).to.be.false
+      })
+    })
+
     it('returns a flat array of included files', () => {
       var files = [
         new config.Pattern('/a.*', true, false), // included: false

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -18,6 +18,11 @@ describe('middleware.karma', () => {
     this.sha = sha || 'sha-default'
   }
 
+  var MockFileNoAppendSha = function (path, sha) {
+    File.call(this, path, undefined, undefined, false)
+    this.sha = sha || 'sha-default'
+  }
+
   var fsMock = mocks.fs.create({
     karma: {
       static: {
@@ -256,6 +261,36 @@ describe('middleware.karma', () => {
     callHandlerWith('/__karma__/context.html')
   })
 
+  it('should serve context.html with the correct path for the script tags without SHAs if the option is specified', (done) => {
+    includedFiles([
+      new MockFileNoAppendSha('/some/abc/a.js', 'sha'),
+      new MockFileNoAppendSha('/base/path/b.js', 'shaaa')
+    ])
+
+    response.once('end', () => {
+      expect(nextSpy).not.to.have.been.called
+      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="/__proxy__/__karma__/absolute/some/abc/a.js" crossorigin="anonymous"></script>\n<script type="text/javascript" src="/__proxy__/__karma__/base/b.js" crossorigin="anonymous"></script>')
+      done()
+    })
+
+    callHandlerWith('/__karma__/context.html')
+  })
+
+  it('should serve context.html with the correct path for link tags without SHAs if the option is specified', (done) => {
+    includedFiles([
+      new MockFileNoAppendSha('/some/abc/a.css', 'sha1'),
+      new MockFileNoAppendSha('/some/abc/b.html', 'sha2')
+    ])
+
+    response.once('end', () => {
+      expect(nextSpy).not.to.have.been.called
+      expect(response).to.beServedAs(200, 'CONTEXT\n<link type="text/css" href="/__proxy__/__karma__/absolute/some/abc/a.css" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/some/abc/b.html" rel="import">')
+      done()
+    })
+
+    callHandlerWith('/__karma__/context.html')
+  })
+
   it('should serve context.json with the correct paths for all files', (done) => {
     includedFiles([
       new MockFile('/some/abc/a.css', 'sha1'),
@@ -341,7 +376,7 @@ describe('middleware.karma', () => {
     callHandlerWith('/__karma__/context.html')
   })
 
-  it('should serve debug.html with replaced script tags without timestamps', (done) => {
+  it('should serve debug.html with replaced script tags without SHAs', (done) => {
     includedFiles([
       new MockFile('/first.js'),
       new MockFile('/base/path/b.js')
@@ -356,7 +391,7 @@ describe('middleware.karma', () => {
     callHandlerWith('/__karma__/debug.html')
   })
 
-  it('should serve debug.html with replaced link tags without timestamps', (done) => {
+  it('should serve debug.html with replaced link tags without SHAs', (done) => {
     includedFiles([
       new MockFile('/first.css'),
       new MockFile('/base/path/b.css'),


### PR DESCRIPTION
This allows users to prevent the file SHA query string from being added
to included files by specifying `appendsha: false`. This is to prevent
files from being loaded twice, which can occur if a file is included by
Karma and then later referenced by another file in the code (such as an
HTML Import)

Example usage:
```js
{ 
  pattern: 'src/elements/**/!(demo|test)/*.html', 
  included: true, 
  served: true, 
  watched: true, 
  appendsha: false
}
```

Closes #2756