### PR TITLE
fix(config): Call debug log methods after setting the loglevel based upon config/cli-options

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -357,7 +357,6 @@ var CONFIG_SYNTAX_HELP = '  module.exports = function(config) {\n' +
 var parseConfig = function (configFilePath, cliOptions) {
   var configModule
   if (configFilePath) {
-    log.debug('Loading config %s', configFilePath)
 
     try {
       configModule = require(configFilePath)
@@ -389,7 +388,6 @@ var parseConfig = function (configFilePath, cliOptions) {
       return process.exit(1)
     }
   } else {
-    log.debug('No config file specified.')
     // if no config file path is passed, we define a dummy config module.
     configModule = function () {}
   }
@@ -432,6 +430,12 @@ var parseConfig = function (configFilePath, cliOptions) {
 
   // configure the logger as soon as we can
   logger.setup(config.logLevel, config.colors, config.loggers)
+
+  if (configFilePath) {
+    log.debug('Loading config %s', configFilePath)
+  } else {
+    log.debug('No config file specified.')
+  }
 
   return normalizeConfig(config, configFilePath)
 }


### PR DESCRIPTION
Currently the debug message about where the configfile was loaded from is always shown, regardless of the user defined loglevel. I've moved those debug messages to be done after the user's defined loglevel has been set which enables the user to choose whether they see this message or not :-)

Alternative fix the problem described in https://github.com/karma-runner/karma/pull/2658