### PR TITLE
Prepare BaseReporter for conversion to class

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -1,23 +1,43 @@
-var util = require('util')
+'use strict'
 
-var constants = require('../constants')
-var helper = require('../helper')
+const util = require('util')
+
+const constants = require('../constants')
+const helper = require('../helper')
 
 var BaseReporter = function (formatError, reportSlow, useColors, browserConsoleLogOptions, adapter) {
   this.adapters = [adapter || process.stdout.write.bind(process.stdout)]
 
-  this.onRunStart = function () {
+  this.USE_COLORS = false
+  this.EXCLUSIVELY_USE_COLORS = undefined
+  this.LOG_SINGLE_BROWSER = '%s: %s\n'
+  this.LOG_MULTI_BROWSER = '%s %s: %s\n'
+
+  this.SPEC_FAILURE = '%s %s FAILED' + '\n'
+  this.SPEC_SLOW = '%s SLOW %s: %s\n'
+  this.ERROR = '%s ERROR\n'
+
+  this.FINISHED_ERROR = ' ERROR'
+  this.FINISHED_SUCCESS = ' SUCCESS'
+  this.FINISHED_DISCONNECTED = ' DISCONNECTED'
+
+  this.X_FAILED = ' (%d FAILED)'
+
+  this.TOTAL_SUCCESS = 'TOTAL: %d SUCCESS\n'
+  this.TOTAL_FAILED = 'TOTAL: %d FAILED, %d SUCCESS\n'
+
+  this.onRunStart = () => {
     this._browsers = []
   }
 
-  this.onBrowserStart = function (browser) {
+  this.onBrowserStart = (browser) => {
     this._browsers.push(browser)
   }
 
-  this.renderBrowser = function (browser) {
-    var results = browser.lastResult
-    var totalExecuted = results.success + results.failed
-    var msg = util.format('%s: Executed %d of %d', browser, totalExecuted, results.total)
+  this.renderBrowser = (browser) => {
+    const results = browser.lastResult
+    const totalExecuted = results.success + results.failed
+    let msg = util.format('%s: Executed %d of %d', browser, totalExecuted, results.total)
 
     if (results.failed) {
       msg += util.format(this.X_FAILED, results.failed)
@@ -43,32 +63,31 @@ var BaseReporter = function (formatError, reportSlow, useColors, browserConsoleL
     return msg
   }
 
-  this.renderBrowser = this.renderBrowser.bind(this)
-
   this.write = function () {
-    var msg = util.format.apply(null, Array.prototype.slice.call(arguments))
-    var self = this
-    this.adapters.forEach(function (adapter) {
+    const msg = util.format.apply(null, Array.prototype.slice.call(arguments))
+    this.adapters.forEach((adapter) => {
       if (!helper.isDefined(adapter.colors)) {
         adapter.colors = useColors
       }
-      if (!helper.isDefined(self.EXCLUSIVELY_USE_COLORS) || adapter.colors === self.EXCLUSIVELY_USE_COLORS) {
+      if (!helper.isDefined(this.EXCLUSIVELY_USE_COLORS) || adapter.colors === this.EXCLUSIVELY_USE_COLORS) {
         return adapter(msg)
       }
     })
   }
 
-  this.writeCommonMsg = this.write
+  this.writeCommonMsg = function () {
+    this.write.apply(this, arguments)
+  }
 
-  this.onBrowserError = function (browser, error) {
+  this.onBrowserError = (browser, error) => {
     this.writeCommonMsg(util.format(this.ERROR, browser) + formatError(error, '  '))
   }
 
-  this.onBrowserLog = function (browser, log, type) {
+  this.onBrowserLog = (browser, log, type) => {
     if (!browserConsoleLogOptions || !browserConsoleLogOptions.terminal) return
     type = type.toUpperCase()
     if (browserConsoleLogOptions.level) {
-      var logPriority = constants.LOG_PRIORITIES.indexOf(browserConsoleLogOptions.level.toUpperCase())
+      const logPriority = constants.LOG_PRIORITIES.indexOf(browserConsoleLogOptions.level.toUpperCase())
       if (constants.LOG_PRIORITIES.indexOf(type) > logPriority) return
     }
     if (!helper.isString(log)) {
@@ -82,7 +101,7 @@ var BaseReporter = function (formatError, reportSlow, useColors, browserConsoleL
     }
   }
 
-  this.onSpecComplete = function (browser, result) {
+  this.onSpecComplete = (browser, result) => {
     if (result.skipped) {
       this.specSkipped(browser, result)
     } else if (result.success) {
@@ -92,28 +111,31 @@ var BaseReporter = function (formatError, reportSlow, useColors, browserConsoleL
     }
 
     if (reportSlow && result.time > reportSlow) {
-      var specName = result.suite.join(' ') + ' ' + result.description
-      var time = helper.formatTimeInterval(result.time)
+      const specName = result.suite.join(' ') + ' ' + result.description
+      const time = helper.formatTimeInterval(result.time)
 
       this.writeCommonMsg(util.format(this.SPEC_SLOW, browser, time, specName))
     }
   }
 
-  this.specSuccess = this.specSkipped = function () {
+  this.specSuccess = () => {
   }
 
-  this.specFailure = function (browser, result) {
-    var specName = result.suite.join(' ') + ' ' + result.description
-    var msg = util.format(this.SPEC_FAILURE, browser, specName)
+  this.specSkipped = () => {
+  }
 
-    result.log.forEach(function (log) {
+  this.specFailure = (browser, result) => {
+    const specName = result.suite.join(' ') + ' ' + result.description
+    let msg = util.format(this.SPEC_FAILURE, browser, specName)
+
+    result.log.forEach((log) => {
       msg += formatError(log, '\t')
     })
 
     this.writeCommonMsg(msg)
   }
 
-  this.onRunComplete = function (browsers, results) {
+  this.onRunComplete = (browsers, results) => {
     if (browsers.length > 1 && !results.error && !results.disconnected) {
       if (!results.failed) {
         this.write(this.TOTAL_SUCCESS, results.success)
@@ -122,24 +144,6 @@ var BaseReporter = function (formatError, reportSlow, useColors, browserConsoleL
       }
     }
   }
-
-  this.USE_COLORS = false
-  this.EXCLUSIVELY_USE_COLORS = undefined
-  this.LOG_SINGLE_BROWSER = '%s: %s\n'
-  this.LOG_MULTI_BROWSER = '%s %s: %s\n'
-
-  this.SPEC_FAILURE = '%s %s FAILED' + '\n'
-  this.SPEC_SLOW = '%s SLOW %s: %s\n'
-  this.ERROR = '%s ERROR\n'
-
-  this.FINISHED_ERROR = ' ERROR'
-  this.FINISHED_SUCCESS = ' SUCCESS'
-  this.FINISHED_DISCONNECTED = ' DISCONNECTED'
-
-  this.X_FAILED = ' (%d FAILED)'
-
-  this.TOTAL_SUCCESS = 'TOTAL: %d SUCCESS\n'
-  this.TOTAL_FAILED = 'TOTAL: %d FAILED, %d SUCCESS\n'
 }
 
 BaseReporter.decoratorFactory = function (formatError, reportSlow, useColors, browserConsoleLogOptions) {

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -5,7 +5,7 @@ const util = require('util')
 const constants = require('../constants')
 const helper = require('../helper')
 
-var BaseReporter = function (formatError, reportSlow, useColors, browserConsoleLogOptions, adapter) {
+const BaseReporter = function (formatError, reportSlow, useColors, browserConsoleLogOptions, adapter) {
   this.adapters = [adapter || process.stdout.write.bind(process.stdout)]
 
   this.USE_COLORS = false

--- a/test/unit/reporters/base.spec.js
+++ b/test/unit/reporters/base.spec.js
@@ -1,26 +1,26 @@
-var path = require('path')
+const path = require('path')
 
-describe('reporter', function () {
-  var loadFile = require('mocks').loadFile
-  var m = null
+describe('reporter', () => {
+  const loadFile = require('mocks').loadFile
+  let m = null
 
-  beforeEach(function () {
+  beforeEach(() => {
     m = loadFile(path.join(__dirname, '/../../../lib/reporters/base.js'))
     return m
   })
 
-  return describe('Progress', function () {
-    var reporter
-    var adapter = reporter = null
+  return describe('Progress', () => {
+    let reporter
+    let adapter = reporter = null
 
-    beforeEach(function () {
+    beforeEach(() => {
       adapter = sinon.spy()
       reporter = new m.BaseReporter(null, null, false, {terminal: true}, adapter)
       return reporter
     })
 
-    it('should write to all registered adapters', function () {
-      var anotherAdapter = sinon.spy()
+    it('should write to all registered adapters', () => {
+      const anotherAdapter = sinon.spy()
       reporter.adapters.push(anotherAdapter)
 
       reporter.write('some')
@@ -28,8 +28,8 @@ describe('reporter', function () {
       return expect(anotherAdapter).to.have.been.calledWith('some')
     })
 
-    it('should omit adapters not using the right color', function () {
-      var anotherAdapter = sinon.spy()
+    it('should omit adapters not using the right color', () => {
+      const anotherAdapter = sinon.spy()
       anotherAdapter.colors = true
       reporter.EXCLUSIVELY_USE_COLORS = false
       reporter.adapters.push(anotherAdapter)
@@ -38,9 +38,9 @@ describe('reporter', function () {
       return expect(anotherAdapter).to.not.have.been.called
     })
 
-    it('should not call non-colored adapters when wrong default setting', function () {
-      var reporter = new m.BaseReporter(null, null, true, {}, adapter)
-      var anotherAdapter = sinon.spy()
+    it('should not call non-colored adapters when wrong default setting', () => {
+      const reporter = new m.BaseReporter(null, null, true, {}, adapter)
+      const anotherAdapter = sinon.spy()
       reporter.adapters.push(anotherAdapter)
       reporter.EXCLUSIVELY_USE_COLORS = false
       reporter.write('some')
@@ -48,9 +48,9 @@ describe('reporter', function () {
       return expect(anotherAdapter).to.not.have.been.called
     })
 
-    it('should call colored adapters regardless of default setting', function () {
-      var reporter = new m.BaseReporter(null, null, true, {}, adapter)
-      var anotherAdapter = sinon.spy()
+    it('should call colored adapters regardless of default setting', () => {
+      const reporter = new m.BaseReporter(null, null, true, {}, adapter)
+      const anotherAdapter = sinon.spy()
       reporter.adapters.push(anotherAdapter)
       reporter.EXCLUSIVELY_USE_COLORS = false
       adapter.colors = false
@@ -59,8 +59,8 @@ describe('reporter', function () {
       return expect(anotherAdapter).to.not.have.been.called
     })
 
-    it('should call all adapters if EXCLUSIVELY_USE_COLORS is undefined', function () {
-      var anotherAdapter = sinon.spy()
+    it('should call all adapters if EXCLUSIVELY_USE_COLORS is undefined', () => {
+      const anotherAdapter = sinon.spy()
       anotherAdapter.colors = true
       reporter.adapters.push(anotherAdapter)
       reporter.write('some')
@@ -68,14 +68,14 @@ describe('reporter', function () {
       expect(anotherAdapter).to.have.been.calledWith('some')
     })
 
-    it('should format', function () {
+    it('should format', () => {
       reporter.write('Success: %d Failure: %d', 10, 20)
 
       return expect(adapter).to.have.been.calledWith('Success: 10 Failure: 20')
     })
 
-    it('should format log messages correctly for single browser', function () {
-      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+    it('should format log messages correctly for single browser', () => {
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome']
       reporter.onBrowserLog('Chrome', 'Message', 'LOG')
@@ -83,12 +83,12 @@ describe('reporter', function () {
       return expect(writeSpy).to.have.been.calledWith('LOG: Message\n')
     })
 
-    it('should not log if lower priority than browserConsoleLogOptions "error"', function () {
-      var reporter = new m.BaseReporter(null, null, true, {
+    it('should not log if lower priority than browserConsoleLogOptions "error"', () => {
+      const reporter = new m.BaseReporter(null, null, true, {
         level: 'error',
         terminal: true
       }, adapter)
-      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome']
       reporter.onBrowserLog('Chrome', 'Message', 'WARN')
@@ -96,12 +96,12 @@ describe('reporter', function () {
       return writeSpy.should.have.not.been.called
     })
 
-    it('should not log if lower priority than browserConsoleLogOptions "warn"', function () {
-      var reporter = new m.BaseReporter(null, null, true, {
+    it('should not log if lower priority than browserConsoleLogOptions "warn"', () => {
+      const reporter = new m.BaseReporter(null, null, true, {
         level: 'warn',
         terminal: true
       }, adapter)
-      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome']
       reporter.onBrowserLog('Chrome', 'Message', 'LOG')
@@ -109,12 +109,12 @@ describe('reporter', function () {
       return writeSpy.should.have.not.been.called
     })
 
-    it('should not log if lower priority than browserConsoleLogOptions "log"', function () {
-      var reporter = new m.BaseReporter(null, null, true, {
+    it('should not log if lower priority than browserConsoleLogOptions "log"', () => {
+      const reporter = new m.BaseReporter(null, null, true, {
         level: 'log',
         terminal: true
       }, adapter)
-      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome']
       reporter.onBrowserLog('Chrome', 'Message', 'INFO')
@@ -122,12 +122,12 @@ describe('reporter', function () {
       return writeSpy.should.have.not.been.called
     })
 
-    it('should not log if lower priority than browserConsoleLogOptions "info"', function () {
-      var reporter = new m.BaseReporter(null, null, true, {
+    it('should not log if lower priority than browserConsoleLogOptions "info"', () => {
+      const reporter = new m.BaseReporter(null, null, true, {
         level: 'info',
         terminal: true
       }, adapter)
-      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome']
       reporter.onBrowserLog('Chrome', 'Message', 'DEBUG')
@@ -135,12 +135,12 @@ describe('reporter', function () {
       return writeSpy.should.have.not.been.called
     })
 
-    it('should log if higher priority than browserConsoleLogOptions "warn"', function () {
-      var reporter = new m.BaseReporter(null, null, true, {
+    it('should log if higher priority than browserConsoleLogOptions "warn"', () => {
+      const reporter = new m.BaseReporter(null, null, true, {
         level: 'warn',
         terminal: true
       }, adapter)
-      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome']
       reporter.onBrowserLog('Chrome', 'Message', 'ERROR')
@@ -148,12 +148,12 @@ describe('reporter', function () {
       return writeSpy.should.have.been.called
     })
 
-    it('should log if higher priority than browserConsoleLogOptions "log"', function () {
-      var reporter = new m.BaseReporter(null, null, true, {
+    it('should log if higher priority than browserConsoleLogOptions "log"', () => {
+      const reporter = new m.BaseReporter(null, null, true, {
         level: 'log',
         terminal: true
       }, adapter)
-      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome']
       reporter.onBrowserLog('Chrome', 'Message', 'WARN')
@@ -161,12 +161,12 @@ describe('reporter', function () {
       return writeSpy.should.have.been.called
     })
 
-    it('should log if higher priority than browserConsoleLogOptions "info"', function () {
-      var reporter = new m.BaseReporter(null, null, true, {
+    it('should log if higher priority than browserConsoleLogOptions "info"', () => {
+      const reporter = new m.BaseReporter(null, null, true, {
         level: 'info',
         terminal: true
       }, adapter)
-      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome']
       reporter.onBrowserLog('Chrome', 'Message', 'LOG')
@@ -174,12 +174,12 @@ describe('reporter', function () {
       return writeSpy.should.have.been.called
     })
 
-    it('should log if higher priority than browserConsoleLogOptions "debug"', function () {
-      var reporter = new m.BaseReporter(null, null, true, {
+    it('should log if higher priority than browserConsoleLogOptions "debug"', () => {
+      const reporter = new m.BaseReporter(null, null, true, {
         level: 'debug',
         terminal: true
       }, adapter)
-      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome']
       reporter.onBrowserLog('Chrome', 'Message', 'INFO')
@@ -187,8 +187,8 @@ describe('reporter', function () {
       return writeSpy.should.have.been.called
     })
 
-    return it('should format log messages correctly for multi browsers', function () {
-      var writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+    return it('should format log messages correctly for multi browsers', () => {
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome', 'Firefox']
       reporter.onBrowserLog('Chrome', 'Message', 'LOG')

--- a/test/unit/reporters/base.spec.js
+++ b/test/unit/reporters/base.spec.js
@@ -1,21 +1,15 @@
-const path = require('path')
+'use strict'
 
 describe('reporter', () => {
-  const loadFile = require('mocks').loadFile
-  let m = null
+  const BaseReporter = require('../../../lib/reporters/base')
 
-  beforeEach(() => {
-    m = loadFile(path.join(__dirname, '/../../../lib/reporters/base.js'))
-    return m
-  })
-
-  return describe('Progress', () => {
+  describe('Progress', () => {
     let reporter
     let adapter = reporter = null
 
     beforeEach(() => {
       adapter = sinon.spy()
-      reporter = new m.BaseReporter(null, null, false, {terminal: true}, adapter)
+      reporter = new BaseReporter(null, null, false, {terminal: true}, adapter)
       return reporter
     })
 
@@ -39,7 +33,7 @@ describe('reporter', () => {
     })
 
     it('should not call non-colored adapters when wrong default setting', () => {
-      const reporter = new m.BaseReporter(null, null, true, {}, adapter)
+      const reporter = new BaseReporter(null, null, true, {}, adapter)
       const anotherAdapter = sinon.spy()
       reporter.adapters.push(anotherAdapter)
       reporter.EXCLUSIVELY_USE_COLORS = false
@@ -49,7 +43,7 @@ describe('reporter', () => {
     })
 
     it('should call colored adapters regardless of default setting', () => {
-      const reporter = new m.BaseReporter(null, null, true, {}, adapter)
+      const reporter = new BaseReporter(null, null, true, {}, adapter)
       const anotherAdapter = sinon.spy()
       reporter.adapters.push(anotherAdapter)
       reporter.EXCLUSIVELY_USE_COLORS = false
@@ -84,7 +78,7 @@ describe('reporter', () => {
     })
 
     it('should not log if lower priority than browserConsoleLogOptions "error"', () => {
-      const reporter = new m.BaseReporter(null, null, true, {
+      const reporter = new BaseReporter(null, null, true, {
         level: 'error',
         terminal: true
       }, adapter)
@@ -97,7 +91,7 @@ describe('reporter', () => {
     })
 
     it('should not log if lower priority than browserConsoleLogOptions "warn"', () => {
-      const reporter = new m.BaseReporter(null, null, true, {
+      const reporter = new BaseReporter(null, null, true, {
         level: 'warn',
         terminal: true
       }, adapter)
@@ -110,7 +104,7 @@ describe('reporter', () => {
     })
 
     it('should not log if lower priority than browserConsoleLogOptions "log"', () => {
-      const reporter = new m.BaseReporter(null, null, true, {
+      const reporter = new BaseReporter(null, null, true, {
         level: 'log',
         terminal: true
       }, adapter)
@@ -123,7 +117,7 @@ describe('reporter', () => {
     })
 
     it('should not log if lower priority than browserConsoleLogOptions "info"', () => {
-      const reporter = new m.BaseReporter(null, null, true, {
+      const reporter = new BaseReporter(null, null, true, {
         level: 'info',
         terminal: true
       }, adapter)
@@ -136,7 +130,7 @@ describe('reporter', () => {
     })
 
     it('should log if higher priority than browserConsoleLogOptions "warn"', () => {
-      const reporter = new m.BaseReporter(null, null, true, {
+      const reporter = new BaseReporter(null, null, true, {
         level: 'warn',
         terminal: true
       }, adapter)
@@ -149,7 +143,7 @@ describe('reporter', () => {
     })
 
     it('should log if higher priority than browserConsoleLogOptions "log"', () => {
-      const reporter = new m.BaseReporter(null, null, true, {
+      const reporter = new BaseReporter(null, null, true, {
         level: 'log',
         terminal: true
       }, adapter)
@@ -162,7 +156,7 @@ describe('reporter', () => {
     })
 
     it('should log if higher priority than browserConsoleLogOptions "info"', () => {
-      const reporter = new m.BaseReporter(null, null, true, {
+      const reporter = new BaseReporter(null, null, true, {
         level: 'info',
         terminal: true
       }, adapter)
@@ -175,7 +169,7 @@ describe('reporter', () => {
     })
 
     it('should log if higher priority than browserConsoleLogOptions "debug"', () => {
-      const reporter = new m.BaseReporter(null, null, true, {
+      const reporter = new BaseReporter(null, null, true, {
         level: 'debug',
         terminal: true
       }, adapter)


### PR DESCRIPTION
Converted to ES2015 syntax and re-arranged code a bit, so conversation to real class won't produce hard to review diff.

In tests import BaseReporter directly instead of using `mocks`. This was unnecessary complexity.