### PR TITLE
Feature: Mute common msg

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -117,7 +117,7 @@ var createReporters = function (names, config, emitter, injector) {
     }
 
     if (config.browserConsoleLogOptions){
-      config.browserConsoleLogOptions.name = name.replace("-", "");
+      config.browserConsoleLogOptions.name = name;
     }
 
     var locals = {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -116,6 +116,10 @@ var createReporters = function (names, config, emitter, injector) {
       return reporters.push(new ClsColor(errorFormatter, config.reportSlowerThan, config.colors, config.browserConsoleLogOptions))
     }
 
+    if (config.browserConsoleLogOptions){
+      config.browserConsoleLogOptions.name = name.replace("-", "");
+    }
+
     var locals = {
       baseReporterDecorator: ['factory', baseReporterDecoratorFactory],
       formatError: ['value', errorFormatter]

--- a/lib/reporters/README.md
+++ b/lib/reporters/README.md
@@ -1,0 +1,20 @@
+## browserConsoleLogOptions
+The configuration *browserConsoleLogOptions* has been augmented.
+
+The **muteCommonMsg** param is added.
+
+**Type:** _Object_
+
+**Description:** Configure for which _reporters_ the common messages are disabled/muted
+
+```javascript
+muteCommonMsg: {
+  dots: true,
+  coverageistanbul: true
+}
+```
+
+:exclamation: :exclamation: :exclamation:  
+> The responders' names will lose the **-** character.
+>
+> coverage-istanbul => coverageistanbul

--- a/lib/reporters/README.md
+++ b/lib/reporters/README.md
@@ -10,11 +10,6 @@ The **muteCommonMsg** param is added.
 ```javascript
 muteCommonMsg: {
   dots: true,
-  coverageistanbul: true
+  coverage-istanbul: true
 }
 ```
-
-:exclamation: :exclamation: :exclamation:  
-> The responders' names will lose the **-** character.
->
-> coverage-istanbul => coverageistanbul

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -6,6 +6,13 @@ var helper = require('../helper')
 var BaseReporter = function (formatError, reportSlow, useColors, browserConsoleLogOptions, adapter) {
   this.adapters = [adapter || process.stdout.write.bind(process.stdout)]
 
+  var reportedName = ""
+  var mutedCommonMsg = false
+  if (browserConsoleLogOptions && browserConsoleLogOptions.muteCommonMsg) {
+    reportedName = browserConsoleLogOptions.name;
+    mutedCommonMsg = browserConsoleLogOptions.muteCommonMsg[reportedName]
+  }
+
   this.onRunStart = function () {
     this._browsers = []
   }
@@ -65,7 +72,7 @@ var BaseReporter = function (formatError, reportSlow, useColors, browserConsoleL
   }
 
   this.onBrowserLog = function (browser, log, type) {
-    if (!browserConsoleLogOptions || !browserConsoleLogOptions.terminal) return
+    if (!browserConsoleLogOptions || !browserConsoleLogOptions.terminal || mutedCommonMsg) return
     type = type.toUpperCase()
     if (browserConsoleLogOptions.level) {
       var logPriority = constants.LOG_PRIORITIES.indexOf(browserConsoleLogOptions.level.toUpperCase())

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -6,10 +6,9 @@ var helper = require('../helper')
 var BaseReporter = function (formatError, reportSlow, useColors, browserConsoleLogOptions, adapter) {
   this.adapters = [adapter || process.stdout.write.bind(process.stdout)]
 
-  var reportedName = ""
   var mutedCommonMsg = false
   if (browserConsoleLogOptions && browserConsoleLogOptions.muteCommonMsg) {
-    reportedName = browserConsoleLogOptions.name;
+    var reportedName = browserConsoleLogOptions.name;
     mutedCommonMsg = browserConsoleLogOptions.muteCommonMsg[reportedName]
   }
 

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -8,7 +8,7 @@ var BaseReporter = function (formatError, reportSlow, useColors, browserConsoleL
 
   var mutedCommonMsg = false
   if (browserConsoleLogOptions && browserConsoleLogOptions.muteCommonMsg) {
-    var reportedName = browserConsoleLogOptions.name;
+    var reportedName = browserConsoleLogOptions.name
     mutedCommonMsg = browserConsoleLogOptions.muteCommonMsg[reportedName]
   }
 

--- a/lib/reporters/dots.js
+++ b/lib/reporters/dots.js
@@ -3,6 +3,8 @@ var BaseReporter = require('./base')
 var DotsReporter = function (formatError, reportSlow, useColors, browserConsoleLogOptions) {
   BaseReporter.call(this, formatError, reportSlow, useColors, browserConsoleLogOptions)
 
+  var mutedCommonMsg = browserConsoleLogOptions && browserConsoleLogOptions.muteCommonMsg && browserConsoleLogOptions.muteCommonMsg.dots
+
   var DOTS_WRAP = 80
   this.EXCLUSIVELY_USE_COLORS = false
   this.onRunStart = function () {
@@ -14,13 +16,15 @@ var DotsReporter = function (formatError, reportSlow, useColors, browserConsoleL
     this._browsers.push(browser)
   }
 
-  this.writeCommonMsg = function (msg) {
+  this.writeCommonMsg = function (msg, force) {
     if (this._dotsCount) {
       this._dotsCount = 0
       msg = '\n' + msg
     }
 
-    this.write(msg)
+    if (!mutedCommonMsg || force) {
+      this.write(msg)
+    }
   }
 
   this.specSuccess = function () {
@@ -29,7 +33,7 @@ var DotsReporter = function (formatError, reportSlow, useColors, browserConsoleL
   }
 
   this.onBrowserComplete = function (browser) {
-    this.writeCommonMsg(this.renderBrowser(browser) + '\n')
+    this.writeCommonMsg(this.renderBrowser(browser) + '\n', true)
   }
 
   this.onRunComplete = function (browsers, results) {


### PR DESCRIPTION
I as a developer of projects was curious why `console.log()` duplicate output several times. 
After some investigation, I found that the reason is that karma has multiple `reporters`. So every reporter writes the same message into the output. 

_My suggestion_ is to have a possibility to mute the reporter's common messages.

_As a benefit_, we will get the possibility easily configure the verbose of reporters. 