### PR TITLE
fix(debug-runner): support asynchronous tests in the debug runner

### DIFF
--- a/static/debug.js
+++ b/static/debug.js
@@ -18,7 +18,7 @@ window.__karma__.result = window.console ? function (result) {
     // Throwing error without losing stack trace
     (function (err) {
       setTimeout(function () {
-        throw err
+        window.console.error(err)
       })
     })(result.log[i])
   }


### PR DESCRIPTION
Use console.error to log errors to the console instead of throwing
an error. This makes sure that errors are scoped properly for
asynchronous tests, instead of showing up as uncaught errors on
all asynchronous tests.

Fixes #2811