### PR TITLE
Normalize my name in .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,4 @@
 <bitwiseman@gmail.com> <lnewman@book.com>
 <vojta.jina@gmail.com> <vojta@google.com>
 <friedel.ziegelmayer@gmail.com> <dignifiedquire@gmail.com>
+Michał Gołębiowski <m.goleb@gmail.com>


### PR DESCRIPTION
The contributors file contains two entries for me, at:
https://github.com/karma-runner/karma/blob/69978ee83e42c88b9cb048b2cb7a07d6e5c20e5b/package.json#L46
and:
https://github.com/karma-runner/karma/blob/69978ee83e42c88b9cb048b2cb7a07d6e5c20e5b/package.json#L54

This is because in Unicode `ę` can be written in two ways:
1. As a separate letter: `ę` (`"ę".length === 1`)
2. As "e" plus "Combining Ogonek" ("ogonek" means "a little tail" in Polish; `"ę".length === 2`, try it yourself), see http://www.fileformat.info/info/unicode/char/0328/index.htm

This `.mailmap` entry will collapse those two entries.