### PR TITLE
feat(middleware): added manual file type option

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -425,7 +425,7 @@ httpsServerOptions: {
 
 **CLI:** `--log-level debug`
 
-**Possible values:**
+**Possible Values:**
 
   * `config.LOG_DISABLE`
   * `config.LOG_ERROR`
@@ -578,7 +578,7 @@ Note: Using `'https:'` requires you to specify `httpsServerOptions`.
 
 **Description:** Module used for Karma webserver.
 
-Uses the provided module instead of node's built in `http` or `https` module. The module loaded here must exactly match the interface of node's http module. This can be useful for loading in a module like `node-http2` to allow for http2 support. 
+Uses the provided module instead of node's built in `http` or `https` module. The module loaded here must exactly match the interface of node's http module. This can be useful for loading in a module like `node-http2` to allow for http2 support.
 
 Note: if you're using this to enable `http2` you must also set the `protocol` to `https:` and specify certificates as http2 can only run of https.
 

--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -425,7 +425,7 @@ httpsServerOptions: {
 
 **CLI:** `--log-level debug`
 
-**Possible Values:**
+**Possible values:**
 
   * `config.LOG_DISABLE`
   * `config.LOG_ERROR`
@@ -578,7 +578,7 @@ Note: Using `'https:'` requires you to specify `httpsServerOptions`.
 
 **Description:** Module used for Karma webserver.
 
-Uses the provided module instead of node's built in `http` or `https` module. The module loaded here must exactly match the interface of node's http module. This can be useful for loading in a module like `node-http2` to allow for http2 support.
+Uses the provided module instead of node's built in `http` or `https` module. The module loaded here must exactly match the interface of node's http module. This can be useful for loading in a module like `node-http2` to allow for http2 support. 
 
 Note: if you're using this to enable `http2` you must also set the `protocol` to `https:` and specify certificates as http2 can only run of https.
 

--- a/docs/config/02-files.md
+++ b/docs/config/02-files.md
@@ -46,17 +46,17 @@ Each pattern is either a simple string or an object with four properties:
 * **Description.** Should the files be included in the browser using
     `<script>` tag? Use `false` if you want to load them manually, eg.
     using [Require.js](../plus/requirejs.html).
-
+    
     If a file is covered by multiple patterns with different `include` properties, the most specific pattern takes
     precedence over the other.
-
-    The specificity of the pattern is defined as a six-tuple, where larger tuple implies lesser specificity:
+    
+    The specificity of the pattern is defined as a six-tuple, where larger tuple implies lesser specificity: 
     *(n<sub>glob parts</sub>, n<sub>glob star</sub>, n<sub>star</sub>, n<sub>ext glob</sub>, n<sub>range</sub>, n<sub>optional</sub>)*.
-    Tuples are compared lexicographically.
-
-    The *n<sub>glob parts</sub>* is the number of patterns after the bracket sections are expanded. E.g. the
+    Tuples are compared lexicographically. 
+    
+    The *n<sub>glob parts</sub>* is the number of patterns after the bracket sections are expanded. E.g. the 
     the pattern *{0...9}* will yield *n<sub>glob parts</sub>=10*. The rest of the tuple is decided as the least
-    specific of each expanded pattern.
+    specific of each expanded pattern. 
 
 ### `served`
 * **Type.** Boolean

--- a/docs/config/02-files.md
+++ b/docs/config/02-files.md
@@ -33,7 +33,7 @@ Each pattern is either a simple string or an object with four properties:
   * `html`
   * `js`
   * `dart`
-  * `esModule`
+  * `module`
 
 ### `watched`
 * **Type.** Boolean

--- a/docs/config/02-files.md
+++ b/docs/config/02-files.md
@@ -24,6 +24,17 @@ Each pattern is either a simple string or an object with four properties:
 * **No Default.**
 * **Description.** The pattern to use for matching. This property is mandatory.
 
+### `type`
+* **Type.** String
+* **Default.** Will attempt to determine type based on file extension. If that fails, defaults to `js`.
+* **Description.** Choose the type to use when including a file.
+* **Possible Values:**
+  * `css`
+  * `html`
+  * `js`
+  * `dart`
+  * `esModule`
+
 ### `watched`
 * **Type.** Boolean
 * **Default.** `true`
@@ -35,17 +46,17 @@ Each pattern is either a simple string or an object with four properties:
 * **Description.** Should the files be included in the browser using
     `<script>` tag? Use `false` if you want to load them manually, eg.
     using [Require.js](../plus/requirejs.html).
-    
+
     If a file is covered by multiple patterns with different `include` properties, the most specific pattern takes
     precedence over the other.
-    
-    The specificity of the pattern is defined as a six-tuple, where larger tuple implies lesser specificity: 
+
+    The specificity of the pattern is defined as a six-tuple, where larger tuple implies lesser specificity:
     *(n<sub>glob parts</sub>, n<sub>glob star</sub>, n<sub>star</sub>, n<sub>ext glob</sub>, n<sub>range</sub>, n<sub>optional</sub>)*.
-    Tuples are compared lexicographically. 
-    
-    The *n<sub>glob parts</sub>* is the number of patterns after the bracket sections are expanded. E.g. the 
+    Tuples are compared lexicographically.
+
+    The *n<sub>glob parts</sub>* is the number of patterns after the bracket sections are expanded. E.g. the
     the pattern *{0...9}* will yield *n<sub>glob parts</sub>=10*. The rest of the tuple is decided as the least
-    specific of each expanded pattern. 
+    specific of each expanded pattern.
 
 ### `served`
 * **Type.** Boolean

--- a/lib/config.js
+++ b/lib/config.js
@@ -30,13 +30,14 @@ try {
   TYPE_SCRIPT_AVAILABLE = true
 } catch (e) {}
 
-var Pattern = function (pattern, served, included, watched, nocache) {
+var Pattern = function (pattern, served, included, watched, nocache, type) {
   this.pattern = pattern
   this.served = helper.isDefined(served) ? served : true
   this.included = helper.isDefined(included) ? included : true
   this.watched = helper.isDefined(watched) ? watched : true
   this.nocache = helper.isDefined(nocache) ? nocache : false
   this.weight = helper.mmPatternWeight(pattern)
+  this.type = type
 }
 
 Pattern.prototype.compare = function (other) {
@@ -61,7 +62,8 @@ var createPatternObject = function (pattern) {
           pattern.served,
           pattern.included,
           pattern.watched,
-          pattern.nocache)
+          pattern.nocache,
+          pattern.type)
     }
 
     log.warn('Invalid pattern %s!\n\tObject is missing "pattern" property.', pattern)

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -184,7 +184,8 @@ List.prototype._refresh = function () {
 
       var mtime = mg.statCache[path].mtime
       var doNotCache = patternObject.nocache
-      var file = new File(path, mtime, doNotCache)
+      var type = patternObject.type
+      var file = new File(path, mtime, doNotCache, type)
 
       if (file.doNotCache) {
         log.debug('Not preprocessing "%s" due to nocache')

--- a/lib/file.js
+++ b/lib/file.js
@@ -9,7 +9,7 @@
 var _ = require('lodash')
 
 // Constructor
-var File = function (path, mtime, doNotCache) {
+var File = function (path, mtime, doNotCache, type) {
   // used for serving (processed path, eg some/file.coffee -> some/file.coffee.js)
   this.path = path
 
@@ -23,6 +23,8 @@ var File = function (path, mtime, doNotCache) {
   this.isUrl = false
 
   this.doNotCache = _.isUndefined(doNotCache) ? false : doNotCache
+
+  this.type = type
 }
 
 File.prototype.toString = function () {

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -194,12 +194,12 @@ var createKarmaMiddleware = function (
 
             scriptUrls.push(filePath)
 
-            if (fileExt === '.css' || fileType === 'css') {
+            if (fileType === 'css' || (!fileType && fileExt === '.css')) {
               scriptTags.push(util.format(LINK_TAG_CSS, filePath))
               continue
             }
 
-            if (fileExt === '.html' || fileType === 'html') {
+            if (fileType === 'html' || (!fileType && fileExt === '.html')) {
               scriptTags.push(util.format(LINK_TAG_HTML, filePath))
               continue
             }

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -32,8 +32,9 @@ var CROSSORIGIN_ATTRIBUTE = 'crossorigin="anonymous"'
 var LINK_TAG_CSS = '<link type="text/css" href="%s" rel="stylesheet">'
 var LINK_TAG_HTML = '<link href="%s" rel="import">'
 var SCRIPT_TYPE = {
-  '.js': 'text/javascript',
-  '.dart': 'application/dart'
+  'js': 'text/javascript',
+  'dart': 'application/dart',
+  'esModule': 'module'
 }
 
 var filePathToUrlPath = function (filePath, basePath, urlRoot, proxyPath) {
@@ -205,7 +206,8 @@ var createKarmaMiddleware = function (
             }
 
             // The script tag to be placed
-            var scriptType = (SCRIPT_TYPE[fileExt] || 'text/javascript')
+            var scriptFileType = (fileType || fileExt.substring(1))
+            var scriptType = (SCRIPT_TYPE[scriptFileType] || 'text/javascript')
 
             // In case there is a JavaScript version specified and this is a Firefox browser
             if (jsVersion && jsVersion > 0 && isFirefox(request)) {

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -15,6 +15,7 @@ var path = require('path')
 var util = require('util')
 var url = require('url')
 var useragent = require('useragent')
+var _ = require('lodash')
 
 var log = require('../logger').create('middleware:karma')
 
@@ -36,6 +37,13 @@ var SCRIPT_TYPE = {
   'dart': 'application/dart',
   'esModule': 'module'
 }
+var FILE_TYPES = [
+  'css',
+  'html',
+  'js',
+  'dart',
+  'esModule'
+]
 
 var filePathToUrlPath = function (filePath, basePath, urlRoot, proxyPath) {
   if (filePath.indexOf(basePath) === 0) {
@@ -183,6 +191,10 @@ var createKarmaMiddleware = function (
 
             if (!files.included.hasOwnProperty(i)) {
               continue
+            }
+
+            if (!_.isUndefined(fileType) && FILE_TYPES.indexOf(fileType) === -1) {
+              log.warn('Invalid file type, defaulting to js.', fileType)
             }
 
             if (!file.isUrl) {

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -178,6 +178,7 @@ var createKarmaMiddleware = function (
             var file = files.included[i]
             var filePath = file.path
             var fileExt = path.extname(filePath)
+            var fileType = file.type
 
             if (!files.included.hasOwnProperty(i)) {
               continue
@@ -193,12 +194,12 @@ var createKarmaMiddleware = function (
 
             scriptUrls.push(filePath)
 
-            if (fileExt === '.css') {
+            if (fileExt === '.css' || fileType === 'css') {
               scriptTags.push(util.format(LINK_TAG_CSS, filePath))
               continue
             }
 
-            if (fileExt === '.html') {
+            if (fileExt === '.html' || fileType === 'html') {
               scriptTags.push(util.format(LINK_TAG_HTML, filePath))
               continue
             }

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -35,14 +35,14 @@ var LINK_TAG_HTML = '<link href="%s" rel="import">'
 var SCRIPT_TYPE = {
   'js': 'text/javascript',
   'dart': 'application/dart',
-  'esModule': 'module'
+  'module': 'module'
 }
 var FILE_TYPES = [
   'css',
   'html',
   'js',
   'dart',
-  'esModule'
+  'module'
 ]
 
 var filePathToUrlPath = function (filePath, basePath, urlRoot, proxyPath) {

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -13,8 +13,8 @@ describe('middleware.karma', () => {
   var nextSpy
   var response
 
-  var MockFile = function (path, sha) {
-    File.call(this, path)
+  var MockFile = function (path, sha, type) {
+    File.call(this, path, undefined, undefined, type)
     this.sha = sha || 'sha-default'
   }
 
@@ -212,12 +212,14 @@ describe('middleware.karma', () => {
   it('should serve context.html with replaced link tags', (done) => {
     includedFiles([
       new MockFile('/first.css', 'sha007'),
-      new MockFile('/second.html', 'sha678')
+      new MockFile('/second.html', 'sha678'),
+      new MockFile('/third', 'sha111', 'css'),
+      new MockFile('/fourth', 'sha222', 'html')
     ])
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'CONTEXT\n<link type="text/css" href="/__proxy__/__karma__/absolute/first.css?sha007" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/second.html?sha678" rel="import">')
+      expect(response).to.beServedAs(200, 'CONTEXT\n<link type="text/css" href="/__proxy__/__karma__/absolute/first.css?sha007" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/second.html?sha678" rel="import">\n<link type="text/css" href="/__proxy__/__karma__/absolute/third?sha111" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/fourth?sha222" rel="import">')
       done()
     })
 
@@ -244,12 +246,16 @@ describe('middleware.karma', () => {
       new MockFile('/some/abc/a.css', 'sha1'),
       new MockFile('/base/path/b.css', 'sha2'),
       new MockFile('/some/abc/c.html', 'sha3'),
-      new MockFile('/base/path/d.html', 'sha4')
+      new MockFile('/base/path/d.html', 'sha4'),
+      new MockFile('/some/abc/e', 'sha5', 'css'),
+      new MockFile('/base/path/f', 'sha6', 'css'),
+      new MockFile('/some/abc/g', 'sha7', 'html'),
+      new MockFile('/base/path/h', 'sha8', 'html')
     ])
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'CONTEXT\n<link type="text/css" href="/__proxy__/__karma__/absolute/some/abc/a.css?sha1" rel="stylesheet">\n<link type="text/css" href="/__proxy__/__karma__/base/b.css?sha2" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/some/abc/c.html?sha3" rel="import">\n<link href="/__proxy__/__karma__/base/d.html?sha4" rel="import">')
+      expect(response).to.beServedAs(200, 'CONTEXT\n<link type="text/css" href="/__proxy__/__karma__/absolute/some/abc/a.css?sha1" rel="stylesheet">\n<link type="text/css" href="/__proxy__/__karma__/base/b.css?sha2" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/some/abc/c.html?sha3" rel="import">\n<link href="/__proxy__/__karma__/base/d.html?sha4" rel="import">\n<link type="text/css" href="/__proxy__/__karma__/absolute/some/abc/e?sha5" rel="stylesheet">\n<link type="text/css" href="/__proxy__/__karma__/base/f?sha6" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/some/abc/g?sha7" rel="import">\n<link href="/__proxy__/__karma__/base/h?sha8" rel="import">')
       done()
     })
 
@@ -261,7 +267,11 @@ describe('middleware.karma', () => {
       new MockFile('/some/abc/a.css', 'sha1'),
       new MockFile('/base/path/b.css', 'sha2'),
       new MockFile('/some/abc/c.html', 'sha3'),
-      new MockFile('/base/path/d.html', 'sha4')
+      new MockFile('/base/path/d.html', 'sha4'),
+      new MockFile('/some/abc/e', 'sha5', 'css'),
+      new MockFile('/base/path/f', 'sha6', 'css'),
+      new MockFile('/some/abc/g', 'sha7', 'html'),
+      new MockFile('/base/path/h', 'sha8', 'html')
     ])
 
     response.once('end', () => {
@@ -271,7 +281,11 @@ describe('middleware.karma', () => {
           '/__proxy__/__karma__/absolute/some/abc/a.css?sha1',
           '/__proxy__/__karma__/base/b.css?sha2',
           '/__proxy__/__karma__/absolute/some/abc/c.html?sha3',
-          '/__proxy__/__karma__/base/d.html?sha4'
+          '/__proxy__/__karma__/base/d.html?sha4',
+          '/__proxy__/__karma__/absolute/some/abc/e?sha5',
+          '/__proxy__/__karma__/base/f?sha6',
+          '/__proxy__/__karma__/absolute/some/abc/g?sha7',
+          '/__proxy__/__karma__/base/h?sha8'
         ]
       }))
       done()
@@ -361,12 +375,16 @@ describe('middleware.karma', () => {
       new MockFile('/first.css'),
       new MockFile('/base/path/b.css'),
       new MockFile('/second.html'),
-      new MockFile('/base/path/d.html')
+      new MockFile('/base/path/d.html'),
+      new MockFile('/third', null, 'css'),
+      new MockFile('/base/path/f', null, 'css'),
+      new MockFile('/fourth', null, 'html'),
+      new MockFile('/base/path/g', null, 'html')
     ])
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'DEBUG\n<link type="text/css" href="/__proxy__/__karma__/absolute/first.css" rel="stylesheet">\n<link type="text/css" href="/__proxy__/__karma__/base/b.css" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/second.html" rel="import">\n<link href="/__proxy__/__karma__/base/d.html" rel="import">')
+      expect(response).to.beServedAs(200, 'DEBUG\n<link type="text/css" href="/__proxy__/__karma__/absolute/first.css" rel="stylesheet">\n<link type="text/css" href="/__proxy__/__karma__/base/b.css" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/second.html" rel="import">\n<link href="/__proxy__/__karma__/base/d.html" rel="import">\n<link type="text/css" href="/__proxy__/__karma__/absolute/third" rel="stylesheet">\n<link type="text/css" href="/__proxy__/__karma__/base/f" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/fourth" rel="import">\n<link href="/__proxy__/__karma__/base/g" rel="import">')
       done()
     })
 


### PR DESCRIPTION
Adds a manual file type so that users can instruct Karma which method to use when loading a file without an extension (such as Google font files)

Example:
```
files: [
    {
        pattern: 'https://fonts.googleapis.com/icon?family=Material+Icons',
        type: 'css'
    }
]
```

Fix for https://github.com/karma-runner/karma/issues/2824

First time working karma so let me know if there are any changes I need to make.