### PR TITLE
feat(config): Allow programmatic config

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -1,6 +1,6 @@
 ## Overview
 In order to serve you well, Karma needs to know about your project in order to test it
-and this is done via a configuration file. The easiest way to generate an initial configuration file
+and this is normally done via a configuration file. The easiest way to generate an initial configuration file
 is by using the `karma init` command. This page lists all of the available configuration options.
 
 Note: Most of the framework adapters, reporters, preprocessors and launchers need to be loaded as [plugins].

--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -139,8 +139,8 @@ stopper.stop({port: 9876}, function(exitCode) {
 ## karma.config.parseConfig([configFilePath], [cliOptions])
 
 This function will load given config file and returns a filled config object.
-This can be useful if you want to integrate karma into another tool and want to load
-the karma config while honoring the karma defaults. For example, the [stryker-karma-runner](https://github.com/stryker-mutator/stryker-karma-runner)
+This can be useful if you want to integrate karma into another tool using a
+pre-existing config file. For example, the [stryker-karma-runner](https://github.com/stryker-mutator/stryker-karma-runner)
 uses this to load your karma configuration and use that in the stryker configuration.
 
 ```javascript
@@ -148,6 +148,24 @@ const cfg = require('karma').config;
 const path = require('path');
 // Read karma.conf.js, but override port with 1337
 const karmaConfig = cfg.parseConfig(path.resolve('./karma.conf.js'), { port: 1337 } );
+```
+
+## karma.config.directConfig([callback=function() {}])
+
+This function allows inline configuration in code. This way you can avoid tracking
+or trusting an extra config file, all while honoring the karma defaults. This is
+also useful for custom integrations where the rest of the toolchain is managed
+programmatically.
+
+Calling `directConfig()` without any arguments is equivalent to creating
+a new config object with default karma options.
+
+```javascript
+const cfg = require('karma').config;
+
+const karmaConfig = cfg.directConfig((config) => {
+	return config.set({ /* ... */ })
+});
 ```
 
 ## karma.constants

--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -153,12 +153,17 @@ const karmaConfig = cfg.parseConfig(path.resolve('./karma.conf.js'), { port: 133
 ## karma.config.directConfig([callback=function() {}])
 
 This function allows inline configuration in code. This way you can avoid tracking
-or trusting an extra config file, all while honoring the karma defaults. This is
+or trusting an extra config file, all while honoring karma defaults. This is
 also useful for custom integrations where the rest of the toolchain is managed
 programmatically.
 
 Calling `directConfig()` without any arguments is equivalent to creating
 a new config object with default karma options.
+
+Note that the `basePath` configuration option should be set in this
+case, because Karma does not know how to locate your project otherwise.
+As a rule of thumb, set `basePath` to the *absolute path* where you
+would otherwise leave a config file.
 
 ```javascript
 const cfg = require('karma').config;

--- a/docs/intro/02-configuration.md
+++ b/docs/intro/02-configuration.md
@@ -1,5 +1,5 @@
 In order to serve you well, Karma needs to know about your project in order to test it
-and this is done via a configuration file. This page explains how to create such a configuration file.
+and this is normally done via a configuration file. This page explains how to create such a configuration file.
 
 See [configuration file docs] for more information about the syntax and all the available options.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -436,8 +436,38 @@ var parseConfig = function (configFilePath, cliOptions) {
   return normalizeConfig(config, configFilePath)
 }
 
+var directConfig = function (configCallback) {
+  if (typeof configCallback === 'function') {
+    log.debug('Loading config from provided callback')
+  } else {
+    log.debug('No config callback specified.')
+    // Respect the flow used by parseConfig
+    configCallback = function () {}
+  }
+
+  var config = new Config()
+
+  try {
+    configCallback(config)
+  } catch (e) {
+    log.error('Error computing config from callback!\n', e)
+    return process.exit(1)
+  }
+
+  logger.setup(config.logLevel, config.colors, config.loggers)
+
+  // Because this approach does not use a config file, warn that this
+  // has implications for basePath in normalizeConfig()
+  if (typeof config.basePath !== 'string') {
+    log.warn('Programmatic config lacks basePath. Defaulting to \'.\'')
+  }
+
+  return normalizeConfig(config)
+}
+
 // PUBLIC API
 exports.parseConfig = parseConfig
+exports.directConfig = directConfig
 exports.Pattern = Pattern
 exports.createPatternObject = createPatternObject
 exports.Config = Config

--- a/lib/config.js
+++ b/lib/config.js
@@ -438,7 +438,7 @@ var parseConfig = function (configFilePath, cliOptions) {
 
 var directConfig = function (configCallback) {
   if (typeof configCallback === 'function') {
-    log.debug('Loading config from provided callback')
+    log.debug('Config callback detected.')
   } else {
     log.debug('No config callback specified.')
     // Respect the flow used by parseConfig

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,6 @@ module.exports = {
   runner: runner,
   stopper: stopper,
   launcher: launcher,
-  config: { parseConfig: cfg.parseConfig }, // lets start with only opening up the `parseConfig` api
+  config: { parseConfig: cfg.parseConfig, directConfig: cfg.directConfig },
   server: oldServer
 }

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "Rob Cherry <rcherry@reverbnation.com>",
     "Rob Dodson <lets.email.rob@gmail.com>",
     "Rémi <r3mi@users.sourceforge.net>",
+    "Sage Gerard <sage@sagegerard.com>",
     "Sahat Yalkabov <sakhat@gmail.com>",
     "Sam Rawlins <sam.rawlins@gmail.com>",
     "Sam Rawlins <srawlins@google.com>",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,6 @@
     "Rob Cherry <rcherry@reverbnation.com>",
     "Rob Dodson <lets.email.rob@gmail.com>",
     "Rémi <r3mi@users.sourceforge.net>",
-    "Sage Gerard <sage@sagegerard.com>",
     "Sahat Yalkabov <sakhat@gmail.com>",
     "Sam Rawlins <sam.rawlins@gmail.com>",
     "Sam Rawlins <srawlins@google.com>",

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -84,13 +84,15 @@ describe('config', () => {
         expect(config).to.be.instanceof(m.Config)
 
         config.set({
-          basePath: '/tmp/example'
+          autoWatch: false,
+          basePath: path.resolve('.')
         })
       })
 
       var other = new m.Config()
       other.set({
-        basePath: '/tmp/example'
+        autoWatch: false,
+        basePath: path.resolve('.')
       })
 
       expect(keepdata(config)).to.deep.equal(keepdata(other))

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -67,6 +67,44 @@ describe('config', () => {
     e = m.exports
   })
 
+  describe('directConfig', () => {
+    // Shallow-strip functions that would complicate deep equal checks.
+    var keepdata = function (o) {
+      return Object.keys(o).reduce((p, k) => {
+        if (typeof o[k] !== 'function') {
+          p[k] = o[k]
+        }
+
+        return p
+      }, {})
+    }
+
+    it('should allow programmatic configuration', () => {
+      var config = e.directConfig((config) => {
+        expect(config).to.be.instanceof(m.Config)
+
+        config.set({
+          basePath: '/tmp/example'
+        })
+      })
+
+      var other = new m.Config()
+      other.set({
+        basePath: '/tmp/example'
+      })
+
+      expect(keepdata(config)).to.deep.equal(keepdata(other))
+    })
+
+    it('should respect defaults', () => {
+      var config = e.directConfig()
+      var other = m.normalizeConfig(new m.Config())
+
+      expect(Object.keys(config)).to.have.length.above(0)
+      expect(keepdata(config)).to.deep.equal(keepdata(other))
+    })
+  })
+
   describe('parseConfig', () => {
     var logSpy
 


### PR DESCRIPTION
In the spirit of Karma's "Fix something that bothers you" as a platform maintainer, I wanted to enable programmatic configuration so that I can use Karma more effectively both without file I/O, and inline with other tools accessible via Node APIs.

A caveat of this change is that a config is obliged to specify a `basePath`.