### PR TITLE
fix(stringify): errors on type symbol

### DIFF
--- a/common/stringify.js
+++ b/common/stringify.js
@@ -14,6 +14,8 @@ var stringify = function stringify (obj, depth) {
   }
 
   switch (typeof obj) {
+    case 'symbol':
+      return obj.toString()
     case 'string':
       return "'" + obj + "'"
     case 'undefined':

--- a/lib/config.js
+++ b/lib/config.js
@@ -429,9 +429,11 @@ function parseConfig (configFilePath, cliOptions) {
 
   // if the user changed listenAddress, but didn't set a hostname, warn them
   if (config.hostname === null && config.listenAddress !== null) {
-    log.warn('ListenAddress was set to %s but hostname was left as the default: ' +
+    log.warn(
+      'ListenAddress was set to %s but hostname was left as the default: ' +
       '%s. If your browsers fail to connect, consider changing the hostname option.',
-      config.listenAddress, defaultHostname)
+      config.listenAddress, defaultHostname
+    )
   }
   // restore values that weren't overwritten by the user
   if (config.hostname === null) {

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -193,8 +193,7 @@ List.prototype._refresh = function () {
       return self._preprocess(file).then(function () {
         return file
       })
-    })
-    .then(function (files) {
+    }).then(function (files) {
       files = _.compact(files)
 
       if (_.isEmpty(files)) {
@@ -203,8 +202,7 @@ List.prototype._refresh = function () {
         buckets.set(pattern, new Set(files))
       }
     })
-  })
-  .then(function () {
+  }).then(function () {
     if (self._refreshing !== promise) {
       return self._refreshing
     }
@@ -232,8 +230,7 @@ Object.defineProperty(List.prototype, 'files', {
 
     var served = this._patterns.filter(function (pattern) {
       return pattern.served
-    })
-    .map(expandPattern)
+    }).map(expandPattern)
 
     var lookup = {}
     var included = {}
@@ -330,8 +327,7 @@ List.prototype.addFile = function (path) {
   ]).spread(function (stat) {
     file.mtime = stat.mtime
     return self._preprocess(file)
-  })
-  .then(function () {
+  }).then(function () {
     log.info('Added file "%s".', path)
     self._emitModified()
     return self.files
@@ -364,13 +360,11 @@ List.prototype.changeFile = function (path) {
 
     file.mtime = stat.mtime
     return self._preprocess(file)
-  })
-  .then(function () {
+  }).then(function () {
     log.info('Changed file "%s".', path)
     self._emitModified()
     return self.files
-  })
-  .catch(Promise.CancellationError, function () {
+  }).catch(Promise.CancellationError, function () {
     return self.files
   })
 }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -43,7 +43,7 @@ var Launcher = function (server, emitter, injector) {
   this.launchSingle = function (protocol, hostname, port, urlRoot, upstreamProxy, processKillTimeout) {
     var self = this
     return function (name) {
-      name = (name + '').trim();
+      name = (name + '').trim()
       if (upstreamProxy) {
         protocol = upstreamProxy.protocol
         hostname = upstreamProxy.hostname

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -45,7 +45,7 @@ var setup = function (level, colors, appenders) {
       })
     }
   } else {
-    appenders = {'console' : constant.CONSOLE_APPENDER}
+    appenders = { 'console': constant.CONSOLE_APPENDER }
   }
 
   log4js.configure({
@@ -110,6 +110,6 @@ var create = function (name, level) {
 exports.create = create
 exports.setup = setup
 exports.setupFromConfig = setupFromConfig
-exports._rebindLog4js4testing = function(mockLog4js) {
+exports._rebindLog4js4testing = function (mockLog4js) {
   log4js = mockLog4js
 }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -78,8 +78,12 @@ var createErrorFormatter = function (config, emitter, SourceMapConsumer) {
           // the path is not absolute yet.
           var sourcePath = resolve(path, original.source)
           var formattedColumn = column ? util.format(':%s', column) : ''
-          return util.format('%s:%d:%d <- %s:%d%s', sourcePath, original.line, original.column,
-              path, line, formattedColumn)
+          return util.format(
+            '%s:%d:%d <- %s:%d%s', sourcePath, original.line, original.column,
+            path,
+            line,
+            formattedColumn
+          )
         } catch (e) {
           log.warn('SourceMap position not found for trace: %s', msg)
           // Fall back to non-source-mapped formatting.

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,7 +32,7 @@ const karmaJsPath = path.join(__dirname, '/../static/karma.js')
 const contextJsPath = path.join(__dirname, '/../static/context.js')
 
 // Dynamic dependence on brwoserify
-var browserify = null;
+var browserify = null
 
 /**
  * Bundles a static resource using Browserify.
@@ -155,8 +155,15 @@ Server.prototype.refreshFiles = function () {
 // Private Methods
 // ---------------
 
-Server.prototype._start = function (config, launcher, preprocess, fileList,
-                                    capturedBrowsers, executor, done) {
+Server.prototype._start = function (
+  config,
+  launcher,
+  preprocess,
+  fileList,
+  capturedBrowsers,
+  executor,
+  done
+) {
   var self = this
   if (config.detached) {
     this._detach(config, done)

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -10,8 +10,8 @@ var DIR_SEP = require('path').sep
 // Get parent folder, that be watched (does not contain any special globbing character)
 var baseDirFromPattern = function (pattern) {
   return pattern
-    .replace(/[/\\][^/\\]*\*.*$/, '')              // remove parts with *
-    .replace(/[/\\][^/\\]*[!+]\(.*$/, '')         // remove parts with !(...) and +(...)
+    .replace(/[/\\][^/\\]*\*.*$/, '') // remove parts with *
+    .replace(/[/\\][^/\\]*[!+]\(.*$/, '') // remove parts with !(...) and +(...)
     .replace(/[/\\][^/\\]*\)\?.*$/, '') || DIR_SEP // remove parts with (...)?
 }
 

--- a/test/client/stringify.spec.js
+++ b/test/client/stringify.spec.js
@@ -4,6 +4,10 @@ var assert = require('assert')
 var stringify = require('../../common/stringify')
 
 describe('stringify', function () {
+  it('should serialize symbols', function () {
+    assert.deepEqual(stringify(Symbol.for('x')), "Symbol('x')")
+  })
+
   it('should serialize string', function () {
     assert.deepEqual(stringify('aaa'), "'aaa'")
   })

--- a/test/unit/middleware/proxy.spec.js
+++ b/test/unit/middleware/proxy.spec.js
@@ -346,8 +346,8 @@ describe('middleware.proxy', () => {
     }
     var parsedProxyConfig = m.parseProxyConfig(proxy, config)
     expect(parsedProxyConfig).to.have.length(1)
-    expect(parsedProxyConfig[0].proxy.listeners('proxyReq', true)).to.equal(true)
-    expect(parsedProxyConfig[0].proxy.listeners('proxyRes', true)).to.equal(true)
+    expect(!!parsedProxyConfig[0].proxy.listeners('proxyReq')).to.equal(true)
+    expect(!!parsedProxyConfig[0].proxy.listeners('proxyRes')).to.equal(true)
   })
 
   it('should handle empty proxy config', () => {

--- a/test/unit/preprocessor.spec.js
+++ b/test/unit/preprocessor.spec.js
@@ -64,7 +64,7 @@ describe('preprocessor', () => {
     })
 
     var injector = new di.Injector([{
-      'preprocessor:fake': ['factory', function () { return fakePreprocessor } ]
+      'preprocessor:fake': ['factory', function () { return fakePreprocessor }]
     }, emitterSetting])
     pp = m.createPreprocessor({'**/*.js': ['fake']}, null, injector)
 


### PR DESCRIPTION
### Main fix

There were problems with using console.log while running test that resulted in errors like:
```
Chrome 66.0.3359 (Windows 7.0.0) moves should move rock box player up if they are adjacent one over each other FAILED
        TypeError: Cannot convert a Symbol value to a string
            at <Jasmine>
            at ContextKarma.stringify (http://localhost:9876/context.js:1804:34) // here stringify
            at ContextKarma.log (http://localhost:9876/context.js:1867:24)
            at <Jasmine>
            at Algorithm.resolveCell (src/game-00/main.test.ts:214654:13)
            at ordered.filter.obj (src/game-00/main.test.ts:214613:42)
            at <Jasmine>
            at Algorithm.update (src/game-00/main.test.ts:214613:23)
            at UserContext.it (src/game-00/main.test.ts:214494:19)
```
or 
```
TypeError: Cannot convert a Symbol value to a string
        at ContextKarma.stringify (context.js:75:34) // here stringify
        at ContextKarma.log (context.js:138:24)
        at console.localConsole.(anonymous function) [as log] (context.js:242:16)
        at Context.<anonymous> (test.webpack.js:9:576885)
```

### Additional fixes

While testing i noticed error with proxy tests fixed them to properly use listeners.

And also I have run linter and found some issues that i have also fixed.
