### PR TITLE
refactor: update eslint configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "standard",
   "rules": {
-    "arrow-parens": [2, "always"]
+    "arrow-parens": [2, "always"],
+    "space-before-function-paren": ["error", "always"]
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -431,7 +431,7 @@ function parseConfig (configFilePath, cliOptions) {
   if (config.hostname === null && config.listenAddress !== null) {
     log.warn('ListenAddress was set to %s but hostname was left as the default: ' +
       '%s. If your browsers fail to connect, consider changing the hostname option.',
-      config.listenAddress, defaultHostname)
+    config.listenAddress, defaultHostname)
   }
   // restore values that weren't overwritten by the user
   if (config.hostname === null) {

--- a/lib/init.js
+++ b/lib/init.js
@@ -123,7 +123,7 @@ var questions = [{
   hint: 'This will generate test-main.js/coffee that configures RequireJS and starts the tests.',
   options: ['no', 'yes'],
   boolean: true,
-  condition: answers => answers.requirejs
+  condition: (answers) => answers.requirejs
 }, {
   id: 'includedFiles',
   question: 'Which files do you want to include with <script> tag ?',
@@ -132,7 +132,7 @@ var questions = [{
     'Enter empty string to move to the next question.',
   multiple: true,
   validate: validatePattern,
-  condition: answers => answers.requirejs && !answers.generateTestMain
+  condition: (answers) => answers.requirejs && !answers.generateTestMain
 }, {
   id: 'autoWatch',
   question: 'Do you want Karma to watch all the files and run the tests on change ?',
@@ -191,7 +191,7 @@ function processAnswers (answers, basePath, testMainFile) {
   }
 
   const allPatterns = answers.files.concat(answers.includedFiles || [])
-  if (allPatterns.some(pattern => mm(pattern, '**/*.coffee'))) {
+  if (allPatterns.some((pattern) => mm(pattern, '**/*.coffee'))) {
     installPackage('karma-coffee-preprocessor')
     processedAnswers.preprocessors['**/*.coffee'] = ['coffee']
   }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -43,7 +43,7 @@ var Launcher = function (server, emitter, injector) {
   this.launchSingle = function (protocol, hostname, port, urlRoot, upstreamProxy, processKillTimeout) {
     var self = this
     return function (name) {
-      name = (name + '').trim();
+      name = (name + '').trim()
       if (upstreamProxy) {
         protocol = upstreamProxy.protocol
         hostname = upstreamProxy.hostname

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -45,7 +45,7 @@ var setup = function (level, colors, appenders) {
       })
     }
   } else {
-    appenders = {'console' : constant.CONSOLE_APPENDER}
+    appenders = {'console': constant.CONSOLE_APPENDER}
   }
 
   log4js.configure({
@@ -110,6 +110,6 @@ var create = function (name, level) {
 exports.create = create
 exports.setup = setup
 exports.setupFromConfig = setupFromConfig
-exports._rebindLog4js4testing = function(mockLog4js) {
+exports._rebindLog4js4testing = function (mockLog4js) {
   log4js = mockLog4js
 }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -79,7 +79,7 @@ var createErrorFormatter = function (config, emitter, SourceMapConsumer) {
           var sourcePath = resolve(path, original.source)
           var formattedColumn = column ? util.format(':%s', column) : ''
           return util.format('%s:%d:%d <- %s:%d%s', sourcePath, original.line, original.column,
-              path, line, formattedColumn)
+            path, line, formattedColumn)
         } catch (e) {
           log.warn('SourceMap position not found for trace: %s', msg)
           // Fall back to non-source-mapped formatting.

--- a/lib/server.js
+++ b/lib/server.js
@@ -75,7 +75,7 @@ var Server = function (cliOptions, done) {
   Object.keys(EventEmitter.prototype).forEach(function (method) {
     this[method] = EventEmitter.prototype[method]
   }, this)
-  
+
   this.bind = KarmaEventEmitter.prototype.bind.bind(this)
   this.emitAsync = KarmaEventEmitter.prototype.emitAsync.bind(this)
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -21,12 +21,12 @@ function watchPatterns (patterns, watcher) {
 
   // expand ['a/{b,c}'] to ['a/b', 'a/c']
   expandBraces(patterns)
-    .forEach(path => pathsToWatch.add(baseDirFromPattern(path)))
+    .forEach((path) => pathsToWatch.add(baseDirFromPattern(path)))
 
   pathsToWatch = Array.from(pathsToWatch)
   // watch only common parents, no sub paths
-  pathsToWatch.forEach(path => {
-    if (!pathsToWatch.some(p => p !== path && path.substr(0, p.length + 1) === p + DIR_SEP)) {
+  pathsToWatch.forEach((path) => {
+    if (!pathsToWatch.some((p) => p !== path && path.substr(0, p.length + 1) === p + DIR_SEP)) {
       watcher.add(path)
       log.debug('Watching "%s"', path)
     }
@@ -34,7 +34,7 @@ function watchPatterns (patterns, watcher) {
 }
 
 function checkAnyPathMatch (patterns, path) {
-  return patterns.some(pattern => mm(path, pattern, {dot: true}))
+  return patterns.some((pattern) => mm(path, pattern, {dot: true}))
 }
 
 function createIgnore (patterns, excludes) {
@@ -70,12 +70,12 @@ exports.watch = function (patterns, excludes, fileList, usePolling, emitter) {
   watchPatterns(watchedPatterns, watcher)
 
   watcher
-    .on('add', path => fileList.addFile(helper.normalizeWinPath(path)))
-    .on('change', path => fileList.changeFile(helper.normalizeWinPath(path)))
-    .on('unlink', path => fileList.removeFile(helper.normalizeWinPath(path)))
+    .on('add', (path) => fileList.addFile(helper.normalizeWinPath(path)))
+    .on('change', (path) => fileList.changeFile(helper.normalizeWinPath(path)))
+    .on('unlink', (path) => fileList.removeFile(helper.normalizeWinPath(path)))
     .on('error', log.debug.bind(log))
 
-  emitter.on('exit', done => {
+  emitter.on('exit', (done) => {
     watcher.close()
     done()
   })

--- a/package.json
+++ b/package.json
@@ -455,7 +455,8 @@
   "version": "2.0.2",
   "license": "MIT",
   "scripts": {
-    "lint": "eslint client/**/*.js common/**/*.js context/**/*.js gruntfile.js wallaby.js lib/**/*.js test/unit/**/*.js test/client/*.js test/e2e/**/*.js static/debug.js",
+    "lint": "eslint . --ext js --ignore-pattern *.tpl.js",
+    "lint:fix": "eslint . --ext js --ignore-pattern *.tpl.js --fix",
     "test": "grunt test",
     "build": "grunt build",
     "test:appveyor": "grunt test-appveyor",

--- a/test/unit/preprocessor.spec.js
+++ b/test/unit/preprocessor.spec.js
@@ -64,7 +64,7 @@ describe('preprocessor', () => {
     })
 
     var injector = new di.Injector([{
-      'preprocessor:fake': ['factory', function () { return fakePreprocessor } ]
+      'preprocessor:fake': ['factory', function () { return fakePreprocessor }]
     }, emitterSetting])
     pp = m.createPreprocessor({'**/*.js': ['fake']}, null, injector)
 

--- a/test/unit/server.spec.js
+++ b/test/unit/server.spec.js
@@ -93,7 +93,7 @@ describe('server', () => {
         callback && callback()
       }),
       removeAllListeners: () => {},
-      close: sinon.spy(callback => callback && callback())
+      close: sinon.spy((callback) => callback && callback())
     }
 
     sinon.stub(server._injector, 'get')


### PR DESCRIPTION
This pull request updates eslint configuration a bit, main changes:
- add `space-before-function-paren` rule to prevent code style changes like [here](https://github.com/karma-runner/karma/pull/2973/files#r190820886)
- I noticed that files `lib/*.js` was not linted by previous configuration, so I updated `npm run lint` script, and fixed a few lint issues
- added `npm run lint:fix` script to make it easier to fix things by developer on localhost