### PR TITLE
fix(server): Remove Socket.IO listeners

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,6 @@ install:
   # Install Node.js
   - ps: Install-Product node $env:nodejs_version
 
-  # Install npm compat with node 4
-  - npm install -g npm@3
-
   # Output our current versions for debugging
   - node --version
   - npm --version

--- a/lib/server.js
+++ b/lib/server.js
@@ -425,6 +425,10 @@ Server.prototype._start = function (config, launcher, preprocess, fileList,
     }
 
     self.emitAsync('exit').then(function () {
+      // Remove Socket.IO listeners. `connection` callback closes over `Server`
+      // instance so it leaks Plugin state e.g. Webpack compilations.
+      socketServer.sockets.removeAllListeners()
+      socketServer.close()
       // don't wait forever on webServer.close() because
       // pending client connections prevent it from closing.
       var closeTimeout = setTimeout(removeAllListeners, webServerCloseTimeout)

--- a/test/unit/middleware/proxy.spec.js
+++ b/test/unit/middleware/proxy.spec.js
@@ -346,8 +346,8 @@ describe('middleware.proxy', () => {
     }
     var parsedProxyConfig = m.parseProxyConfig(proxy, config)
     expect(parsedProxyConfig).to.have.length(1)
-    expect(parsedProxyConfig[0].proxy.listeners('proxyReq', true)).to.equal(true)
-    expect(parsedProxyConfig[0].proxy.listeners('proxyRes', true)).to.equal(true)
+    expect(parsedProxyConfig[0].proxy.listeners('proxyReq')[0]).to.equal(config.proxyReq)
+    expect(parsedProxyConfig[0].proxy.listeners('proxyRes')[0]).to.equal(config.proxyRes)
   })
 
   it('should handle empty proxy config', () => {

--- a/test/unit/server.spec.js
+++ b/test/unit/server.spec.js
@@ -65,13 +65,15 @@ describe('server', () => {
     }
 
     mockSocketServer = {
+      close: () => {},
       flashPolicyServer: {
         close: () => {}
       },
       sockets: {
         sockets: {},
         on: () => {},
-        emit: () => {}
+        emit: () => {},
+        removeAllListeners: () => {}
       }
     }
 


### PR DESCRIPTION
Not removing Socket.IO listeners can cause memory issues
in long running processes that spawn many Karma instance.

Fixes #2980