### PR TITLE
Support the new CoffeeScript module name

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -18,6 +18,12 @@ try {
   COFFEE_SCRIPT_AVAILABLE = true
 } catch (e) {}
 
+// CoffeeScript lost the hyphen in the module name a long time ago, all new version are named this:
+try {
+  require('coffeescript').register()
+  COFFEE_SCRIPT_AVAILABLE = true
+} catch (e) {}
+
 // LiveScript is required here to enable config files written in LiveScript.
 // It's not directly used in this file.
 try {


### PR DESCRIPTION
CoffeeScript lost the hyphen in the module name about 9 months ago, all the new versions are going to be released as coffeescript not the coffee-script