### PR TITLE
feat(cli): Warn on commands with underscores.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,6 +21,9 @@ var processArgs = function (argv, options, fs, path) {
   Object.getOwnPropertyNames(argv).forEach(function (name) {
     var argumentValue = argv[name]
     if (name !== '_' && name !== '$0') {
+      if (name.indexOf('_') !== -1) {
+        throw new Error('Bad argument: ' + name + ' did you mean ' + name.replace('_', '-'))
+      }
       if (Array.isArray(argumentValue)) {
         // If the same argument is defined multiple times, override.
         argumentValue = argumentValue.pop()

--- a/test/unit/cli.spec.js
+++ b/test/unit/cli.spec.js
@@ -183,6 +183,18 @@ describe('cli', () => {
       expect(options.addedFiles).to.deep.equal(['a1.js', 'a2.js'])
       expect(options.changedFiles).to.deep.equal(['ch1.js', 'ch2.js'])
     })
+
+    it('should error on args with underscores', () => {
+      var expectedException
+      try {
+        var options = processArgs(['--no_browsers'])
+        expectedException = 'Should have thrown but got ' + options
+      } catch (e) {
+        expectedException = e
+      } finally {
+        expect(expectedException + '').to.equal('Error: Bad argument: no_browsers did you mean no-browsers')
+      }
+    })
   })
 
   describe('parseClientArgs', () => {


### PR DESCRIPTION
The cli silently ignores unknown options. Until we can fix this, a simple
improvement is to warn on options with underscores. In our experience, --no_browsers
is common user error that gives confusion because browsers are used.