### PR TITLE
fix(config): Retry install with appveyor-retry.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
 
   # Upgrade npm
-  - npm install -g npm
+  - npm install -g npm@5.3
 
   # Output our current versions for debugging
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
 
   # Upgrade npm
-  - npm install -g npm@5.3
+  - appveyor-retry npm install -g npm@5.3
 
   # Output our current versions for debugging
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,14 +16,14 @@ install:
   - ps: Install-Product node $env:nodejs_version
 
   # Upgrade npm
-  - appveyor-retry npm install -g npm@5.3
+  - npm install -g npm@5.3
 
   # Output our current versions for debugging
   - node --version
   - npm --version
 
   # Install our package dependencies
-  - npm install
+  - appveyor-retry npm install
 
   # Install our current directory as a dependency of itself
   - npm run init:windows

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
 
   # Upgrade npm
-  - npm install -g npm@5.3
+  - npm install -g npm
 
   # Output our current versions for debugging
   - node --version


### PR DESCRIPTION
appveyor CI fails on node 8 with
Error: EPERM: operation not permitted, scandir 'C:\projects\karma\node_modules\fsevents\node_modules'
See https://github.com/npm/npm/issues/18380