### PR TITLE
Avoid using deprecated Buffer constructor

### DIFF
--- a/lib/middleware/common.js
+++ b/lib/middleware/common.js
@@ -58,7 +58,7 @@ var createServeFile = function (fs, directory, config) {
           return 206
         } else {
           // Multiple ranges are not supported. Maybe future?
-          responseData = new Buffer(0)
+          responseData = Buffer.alloc(0)
           return 416
         }
       }


### PR DESCRIPTION
`safe-buffer` is already used and provides `Buffer.alloc` polyfill, so just use `Buffer.alloc` directly to avoid hitting deprecated API.

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

This was overlooked in 3d94b8cf18c695104ca195334dc75ff054c74eec (#2484).

Tracking: https://github.com/nodejs/node/issues/19079