### PR TITLE
refactor: transition from pseudoclasses to ES6 classes

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -19,122 +19,127 @@ var EXECUTING_DISCONNECTED = 4
 // The browser got permanently disconnected (being removed from the collection and destroyed).
 var DISCONNECTED = 5
 
-var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter, socket, timer,
-  /* config.browserDisconnectTimeout */ disconnectDelay,
-  /* config.browserNoActivityTimeout */ noActivityTimeout) {
-  var name = helper.browserFullNameToShort(fullName)
-  var log = logger.create(name)
-  var activeSockets = [socket]
-  var activeSocketsIds = function () {
-    return activeSockets.map(function (s) {
+class Browser {
+  constructor (id, fullName, /* capturedBrowsers */ collection, emitter, socket, timer,
+    /* config.browserDisconnectTimeout */ disconnectDelay,
+    /* config.browserNoActivityTimeout */ noActivityTimeout) {
+    this.name = helper.browserFullNameToShort(fullName)
+    this.log = logger.create(this.name)
+    this.activeSockets = [socket]
+    this.id = id
+    this.fullName = fullName
+    this.state = READY
+    this.lastResult = new Result()
+    this.disconnectsCount = 0
+    this.pendingDisconnect = null
+    this.timer = timer
+    this.noActivityTimeoutId = null
+    this.noActivityTimeout = noActivityTimeout
+    this.emitter = emitter
+    this.collection = collection
+    this.disconnectDelay = disconnectDelay
+    this.socket = socket
+  }
+  activeSocketsIds () {
+    return this.activeSockets.map(function (s) {
       return s.id
     }).join(', ')
   }
-
-  var self = this
-  var pendingDisconnect
-  var disconnect = function (reason) {
-    self.state = DISCONNECTED
-    self.disconnectsCount++
-    log.warn('Disconnected (%d times)' + (reason || ''), self.disconnectsCount)
-    emitter.emit('browser_error', self, 'Disconnected' + reason)
-    collection.remove(self)
+  disconnect (reason) {
+    this.state = DISCONNECTED
+    this.disconnectsCount++
+    this.log.warn('Disconnected (%d times)' + (reason || ''), this.disconnectsCount)
+    this.emitter.emit('browser_error', this, 'Disconnected' + reason)
+    this.collection.remove(this)
+  }
+  refreshNoActivityTimeout () {
+    if (this.noActivityTimeout) {
+      this.clearNoActivityTimeout()
+      this.noActivityTimeoutId = this.timer.setTimeout(() => {
+        this.lastResult.totalTimeEnd()
+        this.lastResult.disconnected = true
+        this.disconnect(', because no message in ' + this.noActivityTimeout + ' ms.')
+        this.emitter.emit('browser_complete', this)
+      }, this.noActivityTimeout)
+    }
   }
 
-  var noActivityTimeoutId
-  var refreshNoActivityTimeout = noActivityTimeout ? function () {
-    clearNoActivityTimeout()
-    noActivityTimeoutId = timer.setTimeout(function () {
-      self.lastResult.totalTimeEnd()
-      self.lastResult.disconnected = true
-      disconnect(', because no message in ' + noActivityTimeout + ' ms.')
-      emitter.emit('browser_complete', self)
-    }, noActivityTimeout)
-  } : function () {}
-
-  var clearNoActivityTimeout = noActivityTimeout ? function () {
-    if (noActivityTimeoutId) {
-      timer.clearTimeout(noActivityTimeoutId)
-      noActivityTimeoutId = null
+  clearNoActivityTimeout () {
+    if (this.noActivityTimeout && this.noActivityTimeoutId) {
+      this.timer.clearTimeout(this.noActivityTimeoutId)
+      this.noActivityTimeoutId = null
     }
-  } : function () {}
+  }
 
-  this.id = id
-  this.fullName = fullName
-  this.name = name
-  this.state = READY
-  this.lastResult = new Result()
-  this.disconnectsCount = 0
+  init () {
+    this.collection.add(this)
 
-  this.init = function () {
-    collection.add(this)
+    events.bindAll(this, this.socket)
 
-    events.bindAll(this, socket)
-
-    log.info('Connected on socket %s with id %s', socket.id, id)
+    this.log.info('Connected on socket %s with id %s', this.socket.id, this.id)
 
     // TODO(vojta): move to collection
-    emitter.emit('browsers_change', collection)
+    this.emitter.emit('browsers_change', this.collection)
 
-    emitter.emit('browser_register', this)
+    this.emitter.emit('browser_register', this)
   }
 
-  this.isReady = function () {
+  isReady () {
     return this.state === READY
   }
 
-  this.toString = function () {
+  toString () {
     return this.name
   }
 
-  this.onKarmaError = function (error) {
+  onKarmaError (error) {
     if (this.isReady()) {
       return
     }
 
     this.lastResult.error = true
-    emitter.emit('browser_error', this, error)
+    this.emitter.emit('browser_error', this, error)
 
-    refreshNoActivityTimeout()
+    this.refreshNoActivityTimeout()
   }
 
-  this.onInfo = function (info) {
+  onInfo (info) {
     if (this.isReady()) {
       return
     }
 
     // TODO(vojta): remove
     if (helper.isDefined(info.dump)) {
-      emitter.emit('browser_log', this, info.dump, 'dump')
+      this.emitter.emit('browser_log', this, info.dump, 'dump')
     }
 
     if (helper.isDefined(info.log)) {
-      emitter.emit('browser_log', this, info.log, info.type)
+      this.emitter.emit('browser_log', this, info.log, info.type)
     }
 
     if (
       !helper.isDefined(info.log) &&
       !helper.isDefined(info.dump)
     ) {
-      emitter.emit('browser_info', this, info)
+      this.emitter.emit('browser_info', this, info)
     }
 
-    refreshNoActivityTimeout()
+    this.refreshNoActivityTimeout()
   }
 
-  this.onStart = function (info) {
+  onStart (info) {
     this.lastResult = new Result()
     this.lastResult.total = info.total
 
     if (info.total === null) {
-      log.warn('Adapter did not report total number of specs.')
+      this.log.warn('Adapter did not report total number of specs.')
     }
 
-    emitter.emit('browser_start', this, info)
-    refreshNoActivityTimeout()
+    this.emitter.emit('browser_start', this, info)
+    this.refreshNoActivityTimeout()
   }
 
-  this.onComplete = function (result) {
+  onComplete (result) {
     if (this.isReady()) {
       return
     }
@@ -146,86 +151,89 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
       this.lastResult.error = true
     }
 
-    emitter.emit('browsers_change', collection)
-    emitter.emit('browser_complete', this, result)
+    this.emitter.emit('browsers_change', this.collection)
+    this.emitter.emit('browser_complete', this, result)
 
-    clearNoActivityTimeout()
+    this.clearNoActivityTimeout()
   }
 
-  this.onDisconnect = function (_, disconnectedSocket) {
-    activeSockets.splice(activeSockets.indexOf(disconnectedSocket), 1)
+  onDisconnect (_, disconnectedSocket) {
+    this.activeSockets.splice(this.activeSockets.indexOf(disconnectedSocket), 1)
 
-    if (activeSockets.length) {
-      log.debug('Disconnected %s, still have %s', disconnectedSocket.id, activeSocketsIds())
+    if (this.activeSockets.length) {
+      this.log.debug('Disconnected %s, still have %s', disconnectedSocket.id, this.activeSocketsIds())
       return
     }
 
     if (this.state === READY) {
-      disconnect()
+      this.disconnect()
     } else if (this.state === EXECUTING) {
-      log.debug('Disconnected during run, waiting %sms for reconnecting.', disconnectDelay)
+      this.log.debug('Disconnected during run, waiting %sms for reconnecting.', this.disconnectDelay)
       this.state = EXECUTING_DISCONNECTED
 
-      pendingDisconnect = timer.setTimeout(function () {
-        self.lastResult.totalTimeEnd()
-        self.lastResult.disconnected = true
-        disconnect()
-        emitter.emit('browser_complete', self)
-      }, disconnectDelay)
+      this.pendingDisconnect = this.timer.setTimeout(() => {
+        this.lastResult.totalTimeEnd()
+        this.lastResult.disconnected = true
+        this.disconnect()
+        this.emitter.emit('browser_complete', this)
+      }, this.disconnectDelay)
 
-      clearNoActivityTimeout()
+      this.clearNoActivityTimeout()
     }
   }
 
-  this.reconnect = function (newSocket) {
+  reconnect (newSocket) {
     if (this.state === EXECUTING_DISCONNECTED) {
       this.state = EXECUTING
-      log.debug('Reconnected on %s.', newSocket.id)
+      this.log.debug('Reconnected on %s.', newSocket.id)
     } else if (this.state === EXECUTING || this.state === READY) {
-      log.debug('New connection %s (already have %s)', newSocket.id, activeSocketsIds())
+      this.log.debug('New connection %s (already have %s)', newSocket.id, this.activeSocketsIds())
     } else if (this.state === DISCONNECTED) {
       this.state = READY
-      log.info('Connected on socket %s with id %s', newSocket.id, this.id)
-      collection.add(this)
+      this.log.info('Connected on socket %s with id %s', newSocket.id, this.id)
+      this.collection.add(this)
 
       // TODO(vojta): move to collection
-      emitter.emit('browsers_change', collection)
+      this.emitter.emit('browsers_change', this.collection)
 
-      emitter.emit('browser_register', this)
+      this.emitter.emit('browser_register', this)
     }
 
-    var exists = activeSockets.some(function (s) {
+    var exists = this.activeSockets.some(function (s) {
       return s.id === newSocket.id
     })
     if (!exists) {
-      activeSockets.push(newSocket)
+      this.activeSockets.push(newSocket)
       events.bindAll(this, newSocket)
     }
 
-    if (pendingDisconnect) {
-      timer.clearTimeout(pendingDisconnect)
+    if (this.pendingDisconnect) {
+      this.timer.clearTimeout(this.pendingDisconnect)
     }
 
-    refreshNoActivityTimeout()
+    this.refreshNoActivityTimeout()
   }
 
-  this.onResult = function (result) {
+  onResult (result) {
     if (result.length) {
-      return result.forEach(this.onResult, this)
+      return result.forEach((element) => {
+        this.onResult(element)
+      })
     }
 
     // ignore - probably results from last run (after server disconnecting)
     if (this.isReady()) {
       return
     }
-
+    console.log('adding result ' + JSON.stringify(result))
     this.lastResult.add(result)
+    console.log('lastResult is now ' + JSON.stringify(this.lastResult))
 
-    emitter.emit('spec_complete', this, result)
-    refreshNoActivityTimeout()
+    this.emitter.emit('spec_complete', this, result)
+    this.refreshNoActivityTimeout()
   }
 
-  this.serialize = function () {
+  serialize () {
     return {
       id: this.id,
       name: this.name,
@@ -233,20 +241,25 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
     }
   }
 
-  this.execute = function (config) {
-    activeSockets.forEach(function (socket) {
+  execute (config) {
+    this.activeSockets.forEach(function (socket) {
       socket.emit('execute', config)
     })
-
     this.state = EXECUTING
-    refreshNoActivityTimeout()
+    this.refreshNoActivityTimeout()
   }
 }
 
-Browser.STATE_READY = READY
-Browser.STATE_EXECUTING = EXECUTING
-Browser.STATE_READY_DISCONNECTED = READY_DISCONNECTED
-Browser.STATE_EXECUTING_DISCONNECTED = EXECUTING_DISCONNECTED
-Browser.STATE_DISCONNECTED = DISCONNECTED
+function browserInjector (id, fullName, /* capturedBrowsers */ collection, emitter, socket, timer,
+  /* config.browserDisconnectTimeout */ disconnectDelay,
+  /* config.browserNoActivityTimeout */ noActivityTimeout) {
+  var browser = new Browser(id, fullName, collection, emitter, socket, timer, disconnectDelay, noActivityTimeout)
+  return browser
+}
+browserInjector.STATE_READY = READY
+browserInjector.STATE_EXECUTING = EXECUTING
+browserInjector.STATE_READY_DISCONNECTED = READY_DISCONNECTED
+browserInjector.STATE_EXECUTING_DISCONNECTED = EXECUTING_DISCONNECTED
+browserInjector.STATE_DISCONNECTED = DISCONNECTED
 
-module.exports = Browser
+module.exports = browserInjector

--- a/lib/browser_collection.js
+++ b/lib/browser_collection.js
@@ -1,49 +1,51 @@
 var EXECUTING = require('./browser').STATE_EXECUTING
 var Result = require('./browser_result')
 
-var Collection = function (emitter, browsers) {
-  browsers = browsers || []
-
-  this.add = function (browser) {
-    browsers.push(browser)
-    emitter.emit('browsers_change', this)
+class BrowserCollection {
+  constructor (emitter, browsers) {
+    this.browsers = browsers || []
+    this.emitter = emitter
+  }
+  add (browser) {
+    this.browsers.push(browser)
+    this.emitter.emit('browsers_change', this)
   }
 
-  this.remove = function (browser) {
-    var index = browsers.indexOf(browser)
+  remove (browser) {
+    var index = this.browsers.indexOf(browser)
 
     if (index === -1) {
       return false
     }
 
-    browsers.splice(index, 1)
-    emitter.emit('browsers_change', this)
+    this.browsers.splice(index, 1)
+    this.emitter.emit('browsers_change', this)
 
     return true
   }
 
-  this.getById = function (browserId) {
-    for (var i = 0; i < browsers.length; i++) {
-      if (browsers[i].id === browserId) {
-        return browsers[i]
+  getById (browserId) {
+    for (var i = 0; i < this.browsers.length; i++) {
+      if (this.browsers[i].id === browserId) {
+        return this.browsers[i]
       }
     }
 
     return null
   }
 
-  this.setAllToExecuting = function () {
-    browsers.forEach(function (browser) {
+  setAllToExecuting () {
+    this.browsers.forEach(function (browser) {
       browser.state = EXECUTING
     })
 
-    emitter.emit('browsers_change', this)
+    this.emitter.emit('browsers_change', this)
   }
 
-  this.areAllReady = function (nonReadyList) {
+  areAllReady (nonReadyList) {
     nonReadyList = nonReadyList || []
 
-    browsers.forEach(function (browser) {
+    this.browsers.forEach(function (browser) {
       if (!browser.isReady()) {
         nonReadyList.push(browser)
       }
@@ -52,20 +54,20 @@ var Collection = function (emitter, browsers) {
     return nonReadyList.length === 0
   }
 
-  this.serialize = function () {
-    return browsers.map(function (browser) {
+  serialize () {
+    return this.browsers.map(function (browser) {
       return browser.serialize()
     })
   }
 
-  this.getResults = function () {
-    var results = browsers.reduce(function (previous, current) {
+  getResults () {
+    var results = this.browsers.reduce(function (previous, current) {
       previous.success += current.lastResult.success
       previous.failed += current.lastResult.failed
       previous.error = previous.error || current.lastResult.error
       previous.disconnected = previous.disconnected || current.lastResult.disconnected
       return previous
-    }, {success: 0, failed: 0, error: false, disconnected: false, exitCode: 0})
+    }, { success: 0, failed: 0, error: false, disconnected: false, exitCode: 0 })
 
     // compute exit status code
     results.exitCode = results.failed || results.error || results.disconnected ? 1 : 0
@@ -74,32 +76,35 @@ var Collection = function (emitter, browsers) {
   }
 
   // TODO(vojta): can we remove this? (we clear the results per browser in onBrowserStart)
-  this.clearResults = function () {
-    browsers.forEach(function (browser) {
+  clearResults () {
+    this.browsers.forEach(function (browser) {
       browser.lastResult = new Result()
     })
   }
 
-  this.clone = function () {
-    return new Collection(emitter, browsers.slice())
+  clone () {
+    return new BrowserCollection(this.emitter, this.browsers.slice())
   }
 
   // Array APIs
-  this.map = function (callback, context) {
-    return browsers.map(callback, context)
+  map (callback, context) {
+    return this.browsers.map(callback, context)
   }
 
-  this.forEach = function (callback, context) {
-    return browsers.forEach(callback, context)
+  forEach (callback, context) {
+    return this.browsers.forEach(callback, context)
   }
 
-  // this.length
-  Object.defineProperty(this, 'length', {
-    get: function () {
-      return browsers.length
-    }
-  })
+  get length () {
+    return this.browsers.length
+  }
 }
-Collection.$inject = ['emitter']
 
-module.exports = Collection
+// shim for DI since it stills uses function.apply
+function browserCollectionInjector (emitter, browsers) {
+  return new BrowserCollection(emitter, browsers)
+}
+
+browserCollectionInjector.$inject = ['emitter']
+
+module.exports = browserCollectionInjector

--- a/lib/browser_collection.js
+++ b/lib/browser_collection.js
@@ -1,7 +1,13 @@
+'use strict'
+
 var EXECUTING = require('./browser').STATE_EXECUTING
 var Result = require('./browser_result')
 
 class BrowserCollection {
+  /**
+   * @param {EventEmitter} emitter the emitter to send events to
+   * @param {Array} browsers the array of browsers to wrap
+   */
   constructor (emitter, browsers) {
     this.browsers = browsers || []
     this.emitter = emitter

--- a/lib/browser_result.js
+++ b/lib/browser_result.js
@@ -1,15 +1,19 @@
-var Result = function () {
-  var startTime = Date.now()
+'use strict'
 
-  this.total = this.skipped = this.failed = this.success = 0
-  this.netTime = this.totalTime = 0
-  this.disconnected = this.error = false
+class BrowserResult {
+  constructor () {
+    this.startTime = Date.now()
 
-  this.totalTimeEnd = function () {
-    this.totalTime = Date.now() - startTime
+    this.total = this.skipped = this.failed = this.success = 0
+    this.netTime = this.totalTime = 0
+    this.disconnected = this.error = false
   }
 
-  this.add = function (result) {
+  totalTimeEnd () {
+    this.totalTime = Date.now() - this.startTime
+  }
+
+  add (result) {
     if (result.skipped) {
       this.skipped++
     } else if (result.success) {
@@ -22,4 +26,4 @@ var Result = function () {
   }
 }
 
-module.exports = Result
+module.exports = BrowserResult

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -40,186 +40,182 @@ function byPath (a, b) {
   return 0
 }
 
-// Constructor
-//
-// patterns      - Array
-// excludes      - Array
-// emitter       - EventEmitter
-// preprocess    - Function
-// batchInterval - Number
-var List = function (patterns, excludes, emitter, preprocess, autoWatchBatchDelay) {
-  // Store options
-  this._patterns = patterns
-  this._excludes = excludes
-  this._emitter = emitter
-  this._preprocess = Promise.promisify(preprocess)
-  this._autoWatchBatchDelay = autoWatchBatchDelay
+/**
+ * An object that tracks all files the Karma instance knows about
+ */
+class List {
+  /**
+   * @param {Array<string>} patterns The path patterns to match
+   * @param {Array<string>} excludes The path patterns to explicitly exclude
+   * @param {EventEmitter} emitter The emitter to notify of changes
+   * @param {Function} preprocess The preprocessor function to call on files
+   * @param {Number} autoWatchBatchDelay The delay between auto-watch triggers
+   */
+  constructor (patterns, excludes, emitter, preprocess, autoWatchBatchDelay) {
+    // Store options
+    this._patterns = patterns
+    this._excludes = excludes
+    this._emitter = emitter
+    this._preprocess = Promise.promisify(preprocess)
+    this._autoWatchBatchDelay = autoWatchBatchDelay
 
-  // The actual list of files
-  this.buckets = new Map()
+    // The actual list of files
+    this.buckets = new Map()
 
-  // Internal tracker if we are refreshing.
-  // When a refresh is triggered this gets set
-  // to the promise that `this._refresh` returns.
-  // So we know we are refreshing when this promise
-  // is still pending, and we are done when it's either
-  // resolved or rejected.
-  this._refreshing = Promise.resolve()
+    // Internal tracker if we are refreshing.
+    // When a refresh is triggered this gets set
+    // to the promise that `this._refresh` returns.
+    // So we know we are refreshing when this promise
+    // is still pending, and we are done when it's either
+    // resolved or rejected.
+    this._refreshing = Promise.resolve()
 
-  var self = this
+    var self = this
 
-  // Emit the `file_list_modified` event.
-  // This function is debounced to the value of `autoWatchBatchDelay`
-  // to avoid reloading while files are still being modified.
-  function emit () {
-    self._emitter.emit('file_list_modified', self.files)
-  }
-  var debouncedEmit = _.debounce(emit, self._autoWatchBatchDelay)
-  self._emitModified = function (immediate) {
-    immediate ? emit() : debouncedEmit()
-  }
-}
-
-// Private Interface
-// -----------------
-
-// Is the given path matched by any exclusion filter
-//
-// path - String
-//
-// Returns `undefined` if no match, otherwise the matching
-// pattern.
-List.prototype._isExcluded = function (path) {
-  return _.find(this._excludes, function (pattern) {
-    return mm(path, pattern)
-  })
-}
-
-// Find the matching include pattern for the given path.
-//
-// path - String
-//
-// Returns the match or `undefined` if none found.
-List.prototype._isIncluded = function (path) {
-  return _.find(this._patterns, function (pattern) {
-    return mm(path, pattern.pattern)
-  })
-}
-
-// Find the given path in the bucket corresponding
-// to the given pattern.
-//
-// path    - String
-// pattern - Object
-//
-// Returns a File or undefined
-List.prototype._findFile = function (path, pattern) {
-  if (!path || !pattern) return
-  if (!this.buckets.has(pattern.pattern)) return
-
-  return _.find(Array.from(this.buckets.get(pattern.pattern)), function (file) {
-    return file.originalPath === path
-  })
-}
-
-// Is the given path already in the files list.
-//
-// path - String
-//
-// Returns a boolean.
-List.prototype._exists = function (path) {
-  var self = this
-
-  var patterns = this._patterns.filter(function (pattern) {
-    return mm(path, pattern.pattern)
-  })
-
-  return !!_.find(patterns, function (pattern) {
-    return self._findFile(path, pattern)
-  })
-}
-
-// Check if we are currently refreshing
-List.prototype._isRefreshing = function () {
-  return this._refreshing.isPending()
-}
-
-// Do the actual work of refreshing
-List.prototype._refresh = function () {
-  var self = this
-  var buckets = this.buckets
-  var matchedFiles = new Set()
-
-  var promise = Promise.map(this._patterns, function (patternObject) {
-    var pattern = patternObject.pattern
-
-    if (helper.isUrlAbsolute(pattern)) {
-      buckets.set(pattern, new Set([new Url(pattern)]))
-      return Promise.resolve()
+    // Emit the `file_list_modified` event.
+    // This function is debounced to the value of `autoWatchBatchDelay`
+    // to avoid reloading while files are still being modified.
+    function emit () {
+      self._emitter.emit('file_list_modified', self.files)
     }
-
-    var mg = new Glob(pathLib.normalize(pattern), GLOB_OPTS)
-    var files = mg.found
-    buckets.set(pattern, new Set())
-
-    if (_.isEmpty(files)) {
-      log.warn('Pattern "%s" does not match any file.', pattern)
-      return
+    var debouncedEmit = _.debounce(emit, self._autoWatchBatchDelay)
+    self._emitModified = function (immediate) {
+      immediate ? emit() : debouncedEmit()
     }
-
-    return Promise.map(files, function (path) {
-      if (self._isExcluded(path)) {
-        log.debug('Excluded file "%s"', path)
-        return Promise.resolve()
-      }
-
-      if (matchedFiles.has(path)) {
-        return Promise.resolve()
-      }
-
-      matchedFiles.add(path)
-
-      var mtime = mg.statCache[path].mtime
-      var doNotCache = patternObject.nocache
-      var type = patternObject.type
-      var file = new File(path, mtime, doNotCache, type)
-
-      if (file.doNotCache) {
-        log.debug('Not preprocessing "%s" due to nocache')
-        return Promise.resolve(file)
-      }
-
-      return self._preprocess(file).then(function () {
-        return file
-      })
+  }
+  // Private Interface
+  // -----------------
+  /**
+   * Checks if the given path is matched by any exclusion filter
+   * @param {String} path the path to check exclusion of
+   * @returns {string|undefined} the matching pattern, or undefined if none found
+   */
+  _isExcluded (path) {
+    return _.find(this._excludes, function (pattern) {
+      return mm(path, pattern)
     })
-    .then(function (files) {
-      files = _.compact(files)
+  }
+  /**
+   * Checks if the given path is matched by any inclusion pattern
+   * @param {string} path the path to check exclusion of
+   * @returns {string|undefined} the matching pattern, or undefined if none found
+   */
+  _isIncluded (path) {
+    return _.find(this._patterns, function (pattern) {
+      return mm(path, pattern.pattern)
+    })
+  }
+  /**
+   * Find the given path in the bucket corresponding to the given pattern.
+   * @param {string} path The path to look up
+   * @param {object} pattern The pattern to match to
+   * @returns {File|undefined} the matching File or undefined if none found.
+   */
+  _findFile (path, pattern) {
+    if (!path || !pattern) return
+    if (!this.buckets.has(pattern.pattern)) return
+
+    return _.find(Array.from(this.buckets.get(pattern.pattern)), function (file) {
+      return file.originalPath === path
+    })
+  }
+  /**
+   * Checks if the given path is already in the files list
+   * @param {string} path the path to check for the presence of
+   * @returns {boolean} Whether or not the file is present in the list
+   */
+  _exists (path) {
+    var self = this
+
+    var patterns = this._patterns.filter(function (pattern) {
+      return mm(path, pattern.pattern)
+    })
+
+    return !!_.find(patterns, function (pattern) {
+      return self._findFile(path, pattern)
+    })
+  }
+  /**
+   * Checks if we're currently refreshing
+   * @returns {boolean} refresh status
+   */
+  _isRefreshing () {
+    return this._refreshing.isPending()
+  }
+  /**
+   * Does the actual work of refreshing
+   * @returns {Promise} a promise that's resolved when refreshing completes
+   */
+  _refresh () {
+    var self = this
+    var buckets = this.buckets
+    var matchedFiles = new Set()
+
+    var promise = Promise.map(this._patterns, function (patternObject) {
+      var pattern = patternObject.pattern
+
+      if (helper.isUrlAbsolute(pattern)) {
+        buckets.set(pattern, new Set([new Url(pattern)]))
+        return Promise.resolve()
+      }
+
+      var mg = new Glob(pathLib.normalize(pattern), GLOB_OPTS)
+      var files = mg.found
+      buckets.set(pattern, new Set())
 
       if (_.isEmpty(files)) {
-        log.warn('All files matched by "%s" were excluded or matched by prior matchers.', pattern)
-      } else {
-        buckets.set(pattern, new Set(files))
+        log.warn('Pattern "%s" does not match any file.', pattern)
+        return
       }
+
+      return Promise.map(files, function (path) {
+        if (self._isExcluded(path)) {
+          log.debug('Excluded file "%s"', path)
+          return Promise.resolve()
+        }
+
+        if (matchedFiles.has(path)) {
+          return Promise.resolve()
+        }
+
+        matchedFiles.add(path)
+
+        var mtime = mg.statCache[path].mtime
+        var doNotCache = patternObject.nocache
+        var type = patternObject.type
+        var file = new File(path, mtime, doNotCache, type)
+
+        if (file.doNotCache) {
+          log.debug('Not preprocessing "%s" due to nocache')
+          return Promise.resolve(file)
+        }
+
+        return self._preprocess(file).then(function () {
+          return file
+        })
+      }).then(function (files) {
+        files = _.compact(files)
+
+        if (_.isEmpty(files)) {
+          log.warn('All files matched by "%s" were excluded or matched by prior matchers.', pattern)
+        } else {
+          buckets.set(pattern, new Set(files))
+        }
+      })
+    }).then(function () {
+      if (self._refreshing !== promise) {
+        return self._refreshing
+      }
+      self.buckets = buckets
+      self._emitModified(true)
+      return self.files
     })
-  })
-  .then(function () {
-    if (self._refreshing !== promise) {
-      return self._refreshing
-    }
-    self.buckets = buckets
-    self._emitModified(true)
-    return self.files
-  })
 
-  return promise
-}
-
-// Public Interface
-// ----------------
-
-Object.defineProperty(List.prototype, 'files', {
-  get: function () {
+    return promise
+  }
+  // Public Interface
+  // ----------------
+  get files () {
     var self = this
     var uniqueFlat = function (list) {
       return _.uniq(_.flatten(list), 'path')
@@ -231,8 +227,7 @@ Object.defineProperty(List.prototype, 'files', {
 
     var served = this._patterns.filter(function (pattern) {
       return pattern.served
-    })
-    .map(expandPattern)
+    }).map(expandPattern)
 
     var lookup = {}
     var included = {}
@@ -262,143 +257,127 @@ Object.defineProperty(List.prototype, 'files', {
       included: _.values(included)
     }
   }
-})
-
-// Reglob all patterns to update the list.
-//
-// Returns a promise that is resolved when the refresh
-// is completed.
-List.prototype.refresh = function () {
-  this._refreshing = this._refresh()
-  return this._refreshing
-}
-
-// Set new patterns and excludes and update
-// the list accordingly
-//
-// patterns - Array, the new patterns.
-// excludes - Array, the new exclude patterns.
-//
-// Returns a promise that is resolved when the refresh
-// is completed.
-List.prototype.reload = function (patterns, excludes) {
-  this._patterns = patterns
-  this._excludes = excludes
-
-  // Wait until the current refresh is done and then do a
-  // refresh to ensure a refresh actually happens
-  return this.refresh()
-}
-
-// Add a new file from the list.
-// This is called by the watcher
-//
-// path - String, the path of the file to update.
-//
-// Returns a promise that is resolved when the update
-// is completed.
-List.prototype.addFile = function (path) {
-  var self = this
-
-  // Ensure we are not adding a file that should be excluded
-  var excluded = this._isExcluded(path)
-  if (excluded) {
-    log.debug('Add file "%s" ignored. Excluded by "%s".', path, excluded)
-
-    return Promise.resolve(this.files)
+  /**
+   * Reglob all patterns to update the list.
+   * @returns {Promise} A promise that is resolved when the refresh is completed.
+   */
+  refresh () {
+    this._refreshing = this._refresh()
+    return this._refreshing
   }
+  /**
+   * Set new patterns and excludes and update the list accordingly.
+   * @param {Array<string>} patterns new patterns to include
+   * @param {Array<string>} excludes new patterns to exclude
+   * @returns {Promise} a promise that is resolved when the refresh is completed.
+   */
+  reload (patterns, excludes) {
+    this._patterns = patterns
+    this._excludes = excludes
 
-  var pattern = this._isIncluded(path)
-
-  if (!pattern) {
-    log.debug('Add file "%s" ignored. Does not match any pattern.', path)
-    return Promise.resolve(this.files)
+    // Wait until the current refresh is done and then do a
+    // refresh to ensure a refresh actually happens
+    return this.refresh()
   }
+  /**
+   * Add a new file from the list. This is called by the watcher.
+   * @param {string} path the path of the file to update.
+   * @returns {Promise} a promise that is resolved when the update is completed.
+   */
+  addFile (path) {
+    var self = this
 
-  if (this._exists(path)) {
-    log.debug('Add file "%s" ignored. Already in the list.', path)
-    return Promise.resolve(this.files)
-  }
+    // Ensure we are not adding a file that should be excluded
+    var excluded = this._isExcluded(path)
+    if (excluded) {
+      log.debug('Add file "%s" ignored. Excluded by "%s".', path, excluded)
 
-  var file = new File(path)
-  this.buckets.get(pattern.pattern).add(file)
-
-  return Promise.all([
-    fs.statAsync(path),
-    this._refreshing
-  ]).spread(function (stat) {
-    file.mtime = stat.mtime
-    return self._preprocess(file)
-  })
-  .then(function () {
-    log.info('Added file "%s".', path)
-    self._emitModified()
-    return self.files
-  })
-}
-
-// Update the `mtime` of a file.
-// This is called by the watcher
-//
-// path - String, the path of the file to update.
-//
-// Returns a promise that is resolved when the update
-// is completed.
-List.prototype.changeFile = function (path) {
-  var self = this
-
-  var pattern = this._isIncluded(path)
-  var file = this._findFile(path, pattern)
-
-  if (!pattern || !file) {
-    log.debug('Changed file "%s" ignored. Does not match any file in the list.', path)
-    return Promise.resolve(this.files)
-  }
-
-  return Promise.all([
-    fs.statAsync(path),
-    this._refreshing
-  ]).spread(function (stat) {
-    if (stat.mtime <= file.mtime) throw new Promise.CancellationError()
-
-    file.mtime = stat.mtime
-    return self._preprocess(file)
-  })
-  .then(function () {
-    log.info('Changed file "%s".', path)
-    self._emitModified()
-    return self.files
-  })
-  .catch(Promise.CancellationError, function () {
-    return self.files
-  })
-}
-
-// Remove a file from the list.
-// This is called by the watcher
-//
-// path - String, the path of the file to update.
-//
-// Returns a promise that is resolved when the update
-// is completed.
-List.prototype.removeFile = function (path) {
-  var self = this
-
-  return Promise.try(function () {
-    var pattern = self._isIncluded(path)
-    var file = self._findFile(path, pattern)
-
-    if (!pattern || !file) {
-      log.debug('Removed file "%s" ignored. Does not match any file in the list.', path)
-      return self.files
+      return Promise.resolve(this.files)
     }
 
-    self.buckets.get(pattern.pattern).delete(file)
+    var pattern = this._isIncluded(path)
 
-    log.info('Removed file "%s".', path)
-    self._emitModified()
-    return self.files
-  })
+    if (!pattern) {
+      log.debug('Add file "%s" ignored. Does not match any pattern.', path)
+      return Promise.resolve(this.files)
+    }
+
+    if (this._exists(path)) {
+      log.debug('Add file "%s" ignored. Already in the list.', path)
+      return Promise.resolve(this.files)
+    }
+
+    var file = new File(path)
+    this.buckets.get(pattern.pattern).add(file)
+
+    return Promise.all([
+      fs.statAsync(path),
+      this._refreshing
+    ]).spread(function (stat) {
+      file.mtime = stat.mtime
+      return self._preprocess(file)
+    }).then(function () {
+      log.info('Added file "%s".', path)
+      self._emitModified()
+      return self.files
+    })
+  }
+  /**
+   * Update the `mtime` of a file. This is called by the watcher.
+   * @param {string} path the path of the file to update.
+   * @returns {Promise} a promise that is resolved when the update is completed.
+   */
+  changeFile (path) {
+    var self = this
+
+    var pattern = this._isIncluded(path)
+    var file = this._findFile(path, pattern)
+
+    if (!pattern || !file) {
+      log.debug('Changed file "%s" ignored. Does not match any file in the list.', path)
+      return Promise.resolve(this.files)
+    }
+
+    return Promise.all([
+      fs.statAsync(path),
+      this._refreshing
+    ]).spread(function (stat) {
+      if (stat.mtime <= file.mtime) throw new Promise.CancellationError()
+
+      file.mtime = stat.mtime
+      return self._preprocess(file)
+    }).then(function () {
+      log.info('Changed file "%s".', path)
+      self._emitModified()
+      return self.files
+    }).catch(Promise.CancellationError, function () {
+      return self.files
+    })
+  }
+  /**
+   * Remove a file from the list. This is called by the watcher.
+   * @param {string} path the path of the file to update.
+   * @returns {Promise} a promise that is resolved when the update is completed.
+   */
+  removeFile (path) {
+    var self = this
+
+    return Promise.try(function () {
+      var pattern = self._isIncluded(path)
+      var file = self._findFile(path, pattern)
+
+      if (!pattern || !file) {
+        log.debug('Removed file "%s" ignored. Does not match any file in the list.', path)
+        return self.files
+      }
+
+      self.buckets.get(pattern.pattern).delete(file)
+
+      log.info('Removed file "%s".', path)
+      self._emitModified()
+      return self.files
+    })
+  }
 }
 
 // Inject dependencies

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -72,16 +72,14 @@ class FileList {
     // resolved or rejected.
     this._refreshing = Promise.resolve()
 
-    var self = this
-
     // Emit the `file_list_modified` event.
     // This function is debounced to the value of `autoWatchBatchDelay`
     // to avoid reloading while files are still being modified.
-    function emit () {
-      self._emitter.emit('file_list_modified', self.files)
+    var emit = () => {
+      this._emitter.emit('file_list_modified', this.files)
     }
-    var debouncedEmit = _.debounce(emit, self._autoWatchBatchDelay)
-    self._emitModified = function (immediate) {
+    var debouncedEmit = _.debounce(emit, this._autoWatchBatchDelay)
+    this._emitModified = function (immediate) {
       immediate ? emit() : debouncedEmit()
     }
   }
@@ -127,14 +125,12 @@ class FileList {
    * @returns {boolean} Whether or not the file is present in the list
    */
   _exists (path) {
-    var self = this
-
     var patterns = this._patterns.filter(function (pattern) {
       return mm(path, pattern.pattern)
     })
 
-    return !!_.find(patterns, function (pattern) {
-      return self._findFile(path, pattern)
+    return !!_.find(patterns, (pattern) => {
+      return this._findFile(path, pattern)
     })
   }
   /**
@@ -149,11 +145,10 @@ class FileList {
    * @returns {Promise} a promise that's resolved when refreshing completes
    */
   _refresh () {
-    var self = this
     var buckets = this.buckets
     var matchedFiles = new Set()
 
-    var promise = Promise.map(this._patterns, function (patternObject) {
+    var promise = Promise.map(this._patterns, (patternObject) => {
       var pattern = patternObject.pattern
 
       if (helper.isUrlAbsolute(pattern)) {
@@ -170,8 +165,8 @@ class FileList {
         return
       }
 
-      return Promise.map(files, function (path) {
-        if (self._isExcluded(path)) {
+      return Promise.map(files, (path) => {
+        if (this._isExcluded(path)) {
           log.debug('Excluded file "%s"', path)
           return Promise.resolve()
         }
@@ -192,7 +187,7 @@ class FileList {
           return Promise.resolve(file)
         }
 
-        return self._preprocess(file).then(function () {
+        return this._preprocess(file).then(function () {
           return file
         })
       }).then(function (files) {
@@ -204,13 +199,13 @@ class FileList {
           buckets.set(pattern, new Set(files))
         }
       })
-    }).then(function () {
-      if (self._refreshing !== promise) {
-        return self._refreshing
+    }).then(() => {
+      if (this._refreshing !== promise) {
+        return this._refreshing
       }
-      self.buckets = buckets
-      self._emitModified(true)
-      return self.files
+      this.buckets = buckets
+      this._emitModified(true)
+      return this.files
     })
 
     return promise
@@ -218,13 +213,12 @@ class FileList {
   // Public Interface
   // ----------------
   get files () {
-    var self = this
     var uniqueFlat = function (list) {
       return _.uniq(_.flatten(list), 'path')
     }
 
-    var expandPattern = function (p) {
-      return Array.from(self.buckets.get(p.pattern) || []).sort(byPath)
+    var expandPattern = (p) => {
+      return Array.from(this.buckets.get(p.pattern) || []).sort(byPath)
     }
 
     var served = this._patterns.filter(function (pattern) {
@@ -287,8 +281,6 @@ class FileList {
    * @returns {Promise} a promise that is resolved when the update is completed.
    */
   addFile (path) {
-    var self = this
-
     // Ensure we are not adding a file that should be excluded
     var excluded = this._isExcluded(path)
     if (excluded) {
@@ -315,13 +307,13 @@ class FileList {
     return Promise.all([
       fs.statAsync(path),
       this._refreshing
-    ]).spread(function (stat) {
+    ]).spread((stat) => {
       file.mtime = stat.mtime
-      return self._preprocess(file)
-    }).then(function () {
+      return this._preprocess(file)
+    }).then(() => {
       log.info('Added file "%s".', path)
-      self._emitModified()
-      return self.files
+      this._emitModified()
+      return this.files
     })
   }
   /**
@@ -330,8 +322,6 @@ class FileList {
    * @returns {Promise} a promise that is resolved when the update is completed.
    */
   changeFile (path) {
-    var self = this
-
     var pattern = this._isIncluded(path)
     var file = this._findFile(path, pattern)
 
@@ -343,17 +333,17 @@ class FileList {
     return Promise.all([
       fs.statAsync(path),
       this._refreshing
-    ]).spread(function (stat) {
+    ]).spread((stat) => {
       if (stat.mtime <= file.mtime) throw new Promise.CancellationError()
 
       file.mtime = stat.mtime
-      return self._preprocess(file)
-    }).then(function () {
+      return this._preprocess(file)
+    }).then(() => {
       log.info('Changed file "%s".', path)
-      self._emitModified()
-      return self.files
-    }).catch(Promise.CancellationError, function () {
-      return self.files
+      this._emitModified()
+      return this.files
+    }).catch(Promise.CancellationError, () => {
+      return this.files
     })
   }
   /**
@@ -362,22 +352,20 @@ class FileList {
    * @returns {Promise} a promise that is resolved when the update is completed.
    */
   removeFile (path) {
-    var self = this
-
-    return Promise.try(function () {
-      var pattern = self._isIncluded(path)
-      var file = self._findFile(path, pattern)
+    return Promise.try(() => {
+      var pattern = this._isIncluded(path)
+      var file = this._findFile(path, pattern)
 
       if (!pattern || !file) {
         log.debug('Removed file "%s" ignored. Does not match any file in the list.', path)
-        return self.files
+        return this.files
       }
 
-      self.buckets.get(pattern.pattern).delete(file)
+      this.buckets.get(pattern.pattern).delete(file)
 
       log.info('Removed file "%s".', path)
-      self._emitModified()
-      return self.files
+      this._emitModified()
+      return this.files
     })
   }
 }

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -7,6 +7,8 @@
 // Dependencies
 // ------------
 
+'use strict'
+
 var Promise = require('bluebird')
 var mm = require('minimatch')
 var Glob = require('glob').Glob

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -382,6 +382,7 @@ class FileList {
   }
 }
 
+// shim for DI since it stills uses function.apply
 function fileListInjector (patterns, excludes, emitter, preprocess, autoWatchBatchDelay) {
   return new FileList(patterns, excludes, emitter, preprocess, autoWatchBatchDelay)
 }

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -45,7 +45,7 @@ function byPath (a, b) {
 /**
  * An object that tracks all files the Karma instance knows about
  */
-class List {
+class FileList {
   /**
    * @param {Array<string>} patterns The path patterns to match
    * @param {Array<string>} excludes The path patterns to explicitly exclude
@@ -382,9 +382,12 @@ class List {
   }
 }
 
+function fileListInjector (patterns, excludes, emitter, preprocess, autoWatchBatchDelay) {
+  return new FileList(patterns, excludes, emitter, preprocess, autoWatchBatchDelay)
+}
 // Inject dependencies
-List.$inject = ['config.files', 'config.exclude', 'emitter', 'preprocess',
+fileListInjector.$inject = ['config.files', 'config.exclude', 'emitter', 'preprocess',
   'config.autoWatchBatchDelay']
 
 // PUBLIC
-module.exports = List
+module.exports = fileListInjector

--- a/test/unit/browser_collection.spec.js
+++ b/test/unit/browser_collection.spec.js
@@ -198,7 +198,9 @@ describe('BrowserCollection', () => {
 
     it('should compute exitCode', () => {
       var browsers = [new Browser(), new Browser()]
-      browsers.forEach(collection.add)
+      browsers.forEach((browser) => {
+        collection.add(browser)
+      })
 
       browsers[0].lastResult.success = 2
       var results = collection.getResults()
@@ -250,7 +252,9 @@ describe('BrowserCollection', () => {
   describe('clone', () => {
     it('should create a shallow copy of the collection', () => {
       var browsers = [new Browser(), new Browser(), new Browser()]
-      browsers.forEach(collection.add)
+      browsers.forEach((browser) => {
+        collection.add(browser)
+      })
 
       var clone = collection.clone()
       expect(clone.length).to.equal(3)
@@ -264,7 +268,9 @@ describe('BrowserCollection', () => {
   describe('map', () => {
     it('should have map()', () => {
       var browsers = [new Browser(1), new Browser(2), new Browser(3)]
-      browsers.forEach(collection.add)
+      browsers.forEach((browser) => {
+        collection.add(browser)
+      })
 
       var mappedIds = collection.map((browser) => browser.id)
 
@@ -275,7 +281,9 @@ describe('BrowserCollection', () => {
   describe('forEach', () => {
     it('should have forEach()', () => {
       var browsers = [new Browser(0), new Browser(1), new Browser(2)]
-      browsers.forEach(collection.add)
+      browsers.forEach((browser) => {
+        collection.add(browser)
+      })
 
       collection.forEach(function (browser, index) {
         expect(browser.id).to.equal(index)


### PR DESCRIPTION
As discussed on #2475, moving to proper ES6 classes from pseudo classing via prototypes will make the code more readable and maintainable. I'm opening this pull request so early into the effort to track any CI failures as I go along.