### PR TITLE
fix(deps): update socket.io to version 2.0.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -350,7 +350,7 @@
     "range-parser": "^1.2.0",
     "rimraf": "^2.6.0",
     "safe-buffer": "^5.0.1",
-    "socket.io": "1.7.4",
+    "socket.io": "2.0.3",
     "source-map": "^0.5.3",
     "tmp": "0.0.31",
     "useragent": "^2.1.12"


### PR DESCRIPTION
This is a duplicate of @kevinsalter PR #2821. I am re-sending after appveyor fixup.
(We don't seem to have the ability to retry appveyor builds).

Fixes #2777