### PR TITLE
fix(middleware): add file type to absolute urls

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -50,8 +50,8 @@ Pattern.prototype.compare = function (other) {
   return helper.mmComparePatternWeights(this.weight, other.weight)
 }
 
-var UrlPattern = function (url) {
-  Pattern.call(this, url, false, true, false, false)
+var UrlPattern = function (url, type) {
+  Pattern.call(this, url, false, true, false, false, type)
 }
 
 var createPatternObject = function (pattern) {
@@ -62,7 +62,7 @@ var createPatternObject = function (pattern) {
   if (helper.isObject(pattern)) {
     if (pattern.pattern && helper.isString(pattern.pattern)) {
       return helper.isUrlAbsolute(pattern.pattern)
-        ? new UrlPattern(pattern.pattern)
+        ? new UrlPattern(pattern.pattern, pattern.type)
         : new Pattern(
           pattern.pattern,
           pattern.served,

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -152,9 +152,10 @@ List.prototype._refresh = function () {
 
   var promise = Promise.map(this._patterns, function (patternObject) {
     var pattern = patternObject.pattern
+    var type = patternObject.type
 
     if (helper.isUrlAbsolute(pattern)) {
-      buckets.set(pattern, new Set([new Url(pattern)]))
+      buckets.set(pattern, new Set([new Url(pattern, type)]))
       return Promise.resolve()
     }
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -3,8 +3,9 @@
 //
 // Url object used for tracking files in `file-list.js`
 
-var Url = function (path) {
+var Url = function (path, type) {
   this.path = path
+  this.type = type
   this.isUrl = true
 }
 

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -215,12 +215,14 @@ describe('middleware.karma', () => {
       new MockFile('/first.css', 'sha007'),
       new MockFile('/second.html', 'sha678'),
       new MockFile('/third', 'sha111', 'css'),
-      new MockFile('/fourth', 'sha222', 'html')
+      new MockFile('/fourth', 'sha222', 'html'),
+      new Url('http://some.url.com/fifth', 'css'),
+      new Url('http://some.url.com/sixth', 'html')
     ])
 
     response.once('end', () => {
       expect(nextSpy).not.to.have.been.called
-      expect(response).to.beServedAs(200, 'CONTEXT\n<link type="text/css" href="/__proxy__/__karma__/absolute/first.css?sha007" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/second.html?sha678" rel="import">\n<link type="text/css" href="/__proxy__/__karma__/absolute/third?sha111" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/fourth?sha222" rel="import">')
+      expect(response).to.beServedAs(200, 'CONTEXT\n<link type="text/css" href="/__proxy__/__karma__/absolute/first.css?sha007" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/second.html?sha678" rel="import">\n<link type="text/css" href="/__proxy__/__karma__/absolute/third?sha111" rel="stylesheet">\n<link href="/__proxy__/__karma__/absolute/fourth?sha222" rel="import">\n<link type="text/css" href="http://some.url.com/fifth" rel="stylesheet">\n<link href="http://some.url.com/sixth" rel="import">')
       done()
     })
 


### PR DESCRIPTION
Currently the file type option does not work with absolute urls, this PR fixes that issue.