### PR TITLE
fix: stringify error on 'Cannot convert a Symbol value to a string'

### DIFF
--- a/common/stringify.js
+++ b/common/stringify.js
@@ -14,6 +14,8 @@ var stringify = function stringify (obj, depth) {
   }
 
   switch (typeof obj) {
+    case 'symbol':
+      return obj.toString()
     case 'string':
       return "'" + obj + "'"
     case 'undefined':

--- a/test/client/stringify.spec.js
+++ b/test/client/stringify.spec.js
@@ -4,6 +4,10 @@ var assert = require('assert')
 var stringify = require('../../common/stringify')
 
 describe('stringify', function () {
+  it('should serialize symbols', function () {
+    assert.deepEqual(stringify(Symbol.for('x')), 'Symbol(x)')
+  })
+
   it('should serialize string', function () {
     assert.deepEqual(stringify('aaa'), "'aaa'")
   })


### PR DESCRIPTION
There were problems with using console.log while running test that resulted in errors like:
```
Chrome 66.0.3359 (Windows 7.0.0) moves should move rock box player up if they are adjacent one over each other FAILED
        TypeError: Cannot convert a Symbol value to a string
            at <Jasmine>
            at ContextKarma.stringify (http://localhost:9876/context.js:1804:34) // here stringify
            at ContextKarma.log (http://localhost:9876/context.js:1867:24)
            at <Jasmine>
            at Algorithm.resolveCell (src/game-00/main.test.ts:214654:13)
            at ordered.filter.obj (src/game-00/main.test.ts:214613:42)
            at <Jasmine>
            at Algorithm.update (src/game-00/main.test.ts:214613:23)
            at UserContext.it (src/game-00/main.test.ts:214494:19)
```
or
```
TypeError: Cannot convert a Symbol value to a string
        at ContextKarma.stringify (context.js:75:34) // here stringify
        at ContextKarma.log (context.js:138:24)
        at console.localConsole.(anonymous function) [as log] (context.js:242:16)
        at Context.<anonymous> (test.webpack.js:9:576885)
```

Related to issue: https://github.com/karma-runner/karma/issues/2856

I have also noticed that i need to remove `static/context.js` and `static/karma.js` from `.gitignore` and include them in the repo so that this fix worked on my repository copy but didn't include it here as I am not sure they are built at some later point.