### PR TITLE
fix(common): Proxy function toString does not contain Proxy.

### DIFF
--- a/common/stringify.js
+++ b/common/stringify.js
@@ -25,8 +25,8 @@ var stringify = function stringify (obj, depth) {
         return obj.toString().replace(/\{[\s\S]*\}/, '{ ... }')
       } catch (err) {
         if (err instanceof TypeError) {
-          // Proxy(function abc(...) { ... })
-          return 'Proxy(function ' + (obj.name || '') + '(...) { ... })'
+          // Support older browsers
+          return 'function ' + (obj.name || '') + '() { ... }'
         } else {
           throw err
         }

--- a/test/client/stringify.spec.js
+++ b/test/client/stringify.spec.js
@@ -40,11 +40,8 @@ describe('stringify', function () {
   //   http://caniuse.com/#feat=proxy
   if (window.Proxy) {
     it('should serialize proxied functions', function () {
-      var abcProxy = new Proxy(function abc (a, b, c) { return 'whatever' }, {})
       var defProxy = new Proxy(function (d, e, f) { return 'whatever' }, {})
-
-      assert.deepEqual(stringify(abcProxy), 'Proxy(function abc(...) { ... })')
-      assert.deepEqual(stringify(defProxy), 'Proxy(function (...) { ... })')
+      assert.deepEqual(stringify(defProxy), 'function () { ... }')
     })
   }
 


### PR DESCRIPTION
Recent change (https://www.chromestatus.com/feature/5666372071718912) means Proxied functions
no longer throw TypeError.  Change the test to conform to the new reality.

Fixes #2942 