### PR TITLE
Revert "fix: stringify error on 'Cannot convert a Symbol value to a string'"

### DIFF
--- a/common/stringify.js
+++ b/common/stringify.js
@@ -14,8 +14,6 @@ var stringify = function stringify (obj, depth) {
   }
 
   switch (typeof obj) {
-    case 'symbol':
-      return obj.toString()
     case 'string':
       return "'" + obj + "'"
     case 'undefined':

--- a/test/client/stringify.spec.js
+++ b/test/client/stringify.spec.js
@@ -4,10 +4,6 @@ var assert = require('assert')
 var stringify = require('../../common/stringify')
 
 describe('stringify', function () {
-  it('should serialize symbols', function () {
-    assert.deepEqual(stringify(Symbol.for('x')), 'Symbol(x)')
-  })
-
   it('should serialize string', function () {
     assert.deepEqual(stringify('aaa'), "'aaa'")
   })


### PR DESCRIPTION
Reverts karma-runner/karma#2990

The tests fail on IE-win7 and win10. because the platform does not support "Symbol".

I do not understand why the tests passed before and github does not seem to keep the test results after a merge 👎  