### PR TITLE
fix(build): Drop support for Node 0.10 and 0.12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
 before_install:
   - npm config set loglevel warn
   - g++-4.8 --version
-  - if [[ "`node --version`" = v0* ]] || [[ "`node --version`" = v4* ]]; then npm install -g npm@latest-3; fi
+  - if [[ "`node --version`" = v4* ]]; then npm install -g npm@latest-3; fi
 
 addons:
   firefox:

--- a/docs/intro/01-installation.md
+++ b/docs/intro/01-installation.md
@@ -5,7 +5,7 @@ Karma runs on [Node.js] and is available as an [NPM] package.
 On Mac or Linux we recommend using [NVM](https://github.com/creationix/nvm). On Windows, download Node.js
 from [the official site](https://nodejs.org/) or use the [NVM PowerShell Module](https://www.powershellgallery.com/packages/nvm).
 
-Note: Karma currently works on Node.js **0.10**, **0.12.x**, **4.x**, **5.x**, **6.x**, **7.x**, and **8.x**. See [FAQ] for more info.
+Note: Karma currently works on Node.js **4.x**, **5.x**, **6.x**, **7.x**, and **8.x**. See [FAQ] for more info.
 
 ## Installing Karma and plugins
 

--- a/docs/intro/04-faq.md
+++ b/docs/intro/04-faq.md
@@ -25,7 +25,7 @@ The latest stable version from NPM (`npm install karma`). See [versioning] for m
 
 
 ### Which version of Node.js does Karma run with?
-Karma works on all LTS versions node in active maintenance state (see [LTS docs](https://github.com/nodejs/LTS/blob/master/README.md) for more info) as well as the latest stable version. That is **0.12.x**, **4.x**, **5.x** and **6.x** at this point. Additionally, Node **0.10** is currently supported.
+Karma works on all LTS versions node in active maintenance state (see [LTS docs](https://github.com/nodejs/LTS/blob/master/README.md) for more info) as well as the latest stable version. That is **4.x**, **5.x**, **6.x**, and **8.x** at this point.
 
 
 [mailing list]: https://groups.google.com/d/forum/karma-users

--- a/package.json
+++ b/package.json
@@ -428,7 +428,7 @@
     "karma": "./bin/karma"
   },
   "engines": {
-    "node": "0.10 || 0.12 || 4 || 5 || 6 || 7 || 8"
+    "node": ">= 4"
   },
   "version": "1.7.0",
   "license": "MIT",

--- a/test/unit/file-list.spec.js
+++ b/test/unit/file-list.spec.js
@@ -80,7 +80,7 @@ describe('FileList', () => {
       List = proxyquire('../../lib/file-list', {
         helper: helper,
         glob: glob,
-        path: pathLib.posix || pathLib/* for node 0.10 */,
+        path: pathLib.posix,
         'graceful-fs': mockFs
       })
     })
@@ -210,7 +210,7 @@ describe('FileList', () => {
       List = proxyquire('../../lib/file-list', {
         helper: helper,
         glob: glob,
-        path: pathLib.posix || pathLib/* for node 0.10 */,
+        path: pathLib.posix,
         'graceful-fs': mockFs
       })
 
@@ -247,7 +247,7 @@ describe('FileList', () => {
       List = proxyquire('../../lib/file-list', {
         helper: helper,
         glob: glob,
-        path: pathLib.posix || pathLib/* for node 0.10 */,
+        path: pathLib.posix,
         'graceful-fs': mockFs
       })
 
@@ -446,7 +446,7 @@ describe('FileList', () => {
         helper: helper,
         glob: glob,
         'graceful-fs': mockFs,
-        path: pathLib.posix || pathLib/* for node 0.10 */,
+        path: pathLib.posix,
         bluebird: Promise
       })
 
@@ -573,7 +573,7 @@ describe('FileList', () => {
         helper: helper,
         glob: glob,
         'graceful-fs': mockFs,
-        path: pathLib.posix || pathLib/* for node 0.10 */,
+        path: pathLib.posix,
         bluebird: Promise
       })
 
@@ -680,7 +680,7 @@ describe('FileList', () => {
         helper: helper,
         glob: glob,
         'graceful-fs': mockFs,
-        path: pathLib.posix || pathLib/* for node 0.10 */,
+        path: pathLib.posix,
         bluebird: Promise
       })
 
@@ -764,7 +764,7 @@ describe('FileList', () => {
         helper: helper,
         glob: glob,
         'graceful-fs': mockFs,
-        path: pathLib.posix || pathLib/* for node 0.10 */,
+        path: pathLib.posix,
         bluebird: Promise
       })
     })


### PR DESCRIPTION
Updated docs.
Updated engines matcher in package.json.
Updated places where node-0.1-specific code was noted in comments.