### PR TITLE
fix: unignore client directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@ tmp
 test
 tasks
 docs
-client
 logo
 integration-tests
 


### PR DESCRIPTION
This directory was missing when trying to use karma from the latest master.