### PR TITLE
config: setup 'arrow-parens' eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "standard"
+  "extends": "standard",
+  "rules": {
+    "arrow-parens": [2, "always"]
+  }
 }

--- a/lib/init/formatters.js
+++ b/lib/init/formatters.js
@@ -13,21 +13,21 @@ function formatLine (items) {
 
 function formatMultiLines (items) {
   return items
-    .map(file => '\n      ' + file)
+    .map((file) => '\n      ' + file)
     .join(',')
 }
 
 function formatFiles (includedFiles, onlyServedFiles) {
   const lines = []
     .concat(includedFiles.map(quote))
-    .concat(onlyServedFiles.map(file => `{ pattern: ${quote(file)}, included: false }`))
+    .concat(onlyServedFiles.map((file) => `{ pattern: ${quote(file)}, included: false }`))
 
   return formatMultiLines(lines)
 }
 
 function formatPreprocessors (preprocessors) {
   const lines = Object.keys(preprocessors)
-    .map(pattern => `${quote(pattern)}: [${formatLine(preprocessors[pattern])}]`)
+    .map((pattern) => `${quote(pattern)}: [${formatLine(preprocessors[pattern])}]`)
 
   return formatMultiLines(lines)
 }

--- a/lib/init/log-queue.js
+++ b/lib/init/log-queue.js
@@ -2,7 +2,7 @@
 
 const logQueue = []
 function printLogQueue () {
-  logQueue.forEach(log => log())
+  logQueue.forEach((log) => log())
   logQueue.length = 0
 }
 


### PR DESCRIPTION
As discussed with @johnjbarton [here](https://github.com/karma-runner/karma/pull/3012#discussion_r190129318) this rule will force us to use parens in arrow functions.