### PR TITLE
fix: Nicer "disconnect" - no more "Disconnectedundefined"

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -37,7 +37,7 @@ var Browser = function (id, fullName, /* capturedBrowsers */ collection, emitter
     self.state = DISCONNECTED
     self.disconnectsCount++
     log.warn('Disconnected (%d times)' + (reason || ''), self.disconnectsCount)
-    emitter.emit('browser_error', self, 'Disconnected' + reason)
+    emitter.emit('browser_error', self, 'Disconnected' + (reason || ''))
     collection.remove(self)
   }
 


### PR DESCRIPTION
The method "disconnect" sometimes is called without arguments. The emited message should not look broken then.

Previously it looked like this:

<img width="741" alt="disconnected" src="https://user-images.githubusercontent.com/86275/37330825-909274ce-26a2-11e8-834f-3b937ff31256.png">
