### PR TITLE
fix(package.json): sinon-chai 2.13 is not compatible with sinon 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -437,7 +437,7 @@
     "proxyquire": "^1.7.11",
     "qunitjs": "^2.1.1",
     "requirejs": "^2.1.20",
-    "sinon": "^4.1.2",
+    "sinon": "^3.0.0",
     "sinon-chai": "^2.7.0",
     "supertest": "^3.0.0",
     "timer-shim": "^0.3.0",


### PR DESCRIPTION

To avoid 
npm ERR! peerinvalid The package sinon@4.3.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer sinon-chai@2.13.0 wants sinon@^1.4.0 || ^2.1.0 || ^3.0.0