### PR TITLE
[add] browser.allResults 

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -65,6 +65,7 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
   this.state = READY
   this.lastResult = new Result()
   this.disconnectsCount = 0
+  this.allResults = []
 
   this.init = function () {
     collection.add(this)
@@ -211,6 +212,7 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
 
   this.onResult = function (result) {
     if (result.length) {
+      this.allResults = result
       return result.forEach(this.onResult, this)
     }
 


### PR DESCRIPTION
saving tests results to the browser variable will allow easier access to unit test results within launcher plug-ins. (specifically karma-sauce-launcher)

