### PR TITLE
Fix Travis commit message checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - sh -e /etc/init.d/xvfb start
   - npm run init
   - export $(openssl aes-256-cbc -pass env:CREDENTIALS_PASS -d -in credentials)
-  - 'if [ "$VALIDATE_COMMIT_MSG" == "true" ]; then npm run travis; else ./scripts/validate-commit-msg.sh $TRAVIS_COMMIT; fi'
+  - 'if [ "$VALIDATE_COMMIT_MSG" == "true" ]; then ./scripts/validate-commit-msg.sh $TRAVIS_COMMIT; fi'
   - 'if [ "$LINT" == "true" ]; then npm run lint; fi'
 
 script:

--- a/scripts/validate-commit-msg.sh
+++ b/scripts/validate-commit-msg.sh
@@ -19,14 +19,20 @@ if [ -z "$COMMIT_REV" ]; then
   exit 1
 fi
 
+
 # Resolve our file for output
 # DEV: We use `.git` to avoid cluttering the working directory
 GIT_DIR="$(git rev-parse --git-dir)"
-TARGET_FILE="$GIT_DIR/VALIDATE_COMMIT_MSG"
+TARGET_FILENAME=VALIDATE_COMMIT_MSG
+TARGET_FILE="$GIT_DIR/$TARGET_FILENAME"
 
+echo "Retrieving relevant commit message for $COMMIT_REV"
 # Output our log message to a file
 # DEV: We use `--no-merges` to skip merge commits introduced by GitHub
 git log --no-merges --format=format:"%s" -n 1 "$COMMIT_REV" > "$TARGET_FILE"
 
+echo "Validating contents of $TARGET_FILE"
+cat "$TARGET_FILE"
+
 # Validate our message
-./node_modules/.bin/validate-commit-msg "$TARGET_FILE"
+./node_modules/.bin/validate-commit-msg "$TARGET_FILENAME"


### PR DESCRIPTION
There were a couple of problems related to commit message validation:

1. inverted condition in travis beforeinstall check
2. passing path relative to project root to `validate-commit-msg` rather than relative to `.git` directory

With those fixed, the ✅ is back!