### PR TITLE
 refactor(server): compile on first run if browserify files missing.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ tmp
 test
 tasks
 docs
+client
 logo
 integration-tests
 
@@ -14,8 +15,6 @@ Gruntfile.coffee
 credentials
 Karma.sublime-*
 
-static/karma.js
-static/context.js
 static/karma.src.js
 static/karma.wrapper
 test-results.xml

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -10,10 +10,24 @@ module.exports = function (grunt) {
       grunt: ['grunt.js', 'tasks/*.js'],
       scripts: ['scripts/init-dev-env.js']
     },
+    browserify: {
+      client: {
+        files: {
+          'static/karma.js': ['client/main.js'],
+          'static/context.js': ['context/main.js']
+        }
+      }
+    },
     test: {
       unit: 'mochaTest:unit',
       client: 'test/client/karma.conf.js',
       e2e: 'cucumberjs:ci'
+    },
+    watch: {
+      client: {
+        files: '<%= files.client %>',
+        tasks: 'browserify:client'
+      }
     },
     mochaTest: {
       options: {
@@ -71,6 +85,7 @@ module.exports = function (grunt) {
     },
     'npm-publish': {
       options: {
+        requires: ['build'],
         abortIfDirty: true,
         tag: 'latest'
       }
@@ -120,13 +135,15 @@ module.exports = function (grunt) {
   require('load-grunt-tasks')(grunt)
 
   grunt.registerTask('lint', ['eslint'])
-  grunt.registerTask('default', ['lint', 'test'])
+  grunt.registerTask('build', ['browserify:client'])
+  grunt.registerTask('default', ['build', 'lint', 'test'])
   grunt.registerTask('test-appveyor', ['test:unit', 'test:client'])
 
-  grunt.registerTask('release', 'Bump and publish to NPM.', function (type) {
+  grunt.registerTask('release', 'Build, bump and publish to NPM.', function (type) {
     grunt.task.run([
       'npm-contributors',
       'bump:' + (type || 'patch') + ':bump-only',
+      'build',
       'conventionalChangelog',
       'bump-commit',
       'conventionalGithubReleaser',

--- a/lib/server.js
+++ b/lib/server.js
@@ -27,29 +27,6 @@ var Browser = require('./browser')
 var BrowserCollection = require('./browser_collection')
 var EmitterWrapper = require('./emitter_wrapper')
 var processWrapper = new EmitterWrapper(process)
-var browserify = require('browserify')
-
-const karmaJsPath = path.join(__dirname, '/../static/karma.js')
-const contextJsPath = path.join(__dirname, '/../static/context.js')
-
-/**
- * Bundles a static resource using Browserify.
- * @param {string} inPath the path to the file to browserify
- * @param {string} outPath the path to output the bundle to
- * @returns {Promise}
- */
-function bundleResource (inPath, outPath) {
-  return new Promise((resolve, reject) => {
-    var bundler = browserify(inPath)
-    bundler.bundle().pipe(fs.createWriteStream(outPath))
-      .once('finish', () => {
-        resolve()
-      })
-      .once('error', (e) => {
-        reject(e)
-      })
-  })
-}
 
 function createSocketIoServer (webServer, executor, config) {
   var server = new SocketIO(webServer, {
@@ -194,41 +171,23 @@ Server.prototype._start = function (config, launcher, preprocess, fileList,
       self._injector.invoke(watcher.watch)
     }
 
-    var startWebServer = function () {
-      webServer.listen(config.port, config.listenAddress, function () {
-        self.log.info('Karma v%s server started at %s//%s:%s%s', constant.VERSION,
-          config.protocol, config.listenAddress, config.port, config.urlRoot)
+    webServer.listen(config.port, config.listenAddress, function () {
+      self.log.info('Karma v%s server started at %s//%s:%s%s', constant.VERSION,
+        config.protocol, config.listenAddress, config.port, config.urlRoot)
 
-        self.emit('listening', config.port)
-        if (config.browsers && config.browsers.length) {
-          self._injector.invoke(launcher.launch, launcher).forEach(function (browserLauncher) {
-            singleRunDoneBrowsers[browserLauncher.id] = false
-          })
-        }
-        var noLoadErrors = self.loadErrors.length
-        if (noLoadErrors > 0) {
-          self.log.error('Found %d load error%s', noLoadErrors, noLoadErrors === 1 ? '' : 's')
-          process.exitCode = 1
-          process.kill(process.pid, 'SIGINT')
-        }
-      })
-    }
-
-    // Check if the static files haven't been compiled
-    if (!(fs.existsSync(karmaJsPath) && fs.existsSync(contextJsPath))) {
-      self.log.info('Front-end scripts not present. Compiling...')
-      var mainPromise = bundleResource(path.join(__dirname, '/../client/main.js'), karmaJsPath)
-      var contextPromise = bundleResource(path.join(__dirname, '/../context/main.js'), contextJsPath)
-      Promise.all([mainPromise, contextPromise]).then(() => {
-        startWebServer()
-      }).catch((error) => {
-        self.log.error('Front-end script compile failed with error: ' + error)
+      self.emit('listening', config.port)
+      if (config.browsers && config.browsers.length) {
+        self._injector.invoke(launcher.launch, launcher).forEach(function (browserLauncher) {
+          singleRunDoneBrowsers[browserLauncher.id] = false
+        })
+      }
+      var noLoadErrors = self.loadErrors.length
+      if (noLoadErrors > 0) {
+        self.log.error('Found %d load error%s', noLoadErrors, noLoadErrors === 1 ? '' : 's')
         process.exitCode = 1
         process.kill(process.pid, 'SIGINT')
-      })
-    } else {
-      startWebServer()
-    }
+      }
+    })
   }
 
   fileList.refresh().then(afterPreprocess, afterPreprocess)

--- a/lib/server.js
+++ b/lib/server.js
@@ -28,6 +28,32 @@ var BrowserCollection = require('./browser_collection')
 var EmitterWrapper = require('./emitter_wrapper')
 var processWrapper = new EmitterWrapper(process)
 
+const karmaJsPath = path.join(__dirname, '/../static/karma.js')
+const contextJsPath = path.join(__dirname, '/../static/context.js')
+
+// Dynamic dependence on brwoserify
+var browserify = null;
+
+/**
+ * Bundles a static resource using Browserify.
+ * @param {string} inPath the path to the file to browserify
+ * @param {string} outPath the path to output the bundle to
+ * @returns {Promise}
+ */
+function bundleResource (inPath, outPath) {
+  return new Promise((resolve, reject) => {
+    browserify = browserify || require('browserify')
+    var bundler = browserify(inPath)
+    bundler.bundle().pipe(fs.createWriteStream(outPath))
+      .once('finish', () => {
+        resolve()
+      })
+      .once('error', (e) => {
+        reject(e)
+      })
+  })
+}
+
 function createSocketIoServer (webServer, executor, config) {
   var server = new SocketIO(webServer, {
     // avoid destroying http upgrades from socket.io to get proxied websockets working
@@ -171,23 +197,41 @@ Server.prototype._start = function (config, launcher, preprocess, fileList,
       self._injector.invoke(watcher.watch)
     }
 
-    webServer.listen(config.port, config.listenAddress, function () {
-      self.log.info('Karma v%s server started at %s//%s:%s%s', constant.VERSION,
-        config.protocol, config.listenAddress, config.port, config.urlRoot)
+    var startWebServer = function () {
+      webServer.listen(config.port, config.listenAddress, function () {
+        self.log.info('Karma v%s server started at %s//%s:%s%s', constant.VERSION,
+          config.protocol, config.listenAddress, config.port, config.urlRoot)
 
-      self.emit('listening', config.port)
-      if (config.browsers && config.browsers.length) {
-        self._injector.invoke(launcher.launch, launcher).forEach(function (browserLauncher) {
-          singleRunDoneBrowsers[browserLauncher.id] = false
-        })
-      }
-      var noLoadErrors = self.loadErrors.length
-      if (noLoadErrors > 0) {
-        self.log.error('Found %d load error%s', noLoadErrors, noLoadErrors === 1 ? '' : 's')
+        self.emit('listening', config.port)
+        if (config.browsers && config.browsers.length) {
+          self._injector.invoke(launcher.launch, launcher).forEach(function (browserLauncher) {
+            singleRunDoneBrowsers[browserLauncher.id] = false
+          })
+        }
+        var noLoadErrors = self.loadErrors.length
+        if (noLoadErrors > 0) {
+          self.log.error('Found %d load error%s', noLoadErrors, noLoadErrors === 1 ? '' : 's')
+          process.exitCode = 1
+          process.kill(process.pid, 'SIGINT')
+        }
+      })
+    }
+
+    // Check if the static files haven't been compiled
+    if (!(fs.existsSync(karmaJsPath) && fs.existsSync(contextJsPath))) {
+      self.log.info('Front-end scripts not present. Compiling...')
+      var mainPromise = bundleResource(path.join(__dirname, '/../client/main.js'), karmaJsPath)
+      var contextPromise = bundleResource(path.join(__dirname, '/../context/main.js'), contextJsPath)
+      Promise.all([mainPromise, contextPromise]).then(() => {
+        startWebServer()
+      }).catch((error) => {
+        self.log.error('Front-end script compile failed with error: ' + error)
         process.exitCode = 1
         process.kill(process.pid, 'SIGINT')
-      }
-    })
+      })
+    } else {
+      startWebServer()
+    }
   }
 
   fileList.refresh().then(afterPreprocess, afterPreprocess)

--- a/package.json
+++ b/package.json
@@ -342,7 +342,6 @@
   "dependencies": {
     "bluebird": "^3.3.0",
     "body-parser": "^1.16.1",
-    "browserify": "^14.5.0",
     "chokidar": "^1.4.1",
     "colors": "^1.1.0",
     "combine-lists": "^1.0.0",
@@ -386,6 +385,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "grunt": "^1.0.0",
     "grunt-auto-release": "^0.0.7",
+    "grunt-browserify": "^5.0.0",
     "grunt-bump": "^0.8.0",
     "grunt-cli": "^1.1.0",
     "grunt-contrib-watch": "^1.0.0",
@@ -447,14 +447,15 @@
   "scripts": {
     "lint": "eslint client/**/*.js common/**/*.js context/**/*.js gruntfile.js wallaby.js lib/**/*.js test/unit/**/*.js test/client/*.js test/e2e/**/*.js static/debug.js",
     "test": "grunt test",
+    "build": "grunt build",
     "test:appveyor": "grunt test-appveyor",
     "test:integration": "./scripts/integration-tests.sh",
     "link": "node --eval \"path=require('path'); require('fs').symlinkSync(path.resolve(__dirname), path.resolve(__dirname, 'node_modules', 'karma'), 'junction')\"",
     "unlink": "node --eval \"require('fs').unlinkSync(require('path').resolve(__dirname, 'node_modules', 'karma'))\"",
     "init": "rm -rf node_modules/karma && cd node_modules && ln -nsf ../ karma && cd ../",
     "init:windows": "(IF EXIST node_modules\\karma (rmdir node_modules\\karma /S /q)) && npm run link",
-    "appveyor": "npm run test:appveyor",
-    "travis": "npm test && npm run test:integration",
+    "appveyor": "npm run build && npm run test:appveyor",
+    "travis": "npm run build && npm test && npm run test:integration",
     "commitmsg": "validate-commit-msg",
     "precommit": "npm run lint"
   }

--- a/package.json
+++ b/package.json
@@ -371,6 +371,7 @@
   "devDependencies": {
     "LiveScript": "^1.3.0",
     "babel-core": "^6.26.0",
+    "browserify": "^14.5.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chai-subset": "^1.2.2",

--- a/test/unit/server.spec.js
+++ b/test/unit/server.spec.js
@@ -1,5 +1,7 @@
 var Server = require('../../lib/server')
 var BrowserCollection = require('../../lib/browser_collection')
+var fs = require('fs')
+var path = require('path')
 
 describe('server', () => {
   var mockConfig
@@ -103,6 +105,17 @@ describe('server', () => {
   // server._start()
   // ============================================================================
   describe('_start', () => {
+    it('should compile static resources on first run', function (done) {
+      this.timeout(5000)
+      server._start(mockConfig, mockLauncher, null, mockFileList, browserCollection, mockExecutor, doneSpy)
+      fileListOnResolve()
+
+      setTimeout(() => {
+        expect(fs.existsSync(path.join(__dirname, '/../../static/karma.js')) && fs.existsSync(path.join(__dirname, '/../../static/context.js'))).to.be.true
+        done()
+      }, 4000)
+    })
+
     it('should start the web server after all files have been preprocessed successfully', () => {
       server._start(mockConfig, mockLauncher, null, mockFileList, browserCollection, mockExecutor, doneSpy)
 

--- a/test/unit/server.spec.js
+++ b/test/unit/server.spec.js
@@ -1,7 +1,5 @@
 var Server = require('../../lib/server')
 var BrowserCollection = require('../../lib/browser_collection')
-var fs = require('fs')
-var path = require('path')
 
 describe('server', () => {
   var mockConfig
@@ -105,17 +103,6 @@ describe('server', () => {
   // server._start()
   // ============================================================================
   describe('_start', () => {
-    it('should compile static resources on first run', function (done) {
-      this.timeout(5000)
-      server._start(mockConfig, mockLauncher, null, mockFileList, browserCollection, mockExecutor, doneSpy)
-      fileListOnResolve()
-
-      setTimeout(() => {
-        expect(fs.existsSync(path.join(__dirname, '/../../static/karma.js')) && fs.existsSync(path.join(__dirname, '/../../static/context.js'))).to.be.true
-        done()
-      }, 4000)
-    })
-
     it('should start the web server after all files have been preprocessed successfully', () => {
       server._start(mockConfig, mockLauncher, null, mockFileList, browserCollection, mockExecutor, doneSpy)
 


### PR DESCRIPTION
To support running karma directly out of the repo, 'browserify' is applied dynamically iff the static files are not already available.  The 'browserify' module is loaded only in the case where it will be used: users installing karma from the npm module will not need to apply it and installs using --production will not depend upon 'browserify' or its otherwise unused deps.

This provides an alternative fix for #2884, one that does not require every user to install the browserify deps.

Fixes #2921