### PR TITLE
Update chokidar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - 6
   - 8
   - 9
+  - 10
 
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
+    - nodejs_version: "10"
 
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -350,7 +350,7 @@
   "dependencies": {
     "bluebird": "^3.3.0",
     "body-parser": "^1.16.1",
-    "chokidar": "^1.4.1",
+    "chokidar": "^2.0.3",
     "colors": "^1.1.0",
     "combine-lists": "^1.0.0",
     "connect": "^3.6.0",


### PR DESCRIPTION
Old chokidar version depends on fsevents that fails to build on OSX with Node 10