### PR TITLE
fix(file-list): Normalized path for mg.stateCache in _refresh function.

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -171,6 +171,8 @@ List.prototype._refresh = function () {
     }
 
     return Promise.map(files, function (path) {
+      var normalizedPath = pathLib.normalize(path)
+
       if (self._isExcluded(path)) {
         log.debug('Excluded file "%s"', path)
         return Promise.resolve()
@@ -182,7 +184,7 @@ List.prototype._refresh = function () {
 
       matchedFiles.add(path)
 
-      var mtime = mg.statCache[path].mtime
+      var mtime = mg.statCache[normalizedPath].mtime
       var doNotCache = patternObject.nocache
       var file = new File(path, mtime, doNotCache)
 


### PR DESCRIPTION
Path must be normalized because Windows uses backslash in paths. Commit resolved problem with crashed Karma on start. `You need to include some adapter that implements __karma__.start method!`