### PR TITLE
Migrate to ES2015

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,139 +1,115 @@
-var helper = require('./helper')
-var logger = require('./logger')
+'use strict'
 
-var Result = require('./browser_result')
+const Result = require('./browser_result')
+const helper = require('./helper')
+const logger = require('./logger')
 
 // The browser is ready to execute tests.
-var READY = 1
+const READY = 1
 
 // The browser is executing the tests.
-var EXECUTING = 2
+const EXECUTING = 2
 
 // The browser is not executing, but temporarily disconnected (waiting for reconnecting).
-var READY_DISCONNECTED = 3
+const READY_DISCONNECTED = 3
 
 // The browser is executing the tests, but temporarily disconnect (waiting for reconnecting).
-var EXECUTING_DISCONNECTED = 4
+const EXECUTING_DISCONNECTED = 4
 
 // The browser got permanently disconnected (being removed from the collection and destroyed).
-var DISCONNECTED = 5
+const DISCONNECTED = 5
 
-var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter, socket, timer,
-  /* config.browserDisconnectTimeout */ disconnectDelay,
-  /* config.browserNoActivityTimeout */ noActivityTimeout) {
-  var name = helper.browserFullNameToShort(fullName)
-  var log = logger.create(name)
-  var activeSockets = [socket]
-  var activeSocketsIds = function () {
-    return activeSockets.map(function (s) {
-      return s.id
-    }).join(', ')
+class Browser {
+  constructor (id, fullName, collection, emitter, socket, timer, disconnectDelay, noActivityTimeout) {
+    this.id = id
+    this.fullName = fullName
+    this.name = helper.browserFullNameToShort(fullName)
+    this.state = READY
+    this.lastResult = new Result()
+    this.disconnectsCount = 0
+    this.activeSockets = [socket]
+    this.noActivityTimeout = noActivityTimeout
+    this.collection = collection
+    this.emitter = emitter
+    this.socket = socket
+    this.timer = timer
+    this.disconnectDelay = disconnectDelay
+
+    this.log = logger.create(this.name)
+
+    this.noActivityTimeoutId = null
+    this.pendingDisconnect = null
   }
 
-  var self = this
-  var pendingDisconnect
-  var disconnect = function (reason) {
-    self.state = DISCONNECTED
-    self.disconnectsCount++
-    log.warn('Disconnected (%d times)' + (reason || ''), self.disconnectsCount)
-    emitter.emit('browser_error', self, 'Disconnected' + (reason || ''))
-    collection.remove(self)
-  }
+  init () {
+    this.collection.add(this)
 
-  var noActivityTimeoutId
-  var refreshNoActivityTimeout = noActivityTimeout ? function () {
-    clearNoActivityTimeout()
-    noActivityTimeoutId = timer.setTimeout(function () {
-      self.lastResult.totalTimeEnd()
-      self.lastResult.disconnected = true
-      disconnect(', because no message in ' + noActivityTimeout + ' ms.')
-      emitter.emit('browser_complete', self)
-    }, noActivityTimeout)
-  } : function () {}
+    this.bindSocketEvents(this.socket)
 
-  var clearNoActivityTimeout = noActivityTimeout ? function () {
-    if (noActivityTimeoutId) {
-      timer.clearTimeout(noActivityTimeoutId)
-      noActivityTimeoutId = null
-    }
-  } : function () {}
-
-  this.id = id
-  this.fullName = fullName
-  this.name = name
-  this.state = READY
-  this.lastResult = new Result()
-  this.disconnectsCount = 0
-
-  this.init = function () {
-    collection.add(this)
-
-    this.bindSocketEvents(socket)
-
-    log.info('Connected on socket %s with id %s', socket.id, id)
+    this.log.info('Connected on socket %s with id %s', this.socket.id, this.id)
 
     // TODO(vojta): move to collection
-    emitter.emit('browsers_change', collection)
+    this.emitter.emit('browsers_change', this.collection)
 
-    emitter.emit('browser_register', this)
+    this.emitter.emit('browser_register', this)
   }
 
-  this.isReady = function () {
+  isReady () {
     return this.state === READY
   }
 
-  this.toString = function () {
+  toString () {
     return this.name
   }
 
-  this.onKarmaError = function (error) {
+  onKarmaError (error) {
     if (this.isReady()) {
       return
     }
 
     this.lastResult.error = true
-    emitter.emit('browser_error', this, error)
+    this.emitter.emit('browser_error', this, error)
 
-    refreshNoActivityTimeout()
+    this.refreshNoActivityTimeout()
   }
 
-  this.onInfo = function (info) {
+  onInfo (info) {
     if (this.isReady()) {
       return
     }
 
     // TODO(vojta): remove
     if (helper.isDefined(info.dump)) {
-      emitter.emit('browser_log', this, info.dump, 'dump')
+      this.emitter.emit('browser_log', this, info.dump, 'dump')
     }
 
     if (helper.isDefined(info.log)) {
-      emitter.emit('browser_log', this, info.log, info.type)
+      this.emitter.emit('browser_log', this, info.log, info.type)
     }
 
     if (
       !helper.isDefined(info.log) &&
       !helper.isDefined(info.dump)
     ) {
-      emitter.emit('browser_info', this, info)
+      this.emitter.emit('browser_info', this, info)
     }
 
-    refreshNoActivityTimeout()
+    this.refreshNoActivityTimeout()
   }
 
-  this.onStart = function (info) {
+  onStart (info) {
     this.lastResult = new Result()
     this.lastResult.total = info.total
 
     if (info.total === null) {
-      log.warn('Adapter did not report total number of specs.')
+      this.log.warn('Adapter did not report total number of specs.')
     }
 
-    emitter.emit('browser_start', this, info)
-    refreshNoActivityTimeout()
+    this.emitter.emit('browser_start', this, info)
+    this.refreshNoActivityTimeout()
   }
 
-  this.onComplete = function (result) {
+  onComplete (result) {
     if (this.isReady()) {
       return
     }
@@ -145,70 +121,68 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
       this.lastResult.error = true
     }
 
-    emitter.emit('browsers_change', collection)
-    emitter.emit('browser_complete', this, result)
+    this.emitter.emit('browsers_change', this.collection)
+    this.emitter.emit('browser_complete', this, result)
 
-    clearNoActivityTimeout()
+    this.clearNoActivityTimeout()
   }
 
-  this.onDisconnect = function (disconnectedSocket) {
-    activeSockets.splice(activeSockets.indexOf(disconnectedSocket), 1)
+  onDisconnect (disconnectedSocket) {
+    this.activeSockets.splice(this.activeSockets.indexOf(disconnectedSocket), 1)
 
-    if (activeSockets.length) {
-      log.debug('Disconnected %s, still have %s', disconnectedSocket.id, activeSocketsIds())
+    if (this.activeSockets.length) {
+      this.log.debug('Disconnected %s, still have %s', disconnectedSocket.id, this.getActiveSocketsIds())
       return
     }
 
     if (this.state === READY) {
-      disconnect()
+      this.disconnect()
     } else if (this.state === EXECUTING) {
-      log.debug('Disconnected during run, waiting %sms for reconnecting.', disconnectDelay)
+      this.log.debug('Disconnected during run, waiting %sms for reconnecting.', this.disconnectDelay)
       this.state = EXECUTING_DISCONNECTED
 
-      pendingDisconnect = timer.setTimeout(function () {
-        self.lastResult.totalTimeEnd()
-        self.lastResult.disconnected = true
-        disconnect()
-        emitter.emit('browser_complete', self)
-      }, disconnectDelay)
+      this.pendingDisconnect = this.timer.setTimeout(() => {
+        this.lastResult.totalTimeEnd()
+        this.lastResult.disconnected = true
+        this.disconnect()
+        this.emitter.emit('browser_complete', this)
+      }, this.disconnectDelay)
 
-      clearNoActivityTimeout()
+      this.clearNoActivityTimeout()
     }
   }
 
-  this.reconnect = function (newSocket) {
+  reconnect (newSocket) {
     if (this.state === EXECUTING_DISCONNECTED) {
       this.state = EXECUTING
-      log.debug('Reconnected on %s.', newSocket.id)
+      this.log.debug('Reconnected on %s.', newSocket.id)
     } else if (this.state === EXECUTING || this.state === READY) {
-      log.debug('New connection %s (already have %s)', newSocket.id, activeSocketsIds())
+      this.log.debug('New connection %s (already have %s)', newSocket.id, this.getActiveSocketsIds())
     } else if (this.state === DISCONNECTED) {
       this.state = READY
-      log.info('Connected on socket %s with id %s', newSocket.id, this.id)
-      collection.add(this)
+      this.log.info('Connected on socket %s with id %s', newSocket.id, this.id)
+      this.collection.add(this)
 
       // TODO(vojta): move to collection
-      emitter.emit('browsers_change', collection)
+      this.emitter.emit('browsers_change', this.collection)
 
-      emitter.emit('browser_register', this)
+      this.emitter.emit('browser_register', this)
     }
 
-    var exists = activeSockets.some(function (s) {
-      return s.id === newSocket.id
-    })
+    const exists = this.activeSockets.some((s) => s.id === newSocket.id)
     if (!exists) {
-      activeSockets.push(newSocket)
+      this.activeSockets.push(newSocket)
       this.bindSocketEvents(newSocket)
     }
 
-    if (pendingDisconnect) {
-      timer.clearTimeout(pendingDisconnect)
+    if (this.pendingDisconnect) {
+      this.timer.clearTimeout(this.pendingDisconnect)
     }
 
-    refreshNoActivityTimeout()
+    this.refreshNoActivityTimeout()
   }
 
-  this.onResult = function (result) {
+  onResult (result) {
     if (result.length) {
       return result.forEach(this.onResult, this)
     }
@@ -220,11 +194,11 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
 
     this.lastResult.add(result)
 
-    emitter.emit('spec_complete', this, result)
-    refreshNoActivityTimeout()
+    this.emitter.emit('spec_complete', this, result)
+    this.refreshNoActivityTimeout()
   }
 
-  this.serialize = function () {
+  serialize () {
     return {
       id: this.id,
       name: this.name,
@@ -232,24 +206,64 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
     }
   }
 
-  this.execute = function (config) {
-    activeSockets.forEach(function (socket) {
-      socket.emit('execute', config)
-    })
+  execute (config) {
+    this.activeSockets.forEach((socket) => socket.emit('execute', config))
 
     this.state = EXECUTING
-    refreshNoActivityTimeout()
+    this.refreshNoActivityTimeout()
   }
 
-  this.bindSocketEvents = function (socket) {
-    // TODO: check which of these events are actually emitted by socket
-    socket.on('disconnect', function () { self.onDisconnect(socket) })
-    socket.on('start', function (info) { self.onStart(info) })
-    socket.on('karma_error', function (error) { self.onKarmaError(error) })
-    socket.on('complete', function (result) { self.onComplete(result) })
-    socket.on('info', function (info) { self.onInfo(info) })
-    socket.on('result', function (result) { self.onResult(result) })
+  getActiveSocketsIds () {
+    return this.activeSockets.map((s) => s.id).join(', ')
   }
+
+  disconnect (reason) {
+    this.state = DISCONNECTED
+    this.disconnectsCount++
+    this.log.warn('Disconnected (%d times)' + (reason || ''), this.disconnectsCount)
+    this.emitter.emit('browser_error', this, 'Disconnected' + (reason || ''))
+    this.collection.remove(this)
+  }
+
+  refreshNoActivityTimeout () {
+    if (this.noActivityTimeout) {
+      this.clearNoActivityTimeout()
+
+      this.noActivityTimeoutId = this.timer.setTimeout(() => {
+        this.lastResult.totalTimeEnd()
+        this.lastResult.disconnected = true
+        this.disconnect(', because no message in ' + this.noActivityTimeout + ' ms.')
+        this.emitter.emit('browser_complete', this)
+      }, this.noActivityTimeout)
+    }
+  }
+
+  clearNoActivityTimeout () {
+    if (this.noActivityTimeout) {
+      if (this.noActivityTimeoutId) {
+        this.timer.clearTimeout(this.noActivityTimeoutId)
+        this.noActivityTimeoutId = null
+      }
+    }
+  }
+
+  bindSocketEvents (socket) {
+    // TODO: check which of these events are actually emitted by socket
+    socket.on('disconnect', () => this.onDisconnect(socket))
+    socket.on('start', (info) => this.onStart(info))
+    socket.on('karma_error', (error) => this.onKarmaError(error))
+    socket.on('complete', (result) => this.onComplete(result))
+    socket.on('info', (info) => this.onInfo(info))
+    socket.on('result', (result) => this.onResult(result))
+  }
+}
+
+Browser.factory = function (
+  id, fullName, /* capturedBrowsers */ collection, emitter, socket, timer,
+  /* config.browserDisconnectTimeout */ disconnectDelay,
+  /* config.browserNoActivityTimeout */ noActivityTimeout
+) {
+  return new Browser(id, fullName, collection, emitter, socket, timer, disconnectDelay, noActivityTimeout)
 }
 
 Browser.STATE_READY = READY

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,5 +1,4 @@
 var helper = require('./helper')
-var events = require('./events')
 var logger = require('./logger')
 
 var Result = require('./browser_result')
@@ -69,7 +68,7 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
   this.init = function () {
     collection.add(this)
 
-    events.bindAll(this, socket)
+    this.bindSocketEvents(socket)
 
     log.info('Connected on socket %s with id %s', socket.id, id)
 
@@ -152,7 +151,7 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
     clearNoActivityTimeout()
   }
 
-  this.onDisconnect = function (_, disconnectedSocket) {
+  this.onDisconnect = function (disconnectedSocket) {
     activeSockets.splice(activeSockets.indexOf(disconnectedSocket), 1)
 
     if (activeSockets.length) {
@@ -199,7 +198,7 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
     })
     if (!exists) {
       activeSockets.push(newSocket)
-      events.bindAll(this, newSocket)
+      this.bindSocketEvents(newSocket)
     }
 
     if (pendingDisconnect) {
@@ -240,6 +239,16 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
 
     this.state = EXECUTING
     refreshNoActivityTimeout()
+  }
+
+  this.bindSocketEvents = function (socket) {
+    // TODO: check which of these events are actually emitted by socket
+    socket.on('disconnect', function () { self.onDisconnect(socket) })
+    socket.on('start', function (info) { self.onStart(info) })
+    socket.on('karma_error', function (error) { self.onKarmaError(error) })
+    socket.on('complete', function (result) { self.onComplete(result) })
+    socket.on('info', function (info) { self.onInfo(info) })
+    socket.on('result', function (result) { self.onResult(result) })
   }
 }
 

--- a/lib/browser_collection.js
+++ b/lib/browser_collection.js
@@ -1,49 +1,48 @@
-var EXECUTING = require('./browser').STATE_EXECUTING
-var Result = require('./browser_result')
+'use strict'
 
-var Collection = function (emitter, browsers) {
-  browsers = browsers || []
+const EXECUTING = require('./browser').STATE_EXECUTING
+const Result = require('./browser_result')
 
-  this.add = function (browser) {
-    browsers.push(browser)
-    emitter.emit('browsers_change', this)
+class BrowserCollection {
+  constructor (emitter, browsers) {
+    this.browsers = browsers || []
+    this.emitter = emitter
   }
 
-  this.remove = function (browser) {
-    var index = browsers.indexOf(browser)
+  add (browser) {
+    this.browsers.push(browser)
+    this.emitter.emit('browsers_change', this)
+  }
+
+  remove (browser) {
+    const index = this.browsers.indexOf(browser)
 
     if (index === -1) {
       return false
     }
 
-    browsers.splice(index, 1)
-    emitter.emit('browsers_change', this)
+    this.browsers.splice(index, 1)
+    this.emitter.emit('browsers_change', this)
 
     return true
   }
 
-  this.getById = function (browserId) {
-    for (var i = 0; i < browsers.length; i++) {
-      if (browsers[i].id === browserId) {
-        return browsers[i]
-      }
-    }
-
-    return null
+  getById (browserId) {
+    return this.browsers.find((browser) => browser.id === browserId) || null
   }
 
-  this.setAllToExecuting = function () {
-    browsers.forEach(function (browser) {
+  setAllToExecuting () {
+    this.browsers.forEach((browser) => {
       browser.state = EXECUTING
     })
 
-    emitter.emit('browsers_change', this)
+    this.emitter.emit('browsers_change', this)
   }
 
-  this.areAllReady = function (nonReadyList) {
+  areAllReady (nonReadyList) {
     nonReadyList = nonReadyList || []
 
-    browsers.forEach(function (browser) {
+    this.browsers.forEach((browser) => {
       if (!browser.isReady()) {
         nonReadyList.push(browser)
       }
@@ -52,14 +51,12 @@ var Collection = function (emitter, browsers) {
     return nonReadyList.length === 0
   }
 
-  this.serialize = function () {
-    return browsers.map(function (browser) {
-      return browser.serialize()
-    })
+  serialize () {
+    return this.browsers.map((browser) => browser.serialize())
   }
 
-  this.getResults = function () {
-    var results = browsers.reduce(function (previous, current) {
+  getResults () {
+    const results = this.browsers.reduce((previous, current) => {
       previous.success += current.lastResult.success
       previous.failed += current.lastResult.failed
       previous.error = previous.error || current.lastResult.error
@@ -74,32 +71,32 @@ var Collection = function (emitter, browsers) {
   }
 
   // TODO(vojta): can we remove this? (we clear the results per browser in onBrowserStart)
-  this.clearResults = function () {
-    browsers.forEach(function (browser) {
+  clearResults () {
+    this.browsers.forEach((browser) => {
       browser.lastResult = new Result()
     })
   }
 
-  this.clone = function () {
-    return new Collection(emitter, browsers.slice())
+  clone () {
+    return new BrowserCollection(this.emitter, this.browsers.slice())
   }
 
   // Array APIs
-  this.map = function (callback, context) {
-    return browsers.map(callback, context)
+  map (callback, context) {
+    return this.browsers.map(callback, context)
   }
 
-  this.forEach = function (callback, context) {
-    return browsers.forEach(callback, context)
+  forEach (callback, context) {
+    return this.browsers.forEach(callback, context)
   }
 
-  // this.length
-  Object.defineProperty(this, 'length', {
-    get: function () {
-      return browsers.length
-    }
-  })
+  get length () {
+    return this.browsers.length
+  }
 }
-Collection.$inject = ['emitter']
 
-module.exports = Collection
+BrowserCollection.factory = function (emitter) {
+  return new BrowserCollection(emitter)
+}
+
+module.exports = BrowserCollection

--- a/lib/browser_result.js
+++ b/lib/browser_result.js
@@ -1,15 +1,19 @@
-var Result = function () {
-  var startTime = Date.now()
+'use strict'
 
-  this.total = this.skipped = this.failed = this.success = 0
-  this.netTime = this.totalTime = 0
-  this.disconnected = this.error = false
+class BrowserResult {
+  constructor () {
+    this.startTime = Date.now()
 
-  this.totalTimeEnd = function () {
-    this.totalTime = Date.now() - startTime
+    this.total = this.skipped = this.failed = this.success = 0
+    this.netTime = this.totalTime = 0
+    this.disconnected = this.error = false
   }
 
-  this.add = function (result) {
+  totalTimeEnd () {
+    this.totalTime = Date.now() - this.startTime
+  }
+
+  add (result) {
     if (result.skipped) {
       this.skipped++
     } else if (result.success) {
@@ -22,4 +26,4 @@ var Result = function () {
   }
 }
 
-module.exports = Result
+module.exports = BrowserResult

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,12 +1,14 @@
-var path = require('path')
-var optimist = require('optimist')
-var fs = require('graceful-fs')
+'use strict'
 
-var Server = require('./server')
-var helper = require('./helper')
-var constant = require('./constants')
+const path = require('path')
+const optimist = require('optimist')
+const fs = require('graceful-fs')
 
-var processArgs = function (argv, options, fs, path) {
+const Server = require('./server')
+const helper = require('./helper')
+const constant = require('./constants')
+
+function processArgs (argv, options, fs, path) {
   if (argv.help) {
     console.log(optimist.help())
     process.exit(0)
@@ -19,7 +21,7 @@ var processArgs = function (argv, options, fs, path) {
 
   // TODO(vojta): warn/throw when unknown argument (probably mispelled)
   Object.getOwnPropertyNames(argv).forEach(function (name) {
-    var argumentValue = argv[name]
+    let argumentValue = argv[name]
     if (name !== '_' && name !== '$0') {
       if (name.indexOf('_') !== -1) {
         throw new Error('Bad argument: ' + name + ' did you mean ' + name.replace('_', '-'))
@@ -45,8 +47,9 @@ var processArgs = function (argv, options, fs, path) {
   }
 
   if (helper.isString(options.formatError)) {
+    let required
     try {
-      var required = require(options.formatError)
+      required = require(options.formatError)
     } catch (err) {
       console.error('Could not require formatError: ' + options.formatError, err)
     }
@@ -59,7 +62,7 @@ var processArgs = function (argv, options, fs, path) {
   }
 
   if (helper.isString(options.logLevel)) {
-    var logConstant = constant['LOG_' + options.logLevel.toUpperCase()]
+    const logConstant = constant['LOG_' + options.logLevel.toUpperCase()]
     if (helper.isDefined(logConstant)) {
       options.logLevel = logConstant
     } else {
@@ -103,7 +106,7 @@ var processArgs = function (argv, options, fs, path) {
     options.refresh = options.refresh === 'true'
   }
 
-  var configFile = argv._.shift()
+  let configFile = argv._.shift()
 
   if (!configFile) {
     // default config file (if exists)
@@ -127,11 +130,11 @@ var processArgs = function (argv, options, fs, path) {
   return options
 }
 
-var parseClientArgs = function (argv) {
+function parseClientArgs (argv) {
   // extract any args after '--' as clientArgs
-  var clientArgs = []
+  let clientArgs = []
   argv = argv.slice(2)
-  var idx = argv.indexOf('--')
+  const idx = argv.indexOf('--')
   if (idx !== -1) {
     clientArgs = argv.slice(idx + 1)
   }
@@ -139,13 +142,13 @@ var parseClientArgs = function (argv) {
 }
 
 // return only args that occur before `--`
-var argsBeforeDoubleDash = function (argv) {
-  var idx = argv.indexOf('--')
+function argsBeforeDoubleDash (argv) {
+  const idx = argv.indexOf('--')
 
   return idx === -1 ? argv : argv.slice(0, idx)
 }
 
-var describeShared = function () {
+function describeShared () {
   optimist
     .usage('Karma - Spectacular Test Runner for JavaScript.\n\n' +
       'Usage:\n' +
@@ -160,7 +163,7 @@ var describeShared = function () {
     .describe('version', 'Print current version.')
 }
 
-var describeInit = function () {
+function describeInit () {
   optimist
     .usage('Karma - Spectacular Test Runner for JavaScript.\n\n' +
       'INIT - Initialize a config file.\n\n' +
@@ -172,7 +175,7 @@ var describeInit = function () {
     .describe('help', 'Print usage and options.')
 }
 
-var describeStart = function () {
+function describeStart () {
   optimist
     .usage('Karma - Spectacular Test Runner for JavaScript.\n\n' +
       'START - Start the server / do a single run.\n\n' +
@@ -196,7 +199,7 @@ var describeStart = function () {
     .describe('help', 'Print usage and options.')
 }
 
-var describeRun = function () {
+function describeRun () {
   optimist
     .usage('Karma - Spectacular Test Runner for JavaScript.\n\n' +
       'RUN - Run the tests (requires running server).\n\n' +
@@ -212,7 +215,7 @@ var describeRun = function () {
     .describe('no-colors', 'Do not use colors when reporting or printing logs.')
 }
 
-var describeStop = function () {
+function describeStop () {
   optimist
     .usage('Karma - Spectacular Test Runner for JavaScript.\n\n' +
       'STOP - Stop the server (requires running server).\n\n' +
@@ -223,7 +226,7 @@ var describeStop = function () {
     .describe('help', 'Print usage.')
 }
 
-var describeCompletion = function () {
+function describeCompletion () {
   optimist
     .usage('Karma - Spectacular Test Runner for JavaScript.\n\n' +
       'COMPLETION - Bash/ZSH completion for karma.\n\n' +
@@ -233,8 +236,8 @@ var describeCompletion = function () {
 }
 
 exports.process = function () {
-  var argv = optimist.parse(argsBeforeDoubleDash(process.argv.slice(2)))
-  var options = {
+  const argv = optimist.parse(argsBeforeDoubleDash(process.argv.slice(2)))
+  const options = {
     cmd: argv._.shift()
   }
 
@@ -276,7 +279,7 @@ exports.process = function () {
 }
 
 exports.run = function () {
-  var config = exports.process()
+  const config = exports.process()
 
   switch (config.cmd) {
     case 'start':

--- a/lib/completion.js
+++ b/lib/completion.js
@@ -1,7 +1,9 @@
-var CUSTOM = ['']
-var BOOLEAN = false
+'use strict'
 
-var options = {
+const CUSTOM = ['']
+const BOOLEAN = false
+
+const options = {
   start: {
     '--port': CUSTOM,
     '--auto-watch': BOOLEAN,
@@ -30,8 +32,8 @@ var options = {
   }
 }
 
-var parseEnv = function (argv, env) {
-  var words = argv.slice(5)
+function parseEnv (argv, env) {
+  const words = argv.slice(5)
 
   return {
     words: words,
@@ -41,7 +43,7 @@ var parseEnv = function (argv, env) {
   }
 }
 
-var opositeWord = function (word) {
+function opositeWord (word) {
   if (word.charAt(0) !== '-') {
     return null
   }
@@ -49,11 +51,11 @@ var opositeWord = function (word) {
   return word.substr(0, 5) === '--no-' ? '--' + word.substr(5) : '--no-' + word.substr(2)
 }
 
-var sendCompletionNoOptions = function () {}
+function sendCompletionNoOptions () {}
 
-var sendCompletion = function (possibleWords, env) {
-  var regexp = new RegExp('^' + env.last)
-  var filteredWords = possibleWords.filter(function (word) {
+function sendCompletion (possibleWords, env) {
+  const regexp = new RegExp('^' + env.last)
+  const filteredWords = possibleWords.filter(function (word) {
     return regexp.test(word) && env.words.indexOf(word) === -1 &&
       env.words.indexOf(opositeWord(word)) === -1
   })
@@ -67,13 +69,13 @@ var sendCompletion = function (possibleWords, env) {
   })
 }
 
-var glob = require('glob')
-var globOpts = {
+const glob = require('glob')
+const globOpts = {
   mark: true,
   nocase: true
 }
 
-var sendCompletionFiles = function (env) {
+function sendCompletionFiles (env) {
   glob(env.last + '*', globOpts, function (err, files) {
     if (err) return console.error(err)
 
@@ -85,11 +87,11 @@ var sendCompletionFiles = function (env) {
   })
 }
 
-var sendCompletionConfirmLast = function (env) {
+function sendCompletionConfirmLast (env) {
   console.log(env.last)
 }
 
-var complete = function (env) {
+function complete (env) {
   if (env.count === 1) {
     if (env.words[0].charAt(0) === '-') {
       return sendCompletion(['--help', '--version'], env)
@@ -103,8 +105,8 @@ var complete = function (env) {
     return sendCompletionFiles(env)
   }
 
-  var cmdOptions = options[env.words[0]]
-  var previousOption = cmdOptions[env.prev]
+  const cmdOptions = options[env.words[0]]
+  const previousOption = cmdOptions[env.prev]
 
   if (!cmdOptions) {
     // no completion, wrong command
@@ -124,14 +126,14 @@ var complete = function (env) {
   return sendCompletion(Object.keys(cmdOptions), env)
 }
 
-var completion = function () {
+function completion () {
   if (process.argv[3] === '--') {
     return complete(parseEnv(process.argv, process.env))
   }
 
   // just print out the karma-completion.sh
-  var fs = require('graceful-fs')
-  var path = require('path')
+  const fs = require('graceful-fs')
+  const path = require('path')
 
   fs.readFile(path.resolve(__dirname, '../scripts/karma-completion.sh'), 'utf8', function (err, data) {
     if (err) return console.error(err)

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,15 +1,17 @@
-var path = require('path')
+'use strict'
 
-var logger = require('./logger')
-var log = logger.create('config')
-var helper = require('./helper')
-var constant = require('./constants')
+const path = require('path')
 
-var _ = require('lodash')
+const logger = require('./logger')
+const log = logger.create('config')
+const helper = require('./helper')
+const constant = require('./constants')
 
-var COFFEE_SCRIPT_AVAILABLE = false
-var LIVE_SCRIPT_AVAILABLE = false
-var TYPE_SCRIPT_AVAILABLE = false
+const _ = require('lodash')
+
+let COFFEE_SCRIPT_AVAILABLE = false
+let LIVE_SCRIPT_AVAILABLE = false
+let TYPE_SCRIPT_AVAILABLE = false
 
 // Coffee is required here to enable config files written in coffee-script.
 // It's not directly used in this file.
@@ -36,25 +38,29 @@ try {
   TYPE_SCRIPT_AVAILABLE = true
 } catch (e) {}
 
-var Pattern = function (pattern, served, included, watched, nocache, type) {
-  this.pattern = pattern
-  this.served = helper.isDefined(served) ? served : true
-  this.included = helper.isDefined(included) ? included : true
-  this.watched = helper.isDefined(watched) ? watched : true
-  this.nocache = helper.isDefined(nocache) ? nocache : false
-  this.weight = helper.mmPatternWeight(pattern)
-  this.type = type
+class Pattern {
+  constructor (pattern, served, included, watched, nocache, type) {
+    this.pattern = pattern
+    this.served = helper.isDefined(served) ? served : true
+    this.included = helper.isDefined(included) ? included : true
+    this.watched = helper.isDefined(watched) ? watched : true
+    this.nocache = helper.isDefined(nocache) ? nocache : false
+    this.weight = helper.mmPatternWeight(pattern)
+    this.type = type
+  }
+
+  compare (other) {
+    return helper.mmComparePatternWeights(this.weight, other.weight)
+  }
 }
 
-Pattern.prototype.compare = function (other) {
-  return helper.mmComparePatternWeights(this.weight, other.weight)
+class UrlPattern extends Pattern {
+  constructor (url, type) {
+    super(url, false, true, false, false, type)
+  }
 }
 
-var UrlPattern = function (url, type) {
-  Pattern.call(this, url, false, true, false, false, type)
-}
-
-var createPatternObject = function (pattern) {
+function createPatternObject (pattern) {
   if (pattern && helper.isString(pattern)) {
     return helper.isUrlAbsolute(pattern) ? new UrlPattern(pattern) : new Pattern(pattern)
   }
@@ -80,7 +86,7 @@ var createPatternObject = function (pattern) {
   return new Pattern(null, false, false, false, false)
 }
 
-var normalizeUrl = function (url) {
+function normalizeUrl (url) {
   if (url.charAt(0) !== '/') {
     url = '/' + url
   }
@@ -92,8 +98,8 @@ var normalizeUrl = function (url) {
   return url
 }
 
-var normalizeUrlRoot = function (urlRoot) {
-  var normalizedUrlRoot = normalizeUrl(urlRoot)
+function normalizeUrlRoot (urlRoot) {
+  const normalizedUrlRoot = normalizeUrl(urlRoot)
 
   if (normalizedUrlRoot !== urlRoot) {
     log.warn('urlRoot normalized to "%s"', normalizedUrlRoot)
@@ -102,8 +108,8 @@ var normalizeUrlRoot = function (urlRoot) {
   return normalizedUrlRoot
 }
 
-var normalizeProxyPath = function (proxyPath) {
-  var normalizedProxyPath = normalizeUrl(proxyPath)
+function normalizeProxyPath (proxyPath) {
+  const normalizedProxyPath = normalizeUrl(proxyPath)
 
   if (normalizedProxyPath !== proxyPath) {
     log.warn('proxyPath normalized to "%s"', normalizedProxyPath)
@@ -112,8 +118,8 @@ var normalizeProxyPath = function (proxyPath) {
   return normalizedProxyPath
 }
 
-var normalizeConfig = function (config, configFilePath) {
-  var basePathResolve = function (relativePath) {
+function normalizeConfig (config, configFilePath) {
+  function basePathResolve (relativePath) {
     if (helper.isUrlAbsolute(relativePath)) {
       return relativePath
     }
@@ -124,8 +130,8 @@ var normalizeConfig = function (config, configFilePath) {
     return path.resolve(config.basePath, relativePath)
   }
 
-  var createPatternMapper = function (resolve) {
-    return function (objectPattern) {
+  function createPatternMapper (resolve) {
+    return (objectPattern) => {
       objectPattern.pattern = resolve(objectPattern.pattern)
 
       return objectPattern
@@ -161,7 +167,7 @@ var normalizeConfig = function (config, configFilePath) {
 
   // normalize and default upstream proxy settings if given
   if (config.upstreamProxy) {
-    var proxy = config.upstreamProxy
+    const proxy = config.upstreamProxy
     proxy.path = _.isUndefined(proxy.path) ? '/' : normalizeProxyPath(proxy.path)
     proxy.hostname = _.isUndefined(proxy.hostname) ? 'localhost' : proxy.hostname
     proxy.port = _.isUndefined(proxy.port) ? 9875 : proxy.port
@@ -223,33 +229,33 @@ var normalizeConfig = function (config, configFilePath) {
     throw new TypeError('Invalid configuration: processKillTimeout option must be a number.')
   }
 
-  var defaultClient = config.defaultClient || {}
+  const defaultClient = config.defaultClient || {}
   Object.keys(defaultClient).forEach(function (key) {
-    var option = config.client[key]
+    const option = config.client[key]
     config.client[key] = helper.isDefined(option) ? option : defaultClient[key]
   })
 
   // normalize preprocessors
-  var preprocessors = config.preprocessors || {}
-  var normalizedPreprocessors = config.preprocessors = Object.create(null)
+  const preprocessors = config.preprocessors || {}
+  const normalizedPreprocessors = config.preprocessors = Object.create(null)
 
   Object.keys(preprocessors).forEach(function (pattern) {
-    var normalizedPattern = helper.normalizeWinPath(basePathResolve(pattern))
+    const normalizedPattern = helper.normalizeWinPath(basePathResolve(pattern))
 
     normalizedPreprocessors[normalizedPattern] = helper.isString(preprocessors[pattern])
       ? [preprocessors[pattern]] : preprocessors[pattern]
   })
 
   // define custom launchers/preprocessors/reporters - create an inlined plugin
-  var module = Object.create(null)
-  var hasSomeInlinedPlugin = false
-  var types = ['launcher', 'preprocessor', 'reporter']
+  const module = Object.create(null)
+  let hasSomeInlinedPlugin = false
+  const types = ['launcher', 'preprocessor', 'reporter']
 
   types.forEach(function (type) {
-    var definitions = config['custom' + helper.ucFirst(type) + 's'] || {}
+    const definitions = config['custom' + helper.ucFirst(type) + 's'] || {}
 
     Object.keys(definitions).forEach(function (name) {
-      var definition = definitions[name]
+      const definition = definitions[name]
 
       if (!helper.isObject(definition)) {
         return log.warn('Can not define %s %s. Definition has to be an object.', type, name)
@@ -259,13 +265,13 @@ var normalizeConfig = function (config, configFilePath) {
         return log.warn('Can not define %s %s. Missing base %s.', type, name, type)
       }
 
-      var token = type + ':' + definition.base
-      var locals = {
+      const token = type + ':' + definition.base
+      const locals = {
         args: ['value', definition]
       }
 
       module[type + ':' + name] = ['factory', function (injector) {
-        var plugin = injector.createChild([locals], [token]).get(token)
+        const plugin = injector.createChild([locals], [token]).get(token)
         if (type === 'launcher' && helper.isDefined(definition.displayName)) {
           plugin.displayName = definition.displayName
         }
@@ -282,90 +288,89 @@ var normalizeConfig = function (config, configFilePath) {
   return config
 }
 
-var Config = function () {
-  var config = this
+class Config {
+  constructor () {
+    this.LOG_DISABLE = constant.LOG_DISABLE
+    this.LOG_ERROR = constant.LOG_ERROR
+    this.LOG_WARN = constant.LOG_WARN
+    this.LOG_INFO = constant.LOG_INFO
+    this.LOG_DEBUG = constant.LOG_DEBUG
 
-  this.LOG_DISABLE = constant.LOG_DISABLE
-  this.LOG_ERROR = constant.LOG_ERROR
-  this.LOG_WARN = constant.LOG_WARN
-  this.LOG_INFO = constant.LOG_INFO
-  this.LOG_DEBUG = constant.LOG_DEBUG
+    // DEFAULT CONFIG
+    this.frameworks = []
+    this.protocol = 'http:'
+    this.port = constant.DEFAULT_PORT
+    this.listenAddress = constant.DEFAULT_LISTEN_ADDR
+    this.hostname = constant.DEFAULT_HOSTNAME
+    this.httpsServerConfig = {}
+    this.basePath = ''
+    this.files = []
+    this.browserConsoleLogOptions = {
+      level: 'debug',
+      format: '%b %T: %m',
+      terminal: true
+    }
+    this.customContextFile = null
+    this.customDebugFile = null
+    this.customClientContextFile = null
+    this.exclude = []
+    this.logLevel = constant.LOG_INFO
+    this.colors = true
+    this.autoWatch = true
+    this.autoWatchBatchDelay = 250
+    this.restartOnFileChange = false
+    this.usePolling = process.platform === 'linux'
+    this.reporters = ['progress']
+    this.singleRun = false
+    this.browsers = []
+    this.captureTimeout = 60000
+    this.proxies = {}
+    this.proxyValidateSSL = true
+    this.preprocessors = {}
+    this.urlRoot = '/'
+    this.upstreamProxy = undefined
+    this.reportSlowerThan = 0
+    this.loggers = [constant.CONSOLE_APPENDER]
+    this.transports = ['polling', 'websocket']
+    this.forceJSONP = false
+    this.plugins = ['karma-*']
+    this.defaultClient = this.client = {
+      args: [],
+      useIframe: true,
+      runInParent: false,
+      captureConsole: true,
+      clearContext: true
+    }
+    this.browserDisconnectTimeout = 2000
+    this.browserDisconnectTolerance = 0
+    this.browserNoActivityTimeout = 10000
+    this.processKillTimeout = 2000
+    this.concurrency = Infinity
+    this.failOnEmptyTestSuite = true
+    this.retryLimit = 2
+    this.detached = false
+    this.crossOriginAttribute = true
+  }
 
-  this.set = function (newConfig) {
-    _.mergeWith(config, newConfig, function (obj, src) {
+  set (newConfig) {
+    _.mergeWith(this, newConfig, (obj, src) => {
       // Overwrite arrays to keep consistent with #283
       if (_.isArray(src)) {
         return src
       }
     })
   }
-
-  // DEFAULT CONFIG
-  this.frameworks = []
-  this.protocol = 'http:'
-  this.port = constant.DEFAULT_PORT
-  this.listenAddress = constant.DEFAULT_LISTEN_ADDR
-  this.hostname = constant.DEFAULT_HOSTNAME
-  this.httpsServerConfig = {}
-  this.basePath = ''
-  this.files = []
-  this.browserConsoleLogOptions = {
-    level: 'debug',
-    format: '%b %T: %m',
-    terminal: true
-  }
-  this.customContextFile = null
-  this.customDebugFile = null
-  this.customClientContextFile = null
-  this.exclude = []
-  this.logLevel = constant.LOG_INFO
-  this.colors = true
-  this.autoWatch = true
-  this.autoWatchBatchDelay = 250
-  this.restartOnFileChange = false
-  this.usePolling = process.platform === 'linux'
-  this.reporters = ['progress']
-  this.singleRun = false
-  this.browsers = []
-  this.captureTimeout = 60000
-  this.proxies = {}
-  this.proxyValidateSSL = true
-  this.preprocessors = {}
-  this.urlRoot = '/'
-  this.upstreamProxy = undefined
-  this.reportSlowerThan = 0
-  this.loggers = [constant.CONSOLE_APPENDER]
-  this.transports = ['polling', 'websocket']
-  this.forceJSONP = false
-  this.plugins = ['karma-*']
-  this.defaultClient = this.client = {
-    args: [],
-    useIframe: true,
-    runInParent: false,
-    captureConsole: true,
-    clearContext: true
-  }
-  this.browserDisconnectTimeout = 2000
-  this.browserDisconnectTolerance = 0
-  this.browserNoActivityTimeout = 10000
-  this.processKillTimeout = 2000
-  this.concurrency = Infinity
-  this.failOnEmptyTestSuite = true
-  this.retryLimit = 2
-  this.detached = false
-  this.crossOriginAttribute = true
 }
 
-var CONFIG_SYNTAX_HELP = '  module.exports = function(config) {\n' +
+const CONFIG_SYNTAX_HELP = '  module.exports = function(config) {\n' +
   '    config.set({\n' +
   '      // your config\n' +
   '    });\n' +
   '  };\n'
 
-var parseConfig = function (configFilePath, cliOptions) {
-  var configModule
+function parseConfig (configFilePath, cliOptions) {
+  let configModule
   if (configFilePath) {
-
     try {
       configModule = require(configFilePath)
       if (typeof configModule === 'object' && typeof configModule.default !== 'undefined') {
@@ -377,7 +382,7 @@ var parseConfig = function (configFilePath, cliOptions) {
       } else {
         log.error('Invalid config file!\n  ' + e.stack)
 
-        var extension = path.extname(configFilePath)
+        const extension = path.extname(configFilePath)
         if (extension === '.coffee' && !COFFEE_SCRIPT_AVAILABLE) {
           log.error('You need to install CoffeeScript.\n' +
             '  npm install coffee-script --save-dev')
@@ -397,16 +402,16 @@ var parseConfig = function (configFilePath, cliOptions) {
     }
   } else {
     // if no config file path is passed, we define a dummy config module.
-    configModule = function () {}
+    configModule = () => {}
   }
 
-  var config = new Config()
+  const config = new Config()
 
   // save and reset hostname and listenAddress so we can detect if the user
   // changed them
-  var defaultHostname = config.hostname
+  const defaultHostname = config.hostname
   config.hostname = null
-  var defaultListenAddress = config.listenAddress
+  const defaultListenAddress = config.listenAddress
   config.listenAddress = null
 
   // add the user's configuration in

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,7 +1,9 @@
-var fs = require('graceful-fs')
-var path = require('path')
+'use strict'
 
-var pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '/../package.json')).toString())
+const fs = require('graceful-fs')
+const path = require('path')
+
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '/../package.json')).toString())
 
 exports.VERSION = pkg.version
 

--- a/lib/detached.js
+++ b/lib/detached.js
@@ -1,9 +1,11 @@
-var fs = require('fs')
+'use strict'
 
-var Server = require('./server')
-var configurationFile = process.argv[2]
-var fileContents = fs.readFileSync(configurationFile, 'utf-8')
+const fs = require('fs')
+
+const Server = require('./server')
+const configurationFile = process.argv[2]
+const fileContents = fs.readFileSync(configurationFile, 'utf-8')
 fs.unlink(configurationFile, function () {})
-var data = JSON.parse(fileContents)
-var server = new Server(data)
+const data = JSON.parse(fileContents)
+const server = new Server(data)
 server.start(data)

--- a/lib/emitter_wrapper.js
+++ b/lib/emitter_wrapper.js
@@ -1,31 +1,38 @@
-function EmitterWrapper (emitter) {
-  this.listeners = {}
-  this.emitter = emitter
-}
+'use strict'
 
-EmitterWrapper.prototype.addListener = EmitterWrapper.prototype.on = function (event, listener) {
-  this.emitter.addListener(event, listener)
-
-  if (!this.listeners.hasOwnProperty(event)) {
-    this.listeners[event] = []
+class EmitterWrapper {
+  constructor (emitter) {
+    this.listeners = {}
+    this.emitter = emitter
   }
 
-  this.listeners[event].push(listener)
+  addListener (event, listener) {
+    this.emitter.addListener(event, listener)
 
-  return this
-}
+    if (!this.listeners.hasOwnProperty(event)) {
+      this.listeners[event] = []
+    }
 
-EmitterWrapper.prototype.removeAllListeners = function (event) {
-  var events = event ? [event] : Object.keys(this.listeners)
-  var self = this
-  events.forEach(function (event) {
-    self.listeners[event].forEach(function (listener) {
-      self.emitter.removeListener(event, listener)
+    this.listeners[event].push(listener)
+
+    return this
+  }
+
+  on (event, listener) {
+    return this.addListener(event, listener)
+  }
+
+  removeAllListeners (event) {
+    const events = event ? [event] : Object.keys(this.listeners)
+    events.forEach((event) => {
+      this.listeners[event].forEach((listener) => {
+        this.emitter.removeListener(event, listener)
+      })
+      delete this.listeners[event]
     })
-    delete self.listeners[event]
-  })
 
-  return this
+    return this
+  }
 }
 
 module.exports = EmitterWrapper

--- a/lib/server.js
+++ b/lib/server.js
@@ -307,7 +307,7 @@ Server.prototype._start = function (config, launcher, preprocess, fileList,
           id: ['value', info.id || null],
           fullName: ['value', (helper.isDefined(info.displayName) ? info.displayName : info.name)],
           socket: ['value', socket]
-        }]).instantiate(Browser)
+        }]).invoke(Browser.factory)
 
         newBrowser.init()
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -99,7 +99,7 @@ var Server = function (cliOptions, done) {
     // TODO(vojta): remove, once karma-dart does not rely on it
     customScriptTypes: ['value', []],
     reporter: ['factory', reporter.createReporters],
-    capturedBrowsers: ['type', BrowserCollection],
+    capturedBrowsers: ['factory', BrowserCollection.factory],
     args: ['value', {}],
     timer: ['value', {
       setTimeout: function () {

--- a/test/unit/browser.spec.js
+++ b/test/unit/browser.spec.js
@@ -1,17 +1,19 @@
+'use strict'
+
 describe('Browser', () => {
-  var collection
-  var emitter
-  var socket
-  var e = require('../../lib/events')
-  var Browser = require('../../lib/browser')
-  var Collection = require('../../lib/browser_collection')
-  var createMockTimer = require('./mocks/timer')
+  let collection
+  let emitter
+  let socket
+  const e = require('../../lib/events')
+  const Browser = require('../../lib/browser')
+  const Collection = require('../../lib/browser_collection')
+  const createMockTimer = require('./mocks/timer')
 
-  var browser = collection = emitter = socket = null
-  var socketId = 0
+  let browser = collection = emitter = socket = null
+  let socketId = 0
 
-  var mkSocket = () => {
-    var s = new e.EventEmitter()
+  const mkSocket = () => {
+    const s = new e.EventEmitter()
     socketId = socketId + 1
     s.id = socketId
     return s
@@ -24,7 +26,7 @@ describe('Browser', () => {
   })
 
   it('should set fullName and name', () => {
-    var fullName = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/535.7 ' + '(KHTML, like Gecko) Chrome/16.0.912.63 Safari/535.7'
+    const fullName = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/535.7 ' + '(KHTML, like Gecko) Chrome/16.0.912.63 Safari/535.7'
     browser = new Browser('id', fullName, collection, emitter, socket)
     expect(browser.name).to.equal('Chrome 16.0.912 (Mac OS X 10.6.8)')
     expect(browser.fullName).to.equal(fullName)
@@ -32,7 +34,7 @@ describe('Browser', () => {
 
   describe('init', () => {
     it('should emit "browser_register"', () => {
-      var spyRegister = sinon.spy()
+      const spyRegister = sinon.spy()
       emitter.on('browser_register', spyRegister)
       browser = new Browser(12345, '', collection, emitter, socket)
       browser.init()
@@ -54,13 +56,13 @@ describe('Browser', () => {
 
   describe('toString', () => {
     it('should return browser name', () => {
-      var fullName = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/535.7 ' + '(KHTML, like Gecko) Chrome/16.0.912.63 Safari/535.7'
+      const fullName = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/535.7 ' + '(KHTML, like Gecko) Chrome/16.0.912.63 Safari/535.7'
       browser = new Browser('id', fullName, collection, emitter, socket)
       expect(browser.toString()).to.equal('Chrome 16.0.912 (Mac OS X 10.6.8)')
     })
 
     it('should return verbatim user agent string for unrecognized browser', () => {
-      var fullName = 'NonexistentBot/1.2.3'
+      const fullName = 'NonexistentBot/1.2.3'
       browser = new Browser('id', fullName, collection, emitter, socket)
       expect(browser.toString()).to.equal('NonexistentBot/1.2.3')
     })
@@ -72,7 +74,7 @@ describe('Browser', () => {
     })
 
     it('should set lastResult.error and fire "browser_error"', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browser_error', spy)
       browser.state = Browser.STATE_EXECUTING
 
@@ -82,7 +84,7 @@ describe('Browser', () => {
     })
 
     it('should ignore if browser not executing', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browser_error', spy)
       browser.state = Browser.STATE_READY
 
@@ -98,7 +100,7 @@ describe('Browser', () => {
     })
 
     it('should emit "browser_log"', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browser_log', spy)
 
       browser.state = Browser.STATE_EXECUTING
@@ -107,8 +109,8 @@ describe('Browser', () => {
     })
 
     it('should emit "browser_info"', () => {
-      var spy = sinon.spy()
-      var infoData = {}
+      const spy = sinon.spy()
+      const infoData = {}
       emitter.on('browser_info', spy)
 
       browser.state = Browser.STATE_EXECUTING
@@ -117,7 +119,7 @@ describe('Browser', () => {
     })
 
     it('should ignore if browser not executing', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browser_dump', spy)
 
       browser.state = Browser.STATE_READY
@@ -141,7 +143,7 @@ describe('Browser', () => {
     })
 
     it('should emit "browser_start"', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browser_start', spy)
 
       browser.state = Browser.STATE_EXECUTING
@@ -169,7 +171,7 @@ describe('Browser', () => {
     })
 
     it('should fire "browsers_change" event', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browsers_change', spy)
 
       browser.state = Browser.STATE_EXECUTING
@@ -178,7 +180,7 @@ describe('Browser', () => {
     })
 
     it('should ignore if browser not executing', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browsers_change', spy)
       emitter.on('browser_complete', spy)
 
@@ -205,7 +207,7 @@ describe('Browser', () => {
   })
 
   describe('onDisconnect', () => {
-    var timer = null
+    let timer = null
 
     beforeEach(() => {
       timer = createMockTimer()
@@ -221,7 +223,7 @@ describe('Browser', () => {
     })
 
     it('should complete if browser executing', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browser_complete', spy)
       browser.state = Browser.STATE_EXECUTING
 
@@ -233,7 +235,7 @@ describe('Browser', () => {
     })
 
     it('should not complete if browser not executing', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browser_complete', spy)
       browser.state = Browser.STATE_READY
 
@@ -244,7 +246,7 @@ describe('Browser', () => {
 
   describe('reconnect', () => {
     it('should cancel disconnecting', () => {
-      var timer = createMockTimer()
+      const timer = createMockTimer()
 
       browser = new Browser('id', 'Chrome 19.0', collection, emitter, socket, timer, 10)
       browser.init()
@@ -289,15 +291,15 @@ describe('Browser', () => {
   })
 
   describe('onResult', () => {
-    var createSuccessResult = () => {
+    const createSuccessResult = () => {
       return {success: true, suite: [], log: []}
     }
 
-    var createFailedResult = () => {
+    const createFailedResult = () => {
       return {success: false, suite: [], log: []}
     }
 
-    var createSkippedResult = () => {
+    const createSkippedResult = () => {
       return {success: true, skipped: true, suite: [], log: []}
     }
 
@@ -362,8 +364,8 @@ describe('Browser', () => {
 
   describe('execute', () => {
     it('should emit execute and change state to EXECUTING', () => {
-      var spyExecute = sinon.spy()
-      var config = {}
+      const spyExecute = sinon.spy()
+      const config = {}
       browser = new Browser('fake-id', 'full name', collection, emitter, socket)
       socket.on('execute', spyExecute)
       browser.execute(config)
@@ -375,7 +377,7 @@ describe('Browser', () => {
 
   describe('scenario:', () => {
     it('reconnecting during the run', () => {
-      var timer = createMockTimer()
+      const timer = createMockTimer()
       browser = new Browser('fake-id', 'full name', collection, emitter, socket, timer, 10)
       browser.init()
       browser.state = Browser.STATE_EXECUTING
@@ -383,7 +385,7 @@ describe('Browser', () => {
       socket.emit('disconnect', 'socket.io reason')
       expect(browser.isReady()).to.equal(false)
 
-      var newSocket = mkSocket()
+      const newSocket = mkSocket()
       browser.reconnect(newSocket)
       expect(browser.isReady()).to.equal(false)
 
@@ -395,16 +397,16 @@ describe('Browser', () => {
     })
 
     it('disconecting during the run', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browser_complete', spy)
-      var timer = createMockTimer()
+      const timer = createMockTimer()
       browser = new Browser('fake-id', 'full name', collection, emitter, socket, timer, 10)
       browser.init()
       browser.state = Browser.STATE_EXECUTING
       socket.emit('result', {success: true, suite: [], log: []})
       socket.emit('disconnect', 'socket.io reason')
 
-      var spyBrowserError = sinon.spy()
+      const spyBrowserError = sinon.spy()
       emitter.on('browser_error', spyBrowserError)
 
       timer.wind(10)
@@ -414,7 +416,7 @@ describe('Browser', () => {
     })
 
     it('restarting a disconnected browser', () => {
-      var timer = createMockTimer()
+      const timer = createMockTimer()
       browser = new Browser('fake-id', 'Chrome 31.0', collection, emitter, socket, timer, 10)
       browser.init()
 
@@ -428,7 +430,7 @@ describe('Browser', () => {
       expect(browser.state).to.equal(Browser.STATE_DISCONNECTED)
       expect(browser.disconnectsCount).to.equal(1)
 
-      var newSocket = mkSocket()
+      const newSocket = mkSocket()
       emitter.on('browser_register', () => browser.execute())
 
       // reconnect on a new socket (which triggers re-execution)
@@ -452,7 +454,7 @@ describe('Browser', () => {
       browser.execute()
 
       // A second connection...
-      var newSocket = mkSocket()
+      const newSocket = mkSocket()
       browser.reconnect(newSocket)
 
       // Disconnect the second connection...
@@ -482,12 +484,12 @@ describe('Browser', () => {
     })
 
     it('disconnect when no message during the run', () => {
-      var timer = createMockTimer()
+      const timer = createMockTimer()
       browser = new Browser('fake-id', 'Chrome 31.0', collection, emitter, socket, timer, 10, 20)
       browser.init()
       browser.execute()
 
-      var spyBrowserComplete = sinon.spy()
+      const spyBrowserComplete = sinon.spy()
       emitter.on('browser_complete', spyBrowserComplete)
 
       socket.emit('start', {total: 11})

--- a/test/unit/browser_collection.spec.js
+++ b/test/unit/browser_collection.spec.js
@@ -1,9 +1,11 @@
+'use strict'
+
 describe('BrowserCollection', () => {
-  var emitter
-  var e = require('../../lib/events')
-  var Collection = require('../../lib/browser_collection')
-  var Browser = require('../../lib/browser')
-  var collection = emitter = null
+  let emitter
+  const e = require('../../lib/events')
+  const Collection = require('../../lib/browser_collection')
+  const Browser = require('../../lib/browser')
+  let collection = emitter = null
 
   beforeEach(() => {
     emitter = new e.EventEmitter()
@@ -18,7 +20,7 @@ describe('BrowserCollection', () => {
     })
 
     it('should fire "browsers_change" event', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browsers_change', spy)
       collection.add({})
       expect(spy).to.have.been.called
@@ -27,7 +29,7 @@ describe('BrowserCollection', () => {
 
   describe('remove', () => {
     it('should remove given browser', () => {
-      var browser = new Browser('id')
+      const browser = new Browser('id')
       collection.add(browser)
 
       expect(collection.length).to.equal(1)
@@ -36,8 +38,8 @@ describe('BrowserCollection', () => {
     })
 
     it('should fire "browsers_change" event', () => {
-      var spy = sinon.spy()
-      var browser = new Browser('id')
+      const spy = sinon.spy()
+      const browser = new Browser('id')
       collection.add(browser)
 
       emitter.on('browsers_change', spy)
@@ -46,7 +48,7 @@ describe('BrowserCollection', () => {
     })
 
     it('should return false if given browser does not exist within the collection', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browsers_change', spy)
       expect(collection.remove({})).to.equal(false)
       expect(spy).not.to.have.been.called
@@ -55,7 +57,7 @@ describe('BrowserCollection', () => {
 
   describe('getById', () => {
     it('should find the browser by id', () => {
-      var browser = new Browser(123)
+      const browser = new Browser(123)
       collection.add(browser)
 
       expect(collection.getById(123)).to.equal(browser)
@@ -70,7 +72,7 @@ describe('BrowserCollection', () => {
   })
 
   describe('setAllToExecuting', () => {
-    var browsers = null
+    let browsers = null
 
     beforeEach(() => {
       browsers = [new Browser(), new Browser(), new Browser()]
@@ -88,7 +90,7 @@ describe('BrowserCollection', () => {
     })
 
     it('should fire "browsers_change" event', () => {
-      var spy = sinon.spy()
+      const spy = sinon.spy()
       emitter.on('browsers_change', spy)
       collection.setAllToExecuting()
       expect(spy).to.have.been.called
@@ -96,7 +98,7 @@ describe('BrowserCollection', () => {
   })
 
   describe('areAllReady', () => {
-    var browsers = null
+    let browsers = null
 
     beforeEach(() => {
       browsers = [new Browser(), new Browser(), new Browser()]
@@ -118,7 +120,7 @@ describe('BrowserCollection', () => {
     it('should add all non-ready browsers into given array', () => {
       browsers[0].state = Browser.STATE_EXECUTING
       browsers[1].state = Browser.STATE_EXECUTING_DISCONNECTED
-      var nonReady = []
+      const nonReady = []
       collection.areAllReady(nonReady)
       expect(nonReady).to.deep.equal([browsers[0], browsers[1]])
     })
@@ -126,7 +128,7 @@ describe('BrowserCollection', () => {
 
   describe('serialize', () => {
     it('should return plain array with serialized browsers', () => {
-      var browsers = [new Browser('1'), new Browser('2')]
+      const browsers = [new Browser('1'), new Browser('2')]
       browsers[0].name = 'B 1.0'
       browsers[1].name = 'B 2.0'
       collection.add(browsers[0])
@@ -141,7 +143,7 @@ describe('BrowserCollection', () => {
 
   describe('getResults', () => {
     it('should return sum of all browser results', () => {
-      var browsers = [new Browser(), new Browser()]
+      const browsers = [new Browser(), new Browser()]
       collection.add(browsers[0])
       collection.add(browsers[1])
       browsers[0].lastResult.success = 2
@@ -149,17 +151,17 @@ describe('BrowserCollection', () => {
       browsers[1].lastResult.success = 4
       browsers[1].lastResult.failed = 5
 
-      var results = collection.getResults()
+      const results = collection.getResults()
       expect(results.success).to.equal(6)
       expect(results.failed).to.equal(8)
     })
 
     it('should compute disconnected true if any browser got disconnected', () => {
-      var browsers = [new Browser(), new Browser()]
+      const browsers = [new Browser(), new Browser()]
       collection.add(browsers[0])
       collection.add(browsers[1])
 
-      var results = collection.getResults()
+      let results = collection.getResults()
       expect(results.disconnected).to.equal(false)
 
       browsers[0].lastResult.disconnected = true
@@ -176,11 +178,11 @@ describe('BrowserCollection', () => {
     })
 
     it('should compute error true if any browser had error', () => {
-      var browsers = [new Browser(), new Browser()]
+      const browsers = [new Browser(), new Browser()]
       collection.add(browsers[0])
       collection.add(browsers[1])
 
-      var results = collection.getResults()
+      let results = collection.getResults()
       expect(results.error).to.equal(false)
 
       browsers[0].lastResult.error = true
@@ -197,11 +199,11 @@ describe('BrowserCollection', () => {
     })
 
     it('should compute exitCode', () => {
-      var browsers = [new Browser(), new Browser()]
-      browsers.forEach(collection.add)
+      const browsers = [new Browser(), new Browser()]
+      browsers.forEach((browser) => collection.add(browser))
 
       browsers[0].lastResult.success = 2
-      var results = collection.getResults()
+      let results = collection.getResults()
       expect(results.exitCode).to.equal(0)
 
       browsers[0].lastResult.failed = 2
@@ -227,7 +229,7 @@ describe('BrowserCollection', () => {
   describe('clearResults', () => {
     it('should clear all results', () => {
       // Date.now.returns 112233
-      var browsers = [new Browser(), new Browser()]
+      const browsers = [new Browser(), new Browser()]
       collection.add(browsers[0])
       collection.add(browsers[1])
       browsers[0].lastResult.sucess++
@@ -249,10 +251,10 @@ describe('BrowserCollection', () => {
 
   describe('clone', () => {
     it('should create a shallow copy of the collection', () => {
-      var browsers = [new Browser(), new Browser(), new Browser()]
-      browsers.forEach(collection.add)
+      const browsers = [new Browser(), new Browser(), new Browser()]
+      browsers.forEach((browser) => collection.add(browser))
 
-      var clone = collection.clone()
+      const clone = collection.clone()
       expect(clone.length).to.equal(3)
 
       clone.remove(browsers[0])
@@ -263,10 +265,10 @@ describe('BrowserCollection', () => {
 
   describe('map', () => {
     it('should have map()', () => {
-      var browsers = [new Browser(1), new Browser(2), new Browser(3)]
-      browsers.forEach(collection.add)
+      const browsers = [new Browser(1), new Browser(2), new Browser(3)]
+      browsers.forEach((browser) => collection.add(browser))
 
-      var mappedIds = collection.map((browser) => browser.id)
+      const mappedIds = collection.map((browser) => browser.id)
 
       expect(mappedIds).to.deep.equal([1, 2, 3])
     })
@@ -274,10 +276,10 @@ describe('BrowserCollection', () => {
 
   describe('forEach', () => {
     it('should have forEach()', () => {
-      var browsers = [new Browser(0), new Browser(1), new Browser(2)]
-      browsers.forEach(collection.add)
+      const browsers = [new Browser(0), new Browser(1), new Browser(2)]
+      browsers.forEach((browser) => collection.add(browser))
 
-      collection.forEach(function (browser, index) {
+      collection.forEach((browser, index) => {
         expect(browser.id).to.equal(index)
       })
     })

--- a/test/unit/browser_result.spec.js
+++ b/test/unit/browser_result.spec.js
@@ -1,20 +1,22 @@
-describe('BrowserResult', () => {
-  var Result = require('../../lib/browser_result')
-  var result = null
+'use strict'
 
-  var successResultFromBrowser = {
+describe('BrowserResult', () => {
+  const Result = require('../../lib/browser_result')
+  let result = null
+
+  const successResultFromBrowser = {
     success: true,
     skipped: false,
     time: 100
   }
 
-  var failedResultFromBrowser = {
+  const failedResultFromBrowser = {
     success: false,
     skipped: false,
     time: 200
   }
 
-  var skippedResultFromBrowser = {
+  const skippedResultFromBrowser = {
     success: false,
     skipped: true,
     time: 0

--- a/test/unit/cli.spec.js
+++ b/test/unit/cli.spec.js
@@ -1,38 +1,40 @@
-var optimist = require('optimist')
-var path = require('path')
-var mocks = require('mocks')
+'use strict'
 
-var cli = require('../../lib/cli')
-var constant = require('../../lib/constants')
+const optimist = require('optimist')
+const path = require('path')
+const mocks = require('mocks')
 
-var loadFile = mocks.loadFile
+const cli = require('../../lib/cli')
+const constant = require('../../lib/constants')
+
+const loadFile = mocks.loadFile
 
 describe('cli', () => {
-  var m
-  var e
-  var mockery
+  let m
+  let e
+  let mockery
 
-  var fsMock = mocks.fs.create({
+  const fsMock = mocks.fs.create({
     cwd: {'karma.conf.js': true},
     cwd2: {'karma.conf.coffee': true},
     cwd3: {'karma.conf.ts': true}
   })
 
-  var currentCwd = null
+  let currentCwd = null
 
-  var pathMock = {
+  const pathMock = {
     resolve (p) {
       return path.resolve(currentCwd, p)
     }
   }
 
-  var setCWD = (cwd) => {
+  const setCWD = (cwd) => {
     currentCwd = cwd
     fsMock._setCWD(cwd)
   }
 
-  var processArgs = (args, opts) => {
-    var argv = optimist.parse(args)
+  const processArgs = (args, opts) => {
+    const argv = optimist.parse(args)
     return e.processArgs(argv, opts || {}, fsMock, pathMock)
   }
 
@@ -61,14 +63,14 @@ describe('cli', () => {
   describe('processArgs', () => {
     it('should override if multiple options given', () => {
       // optimist parses --port 123 --port 456 as port = [123, 456] which makes no sense
-      var options = processArgs(['some.conf', '--port', '12', '--log-level', 'info', '--port', '34', '--log-level', 'debug'])
+      const options = processArgs(['some.conf', '--port', '12', '--log-level', 'info', '--port', '34', '--log-level', 'debug'])
 
       expect(options.port).to.equal(34)
       expect(options.logLevel).to.equal('DEBUG')
     })
 
     it('should return camelCased options', () => {
-      var options = processArgs(['some.conf', '--port', '12', '--single-run'])
+      const options = processArgs(['some.conf', '--port', '12', '--single-run'])
 
       expect(options.configFile).to.exist
       expect(options.port).to.equal(12)
@@ -77,7 +79,7 @@ describe('cli', () => {
 
     it('should parse options without configFile and set default', () => {
       setCWD('/cwd')
-      var options = processArgs(['--auto-watch', '--auto-watch-interval', '10'])
+      const options = processArgs(['--auto-watch', '--auto-watch-interval', '10'])
       expect(path.resolve(options.configFile)).to.equal(path.resolve('/cwd/karma.conf.js'))
       expect(options.autoWatch).to.equal(true)
       expect(options.autoWatchInterval).to.equal(10)
@@ -85,27 +87,27 @@ describe('cli', () => {
 
     it('should set default karma.conf.coffee config file if exists', () => {
       setCWD('/cwd2')
-      var options = processArgs(['--port', '10'])
+      const options = processArgs(['--port', '10'])
 
       expect(path.resolve(options.configFile)).to.equal(path.resolve('/cwd2/karma.conf.coffee'))
     })
 
     it('should set default karma.conf.ts config file if exists', () => {
       setCWD('/cwd3')
-      var options = processArgs(['--port', '10'])
+      const options = processArgs(['--port', '10'])
 
       expect(path.resolve(options.configFile)).to.equal(path.resolve('/cwd3/karma.conf.ts'))
     })
 
     it('should not set default config if neither exists', () => {
       setCWD('/')
-      var options = processArgs([])
+      const options = processArgs([])
 
       expect(options.configFile).to.equal(null)
     })
 
     it('should parse auto-watch, colors, singleRun to boolean', () => {
-      var options = processArgs(['--auto-watch', 'false', '--colors', 'false', '--single-run', 'false'])
+      let options = processArgs(['--auto-watch', 'false', '--colors', 'false', '--single-run', 'false'])
 
       expect(options.autoWatch).to.equal(false)
       expect(options.colors).to.equal(false)
@@ -119,7 +121,7 @@ describe('cli', () => {
     })
 
     it('should replace log-level constants', () => {
-      var options = processArgs(['--log-level', 'debug'])
+      let options = processArgs(['--log-level', 'debug'])
       expect(options.logLevel).to.equal(constant.LOG_DEBUG)
 
       options = processArgs(['--log-level', 'error'])
@@ -137,29 +139,29 @@ describe('cli', () => {
 
     it('should parse format-error into a function', () => {
       // root export
-      var options = processArgs(['--format-error', '../../test/unit/fixtures/format-error-root'])
-      var formatErrorRoot = require('../../test/unit/fixtures/format-error-root')
+      let options = processArgs(['--format-error', '../../test/unit/fixtures/format-error-root'])
+      const formatErrorRoot = require('../../test/unit/fixtures/format-error-root')
       expect(options.formatError).to.equal(formatErrorRoot)
 
       // property export
       options = processArgs(['--format-error', '../../test/unit/fixtures/format-error-property'])
-      var formatErrorProperty = require('../../test/unit/fixtures/format-error-property').formatError
+      const formatErrorProperty = require('../../test/unit/fixtures/format-error-property').formatError
       expect(options.formatError).to.equal(formatErrorProperty)
     })
 
     it('should parse browsers into an array', () => {
-      var options = processArgs(['--browsers', 'Chrome,ChromeCanary,Firefox'])
+      const options = processArgs(['--browsers', 'Chrome,ChromeCanary,Firefox'])
       expect(options.browsers).to.deep.equal(['Chrome', 'ChromeCanary', 'Firefox'])
     })
 
     it('should resolve configFile to absolute path', () => {
       setCWD('/cwd')
-      var options = processArgs(['some/config.js'])
+      const options = processArgs(['some/config.js'])
       expect(path.resolve(options.configFile)).to.equal(path.resolve('/cwd/some/config.js'))
     })
 
     it('should parse report-slower-than to a number', () => {
-      var options = processArgs(['--report-slower-than', '2000'])
+      let options = processArgs(['--report-slower-than', '2000'])
       expect(options.reportSlowerThan).to.equal(2000)
 
       options = processArgs(['--no-report-slower-than'])
@@ -167,7 +169,7 @@ describe('cli', () => {
     })
 
     it('should cast reporters to array', () => {
-      var options = processArgs(['--reporters', 'dots,junit'])
+      let options = processArgs(['--reporters', 'dots,junit'])
       expect(options.reporters).to.deep.equal(['dots', 'junit'])
 
       options = processArgs(['--reporters', 'dots'])
@@ -175,7 +177,7 @@ describe('cli', () => {
     })
 
     it('should parse removed/added/changed files to array', () => {
-      var options = processArgs([
+      const options = processArgs([
         '--removed-files', 'r1.js,r2.js',
         '--changed-files', 'ch1.js,ch2.js',
         '--added-files', 'a1.js,a2.js'
@@ -187,9 +189,9 @@ describe('cli', () => {
     })
 
     it('should error on args with underscores', () => {
-      var expectedException
+      let expectedException
       try {
-        var options = processArgs(['--no_browsers'])
+        const options = processArgs(['--no_browsers'])
         expectedException = 'Should have thrown but got ' + options
       } catch (e) {
         expectedException = e
@@ -201,19 +203,19 @@ describe('cli', () => {
 
   describe('parseClientArgs', () => {
     it('should return arguments after --', () => {
-      var args = cli.parseClientArgs(['node', 'karma.js', 'runArg', '--flag', '--', '--foo', '--bar', 'baz'])
+      const args = cli.parseClientArgs(['node', 'karma.js', 'runArg', '--flag', '--', '--foo', '--bar', 'baz'])
       expect(args).to.deep.equal(['--foo', '--bar', 'baz'])
     })
 
     it('should return empty args if -- is not present', () => {
-      var args = cli.parseClientArgs(['node', 'karma.js', 'runArg', '--flag', '--foo', '--bar', 'baz'])
+      const args = cli.parseClientArgs(['node', 'karma.js', 'runArg', '--flag', '--foo', '--bar', 'baz'])
       expect(args).to.deep.equal([])
     })
   })
 
   describe('argsBeforeDoubleDash', () => {
     it('should return array of args that occur before --', () => {
-      var args = cli.argsBeforeDoubleDash(['aa', '--bb', 'value', '--', 'some', '--no-more'])
+      const args = cli.argsBeforeDoubleDash(['aa', '--bb', 'value', '--', 'some', '--no-more'])
       expect(args).to.deep.equal(['aa', '--bb', 'value'])
     })
   })

--- a/test/unit/completion.spec.js
+++ b/test/unit/completion.spec.js
@@ -1,10 +1,12 @@
-var c = require('../../lib/completion')
+'use strict'
+
+const c = require('../../lib/completion')
 
 describe('completion', () => {
-  var completion
+  let completion
 
   function mockEnv (line) {
-    var words = line.split(' ')
+    const words = line.split(' ')
 
     return {
       words: words,

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -1,16 +1,18 @@
-var path = require('path')
-var loadFile = require('mocks').loadFile
-var helper = require('../../lib/helper')
-var logger = require('../../lib/logger.js')
+'use strict'
+
+const path = require('path')
+const loadFile = require('mocks').loadFile
+const helper = require('../../lib/helper')
+const logger = require('../../lib/logger.js')
 
 describe('config', () => {
-  var m
-  var e
-  var mocks
+  let m
+  let e
+  let mocks
 
-  var resolveWinPath = (p) => helper.normalizeWinPath(path.resolve(p))
+  const resolveWinPath = (p) => helper.normalizeWinPath(path.resolve(p))
 
-  var normalizeConfigWithDefaults = (cfg) => {
+  const normalizeConfigWithDefaults = (cfg) => {
     if (!cfg.urlRoot) cfg.urlRoot = ''
     if (!cfg.proxyPath) cfg.proxyPath = ''
     if (!cfg.files) cfg.files = []
@@ -23,25 +25,27 @@ describe('config', () => {
   }
 
   // extract only pattern properties from list of pattern objects
-  var patternsFrom = (list) => list.map((pattern) => pattern.pattern)
+  const patternsFrom = (list) => list.map((pattern) => pattern.pattern)
 
-  var wrapCfg = function (cfg) {
+  const wrapCfg = function (cfg) {
     return (config) => config.set(cfg)
   }
 
   beforeEach(() => {
     mocks = {}
     mocks.process = {exit: sinon.spy()}
-    var mockConfigs = {
+    const mockConfigs = {
       '/home/config1.js': wrapCfg({basePath: 'base', reporters: ['dots']}),
       '/home/config2.js': wrapCfg({basePath: '/abs/base'}),
       '/home/config3.js': wrapCfg({files: ['one.js', 'sub/two.js']}),
       '/home/config4.js': wrapCfg({port: 123, autoWatch: true, basePath: '/abs/base'}),
       '/home/config6.js': wrapCfg({reporters: 'junit'}),
       '/home/config7.js': wrapCfg({browsers: ['Chrome', 'Firefox']}),
-      '/home/config8.js': (config) => config.set({ files: config.suite === 'e2e' ? ['tests/e2e.spec.js'] : ['tests/unit.spec.js'] }),
+      '/home/config8.js': (config) => config.set({files: config.suite === 'e2e' ? ['tests/e2e.spec.js'] : ['tests/unit.spec.js']}),
       '/home/config9.js': wrapCfg({client: {useIframe: false}}),
-      '/conf/invalid.js': () => { throw new SyntaxError('Unexpected token =') },
+      '/conf/invalid.js': () => {
+        throw new SyntaxError('Unexpected token =')
+      },
       '/conf/exclude.js': wrapCfg({exclude: ['one.js', 'sub/two.js']}),
       '/conf/absolute.js': wrapCfg({files: ['http://some.com', 'https://more.org/file.js']}),
       '/conf/both.js': wrapCfg({files: ['one.js', 'two.js'], exclude: ['third.js']}),
@@ -68,30 +72,30 @@ describe('config', () => {
   })
 
   describe('parseConfig', () => {
-    var logSpy
+    let logSpy
 
     beforeEach(() => {
       logSpy = sinon.spy(logger.create('config'), 'error')
     })
 
     it('should resolve relative basePath to config directory', () => {
-      var config = e.parseConfig('/home/config1.js', {})
+      const config = e.parseConfig('/home/config1.js', {})
       expect(config.basePath).to.equal(resolveWinPath('/home/base'))
     })
 
     it('should keep absolute basePath', () => {
-      var config = e.parseConfig('/home/config2.js', {})
+      const config = e.parseConfig('/home/config2.js', {})
       expect(config.basePath).to.equal(resolveWinPath('/abs/base'))
     })
 
     it('should resolve all file patterns', () => {
-      var config = e.parseConfig('/home/config3.js', {})
-      var actual = [resolveWinPath('/home/one.js'), resolveWinPath('/home/sub/two.js')]
+      const config = e.parseConfig('/home/config3.js', {})
+      const actual = [resolveWinPath('/home/one.js'), resolveWinPath('/home/sub/two.js')]
       expect(patternsFrom(config.files)).to.deep.equal(actual)
     })
 
     it('should keep absolute url file patterns', () => {
-      var config = e.parseConfig('/conf/absolute.js', {})
+      const config = e.parseConfig('/conf/absolute.js', {})
       expect(patternsFrom(config.files)).to.deep.equal([
         'http://some.com',
         'https://more.org/file.js'
@@ -99,8 +103,8 @@ describe('config', () => {
     })
 
     it('should resolve all exclude patterns', () => {
-      var config = e.parseConfig('/conf/exclude.js', {})
-      var actual = [
+      const config = e.parseConfig('/conf/exclude.js', {})
+      const actual = [
         resolveWinPath('/conf/one.js'),
         resolveWinPath('/conf/sub/two.js'),
         resolveWinPath('/conf/exclude.js')
@@ -113,7 +117,7 @@ describe('config', () => {
       e.parseConfig('/conf/not-exist.js', {})
 
       expect(logSpy).to.have.been.called
-      var event = logSpy.lastCall.args
+      const event = logSpy.lastCall.args
       expect(event).to.be.deep.equal(['File %s does not exist!', '/conf/not-exist.js'])
       expect(mocks.process.exit).to.have.been.calledWith(1)
     })
@@ -122,14 +126,14 @@ describe('config', () => {
       e.parseConfig('/conf/invalid.js', {})
 
       expect(logSpy).to.have.been.called
-      var event = logSpy.lastCall.args
+      const event = logSpy.lastCall.args
       expect(event[0]).to.eql('Error in config file!\n')
       expect(event[1].message).to.eql('Unexpected token =')
       expect(mocks.process.exit).to.have.been.calledWith(1)
     })
 
     it('should override config with given cli options', () => {
-      var config = e.parseConfig('/home/config4.js', {port: 456, autoWatch: false})
+      const config = e.parseConfig('/home/config4.js', {port: 456, autoWatch: false})
 
       expect(config.port).to.equal(456)
       expect(config.autoWatch).to.equal(false)
@@ -138,21 +142,21 @@ describe('config', () => {
 
     it('should override config with cli options if the config property is an array', () => {
       // regression https://github.com/karma-runner/karma/issues/283
-      var config = e.parseConfig('/home/config7.js', {browsers: ['Safari']})
+      const config = e.parseConfig('/home/config7.js', {browsers: ['Safari']})
 
       expect(config.browsers).to.deep.equal(['Safari'])
     })
 
     it('should merge config with cli options if the config property is an object', () => {
       // regression https://github.com/karma-runner/grunt-karma/issues/165
-      var config = e.parseConfig('/home/config9.js', {client: {captureConsole: false}})
+      const config = e.parseConfig('/home/config9.js', {client: {captureConsole: false}})
 
       expect(config.client.useIframe).to.equal(false)
       expect(config.client.captureConsole).to.equal(false)
     })
 
     it('should have access to cli options in the config file', () => {
-      var config = e.parseConfig('/home/config8.js', {suite: 'e2e'})
+      let config = e.parseConfig('/home/config8.js', {suite: 'e2e'})
       expect(patternsFrom(config.files)).to.deep.equal([resolveWinPath('/home/tests/e2e.spec.js')])
 
       config = e.parseConfig('/home/config8.js', {})
@@ -160,10 +164,10 @@ describe('config', () => {
     })
 
     it('should resolve files and excludes to overriden basePath from cli', () => {
-      var config = e.parseConfig('/conf/both.js', {port: 456, autoWatch: false, basePath: '/xxx'})
+      const config = e.parseConfig('/conf/both.js', {port: 456, autoWatch: false, basePath: '/xxx'})
 
       expect(config.basePath).to.equal(resolveWinPath('/xxx'))
-      var actual = [resolveWinPath('/xxx/one.js'), resolveWinPath('/xxx/two.js')]
+      const actual = [resolveWinPath('/xxx/one.js'), resolveWinPath('/xxx/two.js')]
       expect(patternsFrom(config.files)).to.deep.equal(actual)
       expect(config.exclude).to.deep.equal([
         resolveWinPath('/xxx/third.js'),
@@ -172,7 +176,7 @@ describe('config', () => {
     })
 
     it('should normalize urlRoot config', () => {
-      var config = normalizeConfigWithDefaults({urlRoot: ''})
+      let config = normalizeConfigWithDefaults({urlRoot: ''})
       expect(config.urlRoot).to.equal('/')
 
       config = normalizeConfigWithDefaults({urlRoot: '/a/b'})
@@ -186,7 +190,7 @@ describe('config', () => {
     })
 
     it('should normalize upstream proxy config', () => {
-      var config = normalizeConfigWithDefaults({})
+      let config = normalizeConfigWithDefaults({})
       expect(config.upstreamProxy).to.be.undefined
 
       config = normalizeConfigWithDefaults({upstreamProxy: {}})
@@ -216,17 +220,17 @@ describe('config', () => {
 
     it('should change autoWatch to false if singleRun', () => {
       // config4.js has autoWatch = true
-      var config = m.parseConfig('/home/config4.js', {singleRun: true})
+      const config = m.parseConfig('/home/config4.js', {singleRun: true})
       expect(config.autoWatch).to.equal(false)
     })
 
     it('should normalize reporters to an array', () => {
-      var config = m.parseConfig('/home/config6.js', {})
+      const config = m.parseConfig('/home/config6.js', {})
       expect(config.reporters).to.deep.equal(['junit'])
     })
 
     it('should compile coffeescript config', () => {
-      var config = e.parseConfig('/conf/coffee.coffee', {})
+      const config = e.parseConfig('/conf/coffee.coffee', {})
       expect(patternsFrom(config.files)).to.deep.equal([
         resolveWinPath('/conf/one.js'),
         resolveWinPath('/conf/two.js')
@@ -234,12 +238,12 @@ describe('config', () => {
     })
 
     it('should set defaults with coffeescript', () => {
-      var config = e.parseConfig('/conf/coffee.coffee', {})
+      const config = e.parseConfig('/conf/coffee.coffee', {})
       expect(config.autoWatch).to.equal(true)
     })
 
     it('should not read config file, when null', () => {
-      var config = e.parseConfig(null, {basePath: '/some'})
+      const config = e.parseConfig(null, {basePath: '/some'})
 
       expect(logSpy).not.to.have.been.called
       expect(config.basePath).to.equal(resolveWinPath('/some')) // overriden by CLI
@@ -247,7 +251,7 @@ describe('config', () => {
     }) // default value
 
     it('should not read config file, when null but still resolve cli basePath', () => {
-      var config = e.parseConfig(null, {basePath: './some'})
+      const config = e.parseConfig(null, {basePath: './some'})
 
       expect(logSpy).not.to.have.been.called
       expect(config.basePath).to.equal(resolveWinPath('./some'))
@@ -255,7 +259,7 @@ describe('config', () => {
     }) // default value
 
     it('should default unset options in client config', () => {
-      var config = e.parseConfig(null, {client: {args: ['--test']}})
+      let config = e.parseConfig(null, {client: {args: ['--test']}})
 
       expect(config.client.useIframe).to.not.be.undefined
       expect(config.client.captureConsole).to.not.be.undefined
@@ -272,34 +276,34 @@ describe('config', () => {
     })
 
     it('should validate and format the protocol', () => {
-      var config = normalizeConfigWithDefaults({})
+      let config = normalizeConfigWithDefaults({})
       expect(config.protocol).to.equal('http:')
 
-      config = normalizeConfigWithDefaults({ protocol: 'http' })
+      config = normalizeConfigWithDefaults({protocol: 'http'})
       expect(config.protocol).to.equal('http:')
 
-      config = normalizeConfigWithDefaults({ protocol: 'http:' })
+      config = normalizeConfigWithDefaults({protocol: 'http:'})
       expect(config.protocol).to.equal('http:')
 
-      config = normalizeConfigWithDefaults({ protocol: 'https' })
+      config = normalizeConfigWithDefaults({protocol: 'https'})
       expect(config.protocol).to.equal('https:')
 
-      config = normalizeConfigWithDefaults({ protocol: 'https:' })
+      config = normalizeConfigWithDefaults({protocol: 'https:'})
       expect(config.protocol).to.equal('https:')
 
-      config = normalizeConfigWithDefaults({ protocol: 'unsupported:' })
+      config = normalizeConfigWithDefaults({protocol: 'unsupported:'})
       expect(config.protocol).to.equal('http:')
     })
 
     it('should allow the config to be set of the default export', () => {
-      var config = e.parseConfig('/conf/default-export.js', {})
+      const config = e.parseConfig('/conf/default-export.js', {})
       expect(config.autoWatch).to.equal(true)
     })
   })
 
   describe('normalizeConfig', () => {
     it('should convert patterns to objects and set defaults', () => {
-      var config = normalizeConfigWithDefaults({
+      const config = normalizeConfigWithDefaults({
         basePath: '/base',
         files: ['a/*.js', {pattern: 'b.js', watched: false, included: false}, {pattern: 'c.js'}],
         customContextFile: 'context.html',
@@ -309,7 +313,7 @@ describe('config', () => {
 
       expect(config.files.length).to.equal(3)
 
-      var file = config.files.shift()
+      let file = config.files.shift()
       expect(file.pattern).to.equal(resolveWinPath('/base/a/*.js'))
       expect(file.included).to.equal(true)
       expect(file.served).to.equal(true)
@@ -333,7 +337,7 @@ describe('config', () => {
     })
 
     it('should normalize preprocessors to an array', () => {
-      var config = normalizeConfigWithDefaults({
+      const config = normalizeConfigWithDefaults({
         basePath: '',
         preprocessors: {
           '/*.coffee': 'coffee',
@@ -346,7 +350,7 @@ describe('config', () => {
     })
 
     it('should resolve relative preprocessor patterns', () => {
-      var config = normalizeConfigWithDefaults({
+      const config = normalizeConfigWithDefaults({
         basePath: '/some/base',
         preprocessors: {
           '*.coffee': 'coffee',
@@ -360,7 +364,7 @@ describe('config', () => {
     })
 
     it('should validate that the browser option is an array', () => {
-      var invalid = function () {
+      const invalid = function () {
         normalizeConfigWithDefaults({
           browsers: 'Firefox'
         })
@@ -370,7 +374,7 @@ describe('config', () => {
     })
 
     it('should validate that the formatError option is a function', () => {
-      var invalid = function () {
+      const invalid = function () {
         normalizeConfigWithDefaults({
           formatError: 'lodash/identity'
         })
@@ -382,7 +386,7 @@ describe('config', () => {
 
   describe('createPatternObject', () => {
     it('should parse string and set defaults', () => {
-      var pattern = m.createPatternObject('some/**/*.js')
+      const pattern = m.createPatternObject('some/**/*.js')
 
       expect(typeof pattern).to.equal('object')
       expect(pattern.pattern).to.equal('some/**/*.js')
@@ -392,7 +396,7 @@ describe('config', () => {
     })
 
     it('should merge pattern object and set defaults', () => {
-      var pattern = m.createPatternObject({pattern: 'a.js', included: false, watched: false})
+      const pattern = m.createPatternObject({pattern: 'a.js', included: false, watched: false})
 
       expect(typeof pattern).to.equal('object')
       expect(pattern.pattern).to.equal('a.js')
@@ -402,7 +406,7 @@ describe('config', () => {
     })
 
     it('should make urls not served neither watched', () => {
-      var pattern = m.createPatternObject('http://some.url.com')
+      let pattern = m.createPatternObject('http://some.url.com')
 
       expect(pattern.pattern).to.equal('http://some.url.com')
       expect(pattern.included).to.equal(true)
@@ -419,20 +423,20 @@ describe('config', () => {
   })
 
   describe('custom', () => {
-    var di = require('di')
+    const di = require('di')
 
-    var forwardArgsFactory = function (args) {
+    const forwardArgsFactory = function (args) {
       return args
     }
 
-    var baseModule = {
+    const baseModule = {
       'preprocessor:base': ['type', forwardArgsFactory],
       'launcher:base': ['type', forwardArgsFactory],
       'reporter:base': ['type', forwardArgsFactory]
     }
 
     it('should define a custom launcher', () => {
-      var config = normalizeConfigWithDefaults({
+      const config = normalizeConfigWithDefaults({
         customLaunchers: {
           custom: {
             base: 'base',
@@ -442,8 +446,8 @@ describe('config', () => {
         }
       })
 
-      var injector = new di.Injector([baseModule].concat(config.plugins))
-      var injectedArgs = injector.get('launcher:custom')
+      const injector = new di.Injector([baseModule].concat(config.plugins))
+      const injectedArgs = injector.get('launcher:custom')
 
       expect(injectedArgs).to.exist
       expect(injectedArgs.first).to.equal(123)
@@ -451,7 +455,7 @@ describe('config', () => {
     })
 
     it('should define a custom preprocessor', () => {
-      var config = normalizeConfigWithDefaults({
+      const config = normalizeConfigWithDefaults({
         customPreprocessors: {
           custom: {
             base: 'base',
@@ -461,8 +465,8 @@ describe('config', () => {
         }
       })
 
-      var injector = new di.Injector([baseModule].concat(config.plugins))
-      var injectedArgs = injector.get('preprocessor:custom')
+      const injector = new di.Injector([baseModule].concat(config.plugins))
+      const injectedArgs = injector.get('preprocessor:custom')
 
       expect(injectedArgs).to.exist
       expect(injectedArgs.second).to.equal(123)
@@ -470,7 +474,7 @@ describe('config', () => {
     })
 
     it('should define a custom reporter', () => {
-      var config = normalizeConfigWithDefaults({
+      const config = normalizeConfigWithDefaults({
         customReporters: {
           custom: {
             base: 'base',
@@ -480,8 +484,8 @@ describe('config', () => {
         }
       })
 
-      var injector = new di.Injector([baseModule].concat(config.plugins))
-      var injectedArgs = injector.get('reporter:custom')
+      const injector = new di.Injector([baseModule].concat(config.plugins))
+      const injectedArgs = injector.get('reporter:custom')
 
       expect(injectedArgs).to.exist
       expect(injectedArgs.third).to.equal(123)
@@ -489,7 +493,7 @@ describe('config', () => {
     })
 
     it('should not create empty module', () => {
-      var config = normalizeConfigWithDefaults({})
+      const config = normalizeConfigWithDefaults({})
       expect(config.plugins).to.deep.equal([])
     })
   })

--- a/test/unit/emitter_wrapper.spec.js
+++ b/test/unit/emitter_wrapper.spec.js
@@ -1,10 +1,11 @@
-var EventEmitter = require('events').EventEmitter
+'use strict'
 
-var EmitterWrapper = require('../../lib/emitter_wrapper')
+const EventEmitter = require('events').EventEmitter
+const EmitterWrapper = require('../../lib/emitter_wrapper')
 
 describe('emitter_wrapper', () => {
-  var emitter
-  var wrapped
+  let emitter
+  let wrapped
 
   beforeEach(() => {
     emitter = new EventEmitter()
@@ -14,7 +15,7 @@ describe('emitter_wrapper', () => {
   })
 
   describe('addListener', () => {
-    var aListener = (e) => true
+    const aListener = (e) => true
 
     it('should add a listener to the wrapped emitter', () => {
       wrapped.addListener('anEvent', aListener)
@@ -27,7 +28,7 @@ describe('emitter_wrapper', () => {
   })
 
   describe('removeAllListeners', () => {
-    var aListener = (e) => true
+    const aListener = (e) => true
 
     beforeEach(() => {
       wrapped.addListener('anEvent', aListener)
@@ -44,7 +45,7 @@ describe('emitter_wrapper', () => {
     })
 
     it('should remove only matching listeners when called with an event name', () => {
-      var anotherListener = (e) => true
+      const anotherListener = (e) => true
       wrapped.addListener('anotherEvent', anotherListener)
       wrapped.removeAllListeners('anEvent')
       expect(emitter.listeners('anEvent')).not.to.contain(aListener)


### PR DESCRIPTION
So this is another take on migrating code base to ES2015 classes, const/let and arrow functions. With Node 4 [reaching](https://github.com/nodejs/Release#release-schedule) end-of-life in 2 months developers soon can enjoy [full support](https://kangax.github.io/compat-table/es6/#node6_5) of ES2015 :smile:

Using mentioned syntaxes should give cleaner, more structured and therefore more maintainable code.

I originally tried to base my work on https://github.com/karma-runner/karma/pull/2904 from @EzraBrooks, but rebasing on master turned out to be very nasty, so I gave up and started over.

The goal of this PR is exclusively migration to ES2015 and NOT change of a DI mechanism. I monkey-patched `di` module to support ES classes for now. Everything should work exactly the same as it worked for functions. The DI migration can be done later (if needed).

I'm looking for confirmation that this approach is fine by maintainers and than I will continue to refactor more classes.