### PR TITLE
refactor: run build on post-install instead of pre-publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@ tmp
 test
 tasks
 docs
-client
 logo
 integration-tests
 
@@ -17,6 +16,8 @@ Karma.sublime-*
 
 static/karma.src.js
 static/karma.wrapper
+static/context.js
+static/karma.js
 test-results.xml
 thesis.pdf
 mocha-watch.sh

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -144,7 +144,6 @@ module.exports = function (grunt) {
     grunt.task.run([
       'npm-contributors',
       'bump:' + (type || 'patch') + ':bump-only',
-      'build',
       'conventionalChangelog',
       'bump-commit',
       'conventionalGithubReleaser',

--- a/package.json
+++ b/package.json
@@ -329,6 +329,7 @@
   "dependencies": {
     "bluebird": "^3.3.0",
     "body-parser": "^1.16.1",
+    "browserify": "^14.5.0",
     "chokidar": "^1.4.1",
     "colors": "^1.1.0",
     "combine-lists": "^1.0.0",
@@ -436,7 +437,8 @@
   "scripts": {
     "lint": "eslint client/**/*.js common/**/*.js context/**/*.js gruntfile.js wallaby.js lib/**/*.js test/**/*.js static/debug.js",
     "test": "grunt test",
-    "build": "grunt build",
+    "build": "browserify ./client/main.js -o ./static/karma.js && browserify ./context/main.js -o ./static/context.js",
+    "postinstall": "npm run build",
     "test:appveyor": "grunt test-appveyor",
     "test:integration": "./scripts/integration-tests.sh",
     "link": "node --eval \"path=require('path'); require('fs').symlinkSync(path.resolve(__dirname), path.resolve(__dirname, 'node_modules', 'karma'), 'junction')\"",


### PR DESCRIPTION
Fixes #2884.

Switching the bundling to happen on the client-side makes Karma development more flexible. For instance, on projects at work we pull npm packages based on git tags, since we don't have enough to warrant running a private npm registry. If we were to fork Karma, it wouldn't work at all due to the bundling being done on pre-publish.

Additionally, it allows developers to easily pull in pre-release versions of Karma to test locally, since they won't have to manually run the build script when installing the module into a test package.