### PR TITLE
Use an active fork of di

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,5 @@
 var SocketIO = require('socket.io')
-var di = require('di')
+var di = require('deckar01-di')
 var util = require('util')
 var Promise = require('bluebird')
 var spawn = require('child_process').spawn

--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "combine-lists": "^1.0.0",
     "connect": "^3.6.0",
     "core-js": "^2.2.0",
-    "di": "^0.0.1",
+    "deckar01-di": "^0.0.2",
     "dom-serialize": "^2.2.0",
     "expand-braces": "^0.1.1",
     "glob": "^7.1.1",

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -424,7 +424,7 @@ describe('config', () => {
   })
 
   describe('custom', () => {
-    var di = require('di')
+    var di = require('deckar01-di')
 
     var forwardArgsFactory = (args) => args
 

--- a/test/unit/launcher.spec.js
+++ b/test/unit/launcher.spec.js
@@ -1,5 +1,5 @@
 import Promise from 'bluebird'
-import di from 'di'
+import di from 'deckar01-di'
 import events from '../../lib/events'
 import launcher from '../../lib/launcher'
 import createMockTimer from './mocks/timer'

--- a/test/unit/preprocessor.spec.js
+++ b/test/unit/preprocessor.spec.js
@@ -1,5 +1,5 @@
 import mocks from 'mocks'
-import di from 'di'
+import di from 'deckar01-di'
 import path from 'path'
 import events from '../../lib/events'
 

--- a/test/unit/web-server.spec.js
+++ b/test/unit/web-server.spec.js
@@ -1,7 +1,7 @@
 import 'core-js'
 import {EventEmitter} from 'events'
 import request from 'supertest'
-import di from 'di'
+import di from 'deckar01-di'
 import mocks from 'mocks'
 import fs from 'fs'
 import mime from 'mime'


### PR DESCRIPTION
Fixes #2781.

This fork of di uses a standards compliant ES parser (Esprima) to parse the arguments for dependency injection instead of using regexes. This strategy is much more robust and easier to maintain as ES standards continue to evolve.