### PR TITLE
fix(lib): switch to sync write

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -269,7 +269,7 @@ Server.prototype._start = function (config, launcher, preprocess, fileList,
         return logMap[m]
       })
       self.log.debug('Writing browser console line: %s', logString)
-      fs.write(browserLogFile, logString + '\n')
+      fs.writeSync(browserLogFile, logString + '\n')
     })
   }
 


### PR DESCRIPTION
The async write operation has no callback and errors are not
detected that way. Switch to the sync version to circumvent that
problem.

This will otherwise cause issues from Node.js 10 on. See https://github.com/nodejs/node/pull/18668.