### PR TITLE
fix: ignore jsVersion configuration property in Firefox 59+

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -803,7 +803,7 @@ sometimes you might want to proxy a url that is already taken by Karma.
 
 If `> 0`, Karma will add a JavaScript version tag to the included JavaScript files.
 
-Note: This will only be applied to the Firefox browser. It is currently the only browser that supports the version tag.
+Note: This will only be applied to the Firefox browser up to version 58. Support for JavaScript version was [removed](https://bugzilla.mozilla.org/show_bug.cgi?id=1428745) in Firefox 59. This property is deprecated and will be removed in the next major release of Karma.
 
 
 [plugins]: plugins.html

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -223,7 +223,15 @@ var createKarmaMiddleware = function (
 
             // In case there is a JavaScript version specified and this is a Firefox browser
             if (jsVersion && jsVersion > 0 && isFirefox(request)) {
-              scriptType += ';version=' + jsVersion
+              var agent = useragent.parse(request.headers['user-agent'])
+
+              log.warn('jsVersion configuration property is deprecated and will be removed in the next major release of Karma.')
+
+              if (agent.major < 59) {
+                scriptType += ';version=' + jsVersion
+              } else {
+                log.warn('jsVersion is not supported in Firefox 59+ (see https://bugzilla.mozilla.org/show_bug.cgi?id=1428745 for more details). Ignoring.')
+              }
             }
 
             var crossOriginAttribute = includeCrossOriginAttribute ? CROSSORIGIN_ATTRIBUTE : ''

--- a/test/e2e/support/tag/tag.js
+++ b/test/e2e/support/tag/tag.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
-var isFirefox = function () {
-  return typeof InstallTrigger !== 'undefined'
+var isFirefoxBefore59 = function () {
+  return typeof InstallTrigger !== 'undefined' && parseFloat(navigator.userAgent.match(/\d+\.\d+$/)) < 59
 }
 
 var containsJsTag = function () {

--- a/test/e2e/support/tag/test-with-version.js
+++ b/test/e2e/support/tag/test-with-version.js
@@ -1,6 +1,6 @@
-/* globals containsJsTag, isFirefox */
+/* globals containsJsTag, isFirefoxBefore59 */
 describe('JavaScript version tag', function () {
   it('should add the version tag, if Firefox is used', function () {
-    expect(containsJsTag()).toBe(isFirefox())
+    expect(containsJsTag()).toBe(isFirefoxBefore59())
   })
 })

--- a/test/e2e/tag.feature
+++ b/test/e2e/tag.feature
@@ -15,7 +15,7 @@ Feature: JavaScript Tag
       ]
       """
     When I start Karma
-    Then it passes with:
+    Then it passes with like:
       """
       .
       Firefox


### PR DESCRIPTION
Support for specifying JavaScript version was removed in Firefox 59. See
https://bugzilla.mozilla.org/show_bug.cgi?id=1428745 for more details.
From now on Karma will ignore `jsVersion` property in Firefox 59+ and
print deprecation warning if `jsVersion` property is set.