### PR TITLE
fix: karma.loaded() started too early (#2955)

### DIFF
--- a/static/context.html
+++ b/static/context.html
@@ -27,7 +27,15 @@ Reloaded before every execution run.
   <!-- Dynamically replaced with <script> tags -->
   %SCRIPTS%
   <script type="text/javascript">
-    window.__karma__.loaded();
+    if (window.addEventListener) {
+      document.addEventListener("DOMContentLoaded",function(){
+        window.__karma__.loaded();
+      });
+    } else {
+      // Hack for IE7 and IE8.
+      // In IE7 and IE8, we don't care about native es6-module, since they are not implemented anyway
+      window.__karma__.loaded();
+    }
   </script>
 </body>
 </html>

--- a/static/debug.html
+++ b/static/debug.html
@@ -29,7 +29,15 @@ just for immediate execution, without reporting to Karma server.
   <!-- Dynamically replaced with <script> tags -->
   %SCRIPTS%
   <script type="text/javascript">
-    window.__karma__.loaded();
+    if (window.addEventListener) {
+      document.addEventListener("DOMContentLoaded",function(){
+        window.__karma__.loaded();
+      });
+    } else {
+      // Hack for IE7 and IE8.
+      // In IE7 and IE8, we don't care about native es6-module, since they are not implemented anyway
+      window.__karma__.loaded();
+    }
   </script>
 </body>
 </html>

--- a/test/e2e/module.feature
+++ b/test/e2e/module.feature
@@ -1,0 +1,26 @@
+Feature: Module Testrunner
+  In order to use Karma
+  As a person who wants to write great tests
+  I want to be able to run tests from the command line.
+  Note: This test can only run in chrome, since chrome is the only
+  one to support this feature at time of developpement (2018-03-14)
+
+  @not-jenkins
+  Scenario: Execute a test with modules in Chrome
+    Given a configuration with:
+      """
+      files = [
+          { pattern: 'module/plus.js', type: 'module', include: false },
+          { pattern: 'module/test.js', type: 'module' },
+      ];
+      browsers = ['Chrome'];
+      plugins = [
+        'karma-jasmine',
+        'karma-chrome-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with like:
+      """
+      Executed 2 of 2 SUCCESS
+      """

--- a/test/e2e/support/module/plus.js
+++ b/test/e2e/support/module/plus.js
@@ -1,0 +1,5 @@
+/* eslint-disable no-unused-vars */
+// Some code under test
+export default function plus (a, b) {
+  return a + b
+}

--- a/test/e2e/support/module/test.js
+++ b/test/e2e/support/module/test.js
@@ -1,0 +1,12 @@
+/* globals plus */
+import plus from './plus.js';
+
+describe('plus', function () {
+  it('should pass', function () {
+    expect(true).toBe(true)
+  })
+
+  it('should work', function () {
+    expect(plus(1, 2)).toBe(3)
+  })
+})


### PR DESCRIPTION
On module, you need to wait explicitely on modules being loaded before
starting the tests.
This commit:
- wait for modules to be loaded
- add a test for modules

This is the same as https://github.com/karma-runner/karma/pull/2956, but with Google CLA ok