### PR TITLE
test(web-server): fix http2 tests

### DIFF
--- a/test/unit/web-server.spec.js
+++ b/test/unit/web-server.spec.js
@@ -252,7 +252,7 @@ describe('web-server', () => {
   })
 
   describe('http2', () => {
-    var http2 = require('http2')
+    var http2 = require('http2/')
 
     beforeEach(() => {
       var credentials = {


### PR DESCRIPTION
Node 8.8.0 includes a new experimental built-in http2 module which trumps
the external one from npm, breaking Karma tests. This commit switches the
require back to using the npm package.