### PR TITLE
test(e2e): fix tests for new cucumber-js

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -46,9 +46,9 @@ module.exports = function (grunt) {
     },
     cucumberjs: {
       options: {
-        steps: 'test/e2e/steps',
+        steps: 'test/e2e/step_definitions',
         format: 'progress',
-        require: 'test/e2e/support/env.js'
+        require: ['test/e2e/support/env.js', 'test/e2e/support/world.js']
       },
       all: 'test/e2e/*.feature',
       current: {
@@ -64,7 +64,7 @@ module.exports = function (grunt) {
           src: 'test/e2e/*.feature'
         },
         options: {
-          tags: '~@not-jenkins'
+          tags: 'not @not-jenkins'
         }
       }
     },

--- a/test/e2e/step_definitions/hooks.js
+++ b/test/e2e/step_definitions/hooks.js
@@ -1,5 +1,7 @@
-module.exports = function afterHooks () {
-  this.After(function (scenario, callback) {
+var {defineSupportCode} = require('cucumber')
+
+defineSupportCode(function ({After}) {
+  After(function (scenario, callback) {
     var running = this.child != null && typeof this.child.kill === 'function'
 
     if (running) {
@@ -10,4 +12,4 @@ module.exports = function afterHooks () {
     // stop the proxy if it was started
     this.proxy.stop(callback)
   })
-}
+})

--- a/test/e2e/support/env.js
+++ b/test/e2e/support/env.js
@@ -1,5 +1,5 @@
-var configure = function () {
-  this.setDefaultTimeout(60 * 1000)
-}
+var {defineSupportCode} = require('cucumber')
 
-module.exports = configure
+defineSupportCode(function ({setDefaultTimeout}) {
+  setDefaultTimeout(60 * 1000)
+})

--- a/test/e2e/support/world.js
+++ b/test/e2e/support/world.js
@@ -4,8 +4,9 @@ var path = require('path')
 var hasher = require('crypto').createHash
 var mkdirp = require('mkdirp')
 var _ = require('lodash')
+var {defineSupportCode} = require('cucumber')
 
-exports.World = function World () {
+function World () {
   this.proxy = require('./proxy')
 
   this.template = _.template('module.exports = function (config) {\n  config.set(\n    <%= content %>\n  );\n};')
@@ -61,3 +62,7 @@ exports.World = function World () {
     stderr: ''
   }
 }
+
+defineSupportCode(function ({setWorldConstructor}) {
+  setWorldConstructor(World)
+})


### PR DESCRIPTION
Update cucumber tests to address the following incompatibilities:

1. usage of `defineSupportCode` instead of relying on invocation with
   appropriate `this` the modules `require`d by cucumber-js
2. replace regex literals with cucumber expression strings, as the
   former cause issues when non-existent capture groups are parsed
3. migrate from old-style tag selection syntax

Fixes #2764