### PR TITLE
test(e2e): add tests for ES2015 module support

### DIFF
--- a/static/context.html
+++ b/static/context.html
@@ -26,7 +26,12 @@ Reloaded before every execution run.
   </script>
   <!-- Dynamically replaced with <script> tags -->
   %SCRIPTS%
-  <script type="text/javascript">
+  <!-- Since %SCRIPTS% might include modules, the `loaded()` call needs to be in a module too.
+   This ensures all the tests will have been declared before karma tries to run them. -->
+  <script type="module">
+    window.__karma__.loaded();
+  </script>
+  <script nomodule>
     window.__karma__.loaded();
   </script>
 </body>

--- a/static/debug.html
+++ b/static/debug.html
@@ -28,7 +28,12 @@ just for immediate execution, without reporting to Karma server.
   </script>
   <!-- Dynamically replaced with <script> tags -->
   %SCRIPTS%
-  <script type="text/javascript">
+  <!-- Since %SCRIPTS% might include modules, the `loaded()` call needs to be in a module too.
+   This ensures all the tests will have been declared before karma tries to run them. -->
+  <script type="module">
+    window.__karma__.loaded();
+  </script>
+  <script nomodule>
     window.__karma__.loaded();
   </script>
 </body>

--- a/test/e2e/module-types.feature
+++ b/test/e2e/module-types.feature
@@ -3,23 +3,33 @@ Feature: ES Modules
   As a person who wants to write great tests
   I want to use different script types with Karma.
 
-  Scenario: Simple middleware
+  Scenario: Globbing modules, with both .js and .mjs extensions
     Given a configuration with:
       """
       files = [
-        { pattern: 'modules/plus.js', esModule: false },
-        { pattern: 'modules/minus.mjs', esModule: true },
-        'modules/test.js'
+        { pattern: 'modules/**/*.js', type: 'module' },
+        { pattern: 'modules/**/*.mjs', type: 'module' },
       ];
-      browsers = ['Firefox'];
+      // Chrome fails on Travis, so we must use Firefox (which means we must
+      // manually enable modules).
+      customLaunchers = {
+        FirefoxWithModules: {
+          base: 'Firefox',
+          prefs: {
+            'dom.moduleScripts.enabled': true
+          }
+        }
+      };
+      browsers = ['FirefoxWithModules'];
+      frameworks = ['mocha', 'chai'];
       plugins = [
-        'karma-jasmine',
+        'karma-mocha',
+        'karma-chai',
         'karma-firefox-launcher'
       ];
       """
     When I start Karma
-    Then it passes with:
+    Then it passes with like:
       """
-      ..
-      Firefox
+      Executed 4 of 4 SUCCESS
       """

--- a/test/e2e/module-types.feature
+++ b/test/e2e/module-types.feature
@@ -1,0 +1,25 @@
+Feature: ES Modules
+  In order to use Karma
+  As a person who wants to write great tests
+  I want to use different script types with Karma.
+
+  Scenario: Simple middleware
+    Given a configuration with:
+      """
+      files = [
+        { pattern: 'modules/plus.js', esModule: false },
+        { pattern: 'modules/minus.mjs', esModule: true },
+        'modules/test.js'
+      ];
+      browsers = ['Firefox'];
+      plugins = [
+        'karma-jasmine',
+        'karma-firefox-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      ..
+      Firefox
+      """

--- a/test/e2e/support/modules/__tests__/minus.test.mjs
+++ b/test/e2e/support/modules/__tests__/minus.test.mjs
@@ -1,10 +1,11 @@
-/* globals plus */
-describe('plus', function () {
+import { minus } from '../minus.mjs'
+
+describe('minus', function () {
   it('should pass', function () {
     expect(true).toBe(true)
   })
 
   it('should work', function () {
-    expect(plus(1, 2)).toBe(3)
+    expect(minus(3, 2)).toBe(1)
   })
 })

--- a/test/e2e/support/modules/__tests__/minus.test.mjs
+++ b/test/e2e/support/modules/__tests__/minus.test.mjs
@@ -2,10 +2,10 @@ import { minus } from '../minus.mjs'
 
 describe('minus', function () {
   it('should pass', function () {
-    expect(true).toBe(true)
+    expect(true).to.be.true
   })
 
   it('should work', function () {
-    expect(minus(3, 2)).toBe(1)
+    expect(minus(3, 2)).to.equal(1)
   })
 })

--- a/test/e2e/support/modules/__tests__/plus.test.js
+++ b/test/e2e/support/modules/__tests__/plus.test.js
@@ -1,0 +1,11 @@
+import { plus } from '../plus.js'
+
+describe('plus', function () {
+  it('should pass', function () {
+    expect(true).toBe(true)
+  })
+
+  it('should work', function () {
+    expect(plus(1, 2)).toBe(3)
+  })
+})

--- a/test/e2e/support/modules/__tests__/plus.test.js
+++ b/test/e2e/support/modules/__tests__/plus.test.js
@@ -2,10 +2,10 @@ import { plus } from '../plus.js'
 
 describe('plus', function () {
   it('should pass', function () {
-    expect(true).toBe(true)
+    expect(true).to.be.true
   })
 
   it('should work', function () {
-    expect(plus(1, 2)).toBe(3)
+    expect(plus(1, 2)).to.equal(3)
   })
 })

--- a/test/e2e/support/modules/minus.mjs
+++ b/test/e2e/support/modules/minus.mjs
@@ -1,0 +1,15 @@
+// Some code under test
+function minus (a, b) {
+  return a - b
+}
+
+describe('minus', function () {
+  it('should pass', function () {
+    expect(true).toBe(true)
+  })
+
+  it('should work', function () {
+    expect(minus(3, 2)).toBe(1)
+  })
+})
+

--- a/test/e2e/support/modules/minus.mjs
+++ b/test/e2e/support/modules/minus.mjs
@@ -1,15 +1,4 @@
 // Some code under test
-function minus (a, b) {
+export function minus (a, b) {
   return a - b
 }
-
-describe('minus', function () {
-  it('should pass', function () {
-    expect(true).toBe(true)
-  })
-
-  it('should work', function () {
-    expect(minus(3, 2)).toBe(1)
-  })
-})
-

--- a/test/e2e/support/modules/plus.js
+++ b/test/e2e/support/modules/plus.js
@@ -1,0 +1,5 @@
+/* eslint-disable no-unused-vars */
+// Some code under test
+function plus (a, b) {
+  return a + b
+}

--- a/test/e2e/support/modules/plus.js
+++ b/test/e2e/support/modules/plus.js
@@ -1,5 +1,4 @@
-/* eslint-disable no-unused-vars */
 // Some code under test
-function plus (a, b) {
+export function plus (a, b) {
   return a + b
 }

--- a/test/e2e/support/modules/test.js
+++ b/test/e2e/support/modules/test.js
@@ -1,0 +1,10 @@
+/* globals plus */
+describe('plus', function () {
+  it('should pass', function () {
+    expect(true).toBe(true)
+  })
+
+  it('should work', function () {
+    expect(plus(1, 2)).toBe(3)
+  })
+})


### PR DESCRIPTION
(Note: this is a continuation of #2685, because @wesleycho had to abandon it.  @dignifiedquire, you already approved that PR.  This is the same one, but rebased off the current HEAD.)