### PR TITLE
feat(grunt): run check_clean before starting release.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -131,6 +131,7 @@ module.exports = function (grunt) {
     }
   })
 
+  grunt.loadNpmTasks('grunt-check-clean')
   grunt.loadTasks('tasks')
   require('load-grunt-tasks')(grunt)
 
@@ -141,6 +142,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('release', 'Build, bump and publish to NPM.', function (type) {
     grunt.task.run([
+      'check_clean',
       'npm-contributors',
       'bump:' + (type || 'patch') + ':bump-only',
       'build',

--- a/package.json
+++ b/package.json
@@ -437,7 +437,7 @@
     "proxyquire": "^1.7.11",
     "qunitjs": "^2.1.1",
     "requirejs": "^2.1.20",
-    "sinon": "^4.1.2",
+    "sinon": "^3.0.0",
     "sinon-chai": "^2.7.0",
     "supertest": "^3.0.0",
     "timer-shim": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -397,6 +397,7 @@
     "grunt-browserify": "^5.0.0",
     "grunt-bump": "^0.8.0",
     "grunt-cli": "^1.1.0",
+    "grunt-check-clean": "^0.1.2",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-conventional-changelog": "^6.0.1",
     "grunt-conventional-github-releaser": "^1.0.0",


### PR DESCRIPTION
By checking early we avoid pushing a new version to github that is not then published to npm.