### PR TITLE
refactor: unify style of functions declarations

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -2,7 +2,7 @@ var stringify = require('../common/stringify')
 var constant = require('./constants')
 var util = require('../common/util')
 
-var Karma = function (socket, iframe, opener, navigator, location) {
+function Karma (socket, iframe, opener, navigator, location) {
   var startEmitted = false
   var reloadingContext = false
   var self = this
@@ -47,7 +47,7 @@ var Karma = function (socket, iframe, opener, navigator, location) {
   }
 
   var childWindow = null
-  var navigateContextTo = function (url) {
+  function navigateContextTo (url) {
     if (self.config.useIframe === false) {
       // run in new window
       if (self.config.runInParent === false) {
@@ -98,7 +98,7 @@ var Karma = function (socket, iframe, opener, navigator, location) {
 
   this.stringify = stringify
 
-  var clearContext = function () {
+  function clearContext () {
     reloadingContext = true
 
     navigateContextTo('about:blank')

--- a/client/updater.js
+++ b/client/updater.js
@@ -1,7 +1,7 @@
 var VERSION = require('./constants').VERSION
 
-var StatusUpdater = function (socket, titleElement, bannerElement, browsersElement) {
-  var updateBrowsersInfo = function (browsers) {
+function StatusUpdater (socket, titleElement, bannerElement, browsersElement) {
+  function updateBrowsersInfo (browsers) {
     if (!browsersElement) {
       return
     }
@@ -14,7 +14,7 @@ var StatusUpdater = function (socket, titleElement, bannerElement, browsersEleme
     browsersElement.innerHTML = items.join('\n')
   }
 
-  var updateBanner = function (status) {
+  function updateBanner (status) {
     return function (param) {
       if (!titleElement || !bannerElement) {
         return

--- a/common/stringify.js
+++ b/common/stringify.js
@@ -1,10 +1,11 @@
 var serialize = require('dom-serialize')
 var instanceOf = require('./util').instanceOf
-var isNode = function (obj) {
+
+function isNode (obj) {
   return (obj.tagName || obj.nodeName) && obj.nodeType
 }
 
-var stringify = function stringify (obj, depth) {
+function stringify (obj, depth) {
   if (depth === 0) {
     return '...'
   }

--- a/context/karma.js
+++ b/context/karma.js
@@ -2,7 +2,7 @@
 var stringify = require('../common/stringify')
 
 // Define our context Karma constructor
-var ContextKarma = function (callParentKarmaMethod) {
+function ContextKarma (callParentKarmaMethod) {
   // Define local variables
   var hasError = false
   var self = this
@@ -30,7 +30,7 @@ var ContextKarma = function (callParentKarmaMethod) {
   }
 
   // Define our start handler
-  var UNIMPLEMENTED_START = function () {
+  function UNIMPLEMENTED_START () {
     this.error('You need to include some adapter that implements __karma__.start method!')
   }
   // all files loaded, let's start the execution
@@ -98,7 +98,7 @@ var ContextKarma = function (callParentKarmaMethod) {
     }
 
     // If we want to overload our console, then do it
-    var getConsole = function (currentWindow) {
+    function getConsole (currentWindow) {
       return currentWindow.console || {
         log: function () {},
         info: function () {},

--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -458,7 +458,7 @@ The plugin must provide an express/connect middleware function (details about th
 
 **Example:**
 ```javascript
-var CustomMiddlewareFactory = function (config) {
+function CustomMiddlewareFactory (config) {
   return function (request, response, /* next */) {
     response.writeHead(200)
     return response.end("content!")

--- a/lib/launchers/base.js
+++ b/lib/launchers/base.js
@@ -15,7 +15,7 @@ var BEING_FORCE_KILLED = 6
 /**
  * Base launcher that any custom launcher extends.
  */
-var BaseLauncher = function (id, emitter) {
+function BaseLauncher (id, emitter) {
   if (this.start) {
     return
   }

--- a/lib/launchers/capture_timeout.js
+++ b/lib/launchers/capture_timeout.js
@@ -3,7 +3,7 @@ var log = require('../logger').create('launcher')
 /**
  * Kill browser if it does not capture in given `captureTimeout`.
  */
-var CaptureTimeoutLauncher = function (timer, captureTimeout) {
+function CaptureTimeoutLauncher (timer, captureTimeout) {
   if (!captureTimeout) {
     return
   }

--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -2,7 +2,7 @@ var path = require('path')
 var log = require('../logger').create('launcher')
 var env = process.env
 
-var ProcessLauncher = function (spawn, tempDir, timer, processKillTimeout) {
+function ProcessLauncher (spawn, tempDir, timer, processKillTimeout) {
   var self = this
   var onExitCallback
   var killTimeout = processKillTimeout || 2000
@@ -164,7 +164,7 @@ ProcessLauncher.decoratorFactory = function (timer) {
   return function (launcher, processKillTimeout) {
     var spawn = require('child_process').spawn
 
-    var spawnWithoutOutput = function () {
+    function spawnWithoutOutput () {
       var proc = spawn.apply(null, arguments)
       proc.stdout.resume()
       proc.stderr.resume()

--- a/lib/launchers/retry.js
+++ b/lib/launchers/retry.js
@@ -1,6 +1,6 @@
 var log = require('../logger').create('launcher')
 
-var RetryLauncher = function (retryLimit) {
+function RetryLauncher (retryLimit) {
   var self = this
 
   this._retryLimit = retryLimit

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,7 +21,7 @@ var constant = require('./constants')
 //   to allow for fine grained configuration of log4js. For more information
 //   see https://github.com/nomiddlename/log4js-node.
 //   *Array* is also accepted for backwards compatibility.
-var setup = function (level, colors, appenders) {
+function setup (level, colors, appenders) {
   // Turn color on/off on the console appenders with pattern layout
   var pattern = colors ? constant.COLOR_PATTERN : constant.NO_COLOR_PATTERN
   if (appenders) {
@@ -69,7 +69,7 @@ var setup = function (level, colors, appenders) {
 //   to allow for fine grained configuration of log4js. For more information
 //   see https://github.com/nomiddlename/log4js-node.
 //   *Array* is also accepted for backwards compatibility.
-var setupFromConfig = function (config, appenders) {
+function setupFromConfig (config, appenders) {
   var useColors = true
   var logLevel = constant.LOG_INFO
 
@@ -90,7 +90,7 @@ const loggerCache = {}
 //   If the `name = 'socket.io'` this will create a special wrapper
 //   to be used as a logger for socket.io.
 // * `level`, which defaults to the global level.
-var create = function (name, level) {
+function create (name, level) {
   name = name || 'karma'
   var logger
   if (loggerCache.hasOwnProperty(name)) {

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -18,7 +18,7 @@ var _ = require('lodash')
 
 var log = require('../logger').create('middleware:karma')
 
-var urlparse = function (urlStr) {
+function urlparse (urlStr) {
   var urlObj = url.parse(urlStr, true)
   urlObj.query = urlObj.query || {}
   return urlObj
@@ -44,7 +44,7 @@ var FILE_TYPES = [
   'module'
 ]
 
-var filePathToUrlPath = function (filePath, basePath, urlRoot, proxyPath) {
+function filePathToUrlPath (filePath, basePath, urlRoot, proxyPath) {
   if (filePath.indexOf(basePath) === 0) {
     return proxyPath + urlRoot.substr(1) + 'base' + filePath.substr(basePath.length)
   }
@@ -52,7 +52,7 @@ var filePathToUrlPath = function (filePath, basePath, urlRoot, proxyPath) {
   return proxyPath + urlRoot.substr(1) + 'absolute' + filePath
 }
 
-var getXUACompatibleMetaElement = function (url) {
+function getXUACompatibleMetaElement (url) {
   var tag = ''
   var urlObj = urlparse(url)
   if (urlObj.query['x-ua-compatible']) {
@@ -62,7 +62,7 @@ var getXUACompatibleMetaElement = function (url) {
   return tag
 }
 
-var getXUACompatibleUrl = function (url) {
+function getXUACompatibleUrl (url) {
   var value = ''
   var urlObj = urlparse(url)
   if (urlObj.query['x-ua-compatible']) {
@@ -71,7 +71,7 @@ var getXUACompatibleUrl = function (url) {
   return value
 }
 
-var createKarmaMiddleware = function (
+function createKarmaMiddleware (
   filesPromise,
   serveStaticFile,
   serveFile,

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -4,8 +4,8 @@ var _ = require('lodash')
 
 var log = require('../logger').create('proxy')
 
-var parseProxyConfig = function (proxies, config) {
-  var endsWithSlash = function (str) {
+function parseProxyConfig (proxies, config) {
+  function endsWithSlash (str) {
     return str.substr(-1) === '/'
   }
 
@@ -96,16 +96,16 @@ var parseProxyConfig = function (proxies, config) {
  * @param urlRoot The URL root that karma is mounted on
  * @return {Function} handler function
  */
-var createProxyHandler = function (proxies, urlRoot) {
+function createProxyHandler (proxies, urlRoot) {
   if (!proxies.length) {
-    var nullProxy = function createNullProxy (request, response, next) {
+    const nullProxy = function (request, response, next) {
       return next()
     }
     nullProxy.upgrade = function upgradeNullProxy () {}
     return nullProxy
   }
 
-  var middleware = function createProxy (request, response, next) {
+  function createProxy (request, response, next) {
     var proxyRecord = _.find(proxies, function (p) {
       return request.url.indexOf(p.path) === 0
     })
@@ -119,7 +119,7 @@ var createProxyHandler = function (proxies, urlRoot) {
     proxyRecord.proxy.web(request, response)
   }
 
-  middleware.upgrade = function upgradeProxy (request, socket, head) {
+  createProxy.upgrade = function upgradeProxy (request, socket, head) {
     // special-case karma's route to avoid upgrading it
     if (request.url.indexOf(urlRoot) === 0) {
       log.debug('NOT upgrading proxyWebSocketRequest %s', request.url)
@@ -140,7 +140,7 @@ var createProxyHandler = function (proxies, urlRoot) {
     proxyRecord.proxy.ws(request, socket, head)
   }
 
-  return middleware
+  return createProxy
 }
 
 exports.create = function (/* config */config, /* config.proxies */proxies) {

--- a/lib/middleware/runner.js
+++ b/lib/middleware/runner.js
@@ -12,7 +12,7 @@ var constant = require('../constants')
 var json = require('body-parser').json()
 
 // TODO(vojta): disable when single-run mode
-var createRunnerMiddleware = function (emitter, fileList, capturedBrowsers, reporter, executor,
+function createRunnerMiddleware (emitter, fileList, capturedBrowsers, reporter, executor,
   /* config.protocol */ protocol, /* config.hostname */ hostname, /* config.port */
   port, /* config.urlRoot */ urlRoot, config) {
   return function (request, response, next) {

--- a/lib/middleware/stopper.js
+++ b/lib/middleware/stopper.js
@@ -4,7 +4,7 @@
 
 var log = require('../logger').create('middleware:stopper')
 
-var createStopperMiddleware = function (urlRoot) {
+function createStopperMiddleware (urlRoot) {
   return function (request, response, next) {
     if (request.url !== urlRoot + 'stop') return next()
     response.writeHead(200)

--- a/lib/middleware/strip_host.js
+++ b/lib/middleware/strip_host.js
@@ -3,7 +3,7 @@
  * This to handle requests that uses (normally over proxies) an absoluteURI as request path
  */
 
-var createStripHostMiddleware = function () {
+function createStripHostMiddleware () {
   return function (request, response, next) {
     function stripHostFromUrl (url) {
       return url.replace(/^http[s]?:\/\/([a-z\-.:\d]+)\//, '/')

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -6,13 +6,13 @@ var combineLists = require('combine-lists')
 
 var log = require('./logger').create('preprocess')
 
-var sha1 = function (data) {
+function sha1 (data) {
   var hash = crypto.createHash('sha1')
   hash.update(data)
   return hash.digest('hex')
 }
 
-var createNextProcessor = function (preprocessors, file, done) {
+function createNextProcessor (preprocessors, file, done) {
   return function nextPreprocessor (error, content) {
     // normalize B-C
     if (arguments.length === 1 && typeof error === 'string') {
@@ -37,14 +37,14 @@ var createNextProcessor = function (preprocessors, file, done) {
   }
 }
 
-var createPreprocessor = function (config, basePath, injector) {
+function createPreprocessor (config, basePath, injector) {
   var alreadyDisplayedErrors = {}
   var instances = {}
   var patterns = Object.keys(config)
 
   var emitter = injector.get('emitter')
 
-  var instantiatePreprocessor = function (name) {
+  function instantiatePreprocessor (name) {
     if (alreadyDisplayedErrors[name]) {
       return
     }

--- a/lib/reporters/base_color.js
+++ b/lib/reporters/base_color.js
@@ -1,6 +1,6 @@
 require('colors')
 
-var BaseColorReporter = function () {
+function BaseColorReporter () {
   this.USE_COLORS = true
 
   this.LOG_SINGLE_BROWSER = '%s: ' + '%s'.cyan + '\n'

--- a/lib/reporters/dots.js
+++ b/lib/reporters/dots.js
@@ -1,6 +1,6 @@
 var BaseReporter = require('./base')
 
-var DotsReporter = function (formatError, reportSlow, useColors, browserConsoleLogOptions) {
+function DotsReporter (formatError, reportSlow, useColors, browserConsoleLogOptions) {
   BaseReporter.call(this, formatError, reportSlow, useColors, browserConsoleLogOptions)
 
   var DOTS_WRAP = 80

--- a/lib/reporters/dots_color.js
+++ b/lib/reporters/dots_color.js
@@ -1,7 +1,7 @@
 var DotsReporter = require('./dots')
 var BaseColorReporter = require('./base_color')
 
-var DotsColorReporter = function (formatError, reportSlow, useColors, browserConsoleLogOptions) {
+function DotsColorReporter (formatError, reportSlow, useColors, browserConsoleLogOptions) {
   DotsReporter.call(this, formatError, reportSlow, useColors, browserConsoleLogOptions)
   BaseColorReporter.call(this)
   this.EXCLUSIVELY_USE_COLORS = true

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -1,6 +1,6 @@
 var BaseReporter = require('./base')
 
-var ProgressReporter = function (formatError, reportSlow, useColors, browserConsoleLogOptions) {
+function ProgressReporter (formatError, reportSlow, useColors, browserConsoleLogOptions) {
   BaseReporter.call(this, formatError, reportSlow, useColors, browserConsoleLogOptions)
 
   this.EXCLUSIVELY_USE_COLORS = false

--- a/lib/reporters/progress_color.js
+++ b/lib/reporters/progress_color.js
@@ -1,7 +1,7 @@
 var ProgressReporter = require('./progress')
 var BaseColorReporter = require('./base_color')
 
-var ProgressColorReporter = function (formatError, reportSlow, useColors, browserConsoleLogOptions) {
+function ProgressColorReporter (formatError, reportSlow, useColors, browserConsoleLogOptions) {
   ProgressReporter.call(this, formatError, reportSlow, useColors, browserConsoleLogOptions)
   BaseColorReporter.call(this)
   this.EXCLUSIVELY_USE_COLORS = true

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -12,7 +12,7 @@ module.exports = function (grunt) {
     var path = require('path')
     var cmd = path.join(__dirname, '..', 'bin', 'karma')
 
-    var spawnKarma = function (args, callback) {
+    function spawnKarma (args, callback) {
       grunt.log.writeln(['Running', cmd].concat(args).join(' '))
       var child
       if (process.platform === 'win32') {
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
       child.stderr.pipe(process.stderr)
     }
 
-    var exec = function (args, failMsg) {
+    function exec (args, failMsg) {
       spawnKarma(args, function (err, result, code) {
         if (code) {
           console.error(err)

--- a/test/client/karma.spec.js
+++ b/test/client/karma.spec.js
@@ -11,7 +11,7 @@ var MockSocket = require('./mocks').Socket
 describe('Karma', function () {
   var socket, k, ck, windowNavigator, windowLocation, windowStub, startSpy, iframe, clientWindow
 
-  var setTransportTo = function (transportName) {
+  function setTransportTo (transportName) {
     socket._setTransportNameTo(transportName)
     socket.emit('connect')
   }
@@ -72,7 +72,7 @@ describe('Karma', function () {
   })
 
   it('should remove reference to start even after syntax error', function () {
-    var ADAPTER_START_FN = function () {}
+    function ADAPTER_START_FN () {}
 
     ck.start = ADAPTER_START_FN
     ck.error('syntax error', '/some/file.js', 11)

--- a/test/client/mocks.js
+++ b/test/client/mocks.js
@@ -1,4 +1,4 @@
-var Emitter = function () {
+function Emitter () {
   var listeners = {}
 
   this.on = function (event, fn) {
@@ -22,7 +22,7 @@ var Emitter = function () {
   }
 }
 
-var MockSocket = function () {
+function MockSocket () {
   Emitter.call(this)
 
   this.socket = {transport: {name: 'websocket'}}

--- a/test/client/stringify.spec.js
+++ b/test/client/stringify.spec.js
@@ -28,7 +28,7 @@ describe('stringify', function () {
 
   it('should serialize functions', function () {
     function abc (a, b, c) { return 'whatever' }
-    var def = function (d, e, f) { return 'whatever' }
+    function def (d, e, f) { return 'whatever' }
 
     var abcString = stringify(abc)
     var partsAbc = ['function', 'abc', '(a, b, c)', '{ ... }']

--- a/test/e2e/step_definitions/core_steps.js
+++ b/test/e2e/step_definitions/core_steps.js
@@ -19,7 +19,7 @@ cucumber.defineSupportCode((a) => {
   var cleansingNeeded = true
   var additionalArgs = []
 
-  var cleanseIfNeeded = function () {
+  function cleanseIfNeeded () {
     if (cleansingNeeded) {
       try {
         rimraf.sync(tmpDir)

--- a/test/e2e/support/proxy.js
+++ b/test/e2e/support/proxy.js
@@ -1,7 +1,7 @@
 var http = require('http')
 var httpProxy = require('http-proxy')
 
-var Proxy = function () {
+function Proxy () {
   var self = this
   self.running = false
 

--- a/test/e2e/support/reconnecting/test.js
+++ b/test/e2e/support/reconnecting/test.js
@@ -1,7 +1,7 @@
 /* globals plus */
 describe('plus', function () {
   // super hacky way to get the actual socket to manipulate it...
-  var socket = function () {
+  function socket () {
     return window.parent.karma.socket
   }
 

--- a/test/e2e/support/tag/tag.js
+++ b/test/e2e/support/tag/tag.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-unused-vars */
-var isFirefoxBefore59 = function () {
+function isFirefoxBefore59 () {
   return typeof InstallTrigger !== 'undefined' && parseFloat(navigator.userAgent.match(/\d+\.\d+$/)) < 59
 }
 
-var containsJsTag = function () {
+function containsJsTag () {
   var scripts = document.getElementsByTagName('script')
   for (var i = 0; i < scripts.length; i++) {
     if (scripts[i].type.indexOf(';version=') > -1) {

--- a/test/unit/init/formatters.spec.js
+++ b/test/unit/init/formatters.spec.js
@@ -9,7 +9,7 @@ describe('init/formatters', () => {
     })
 
     describe('formatAnswers', () => {
-      var createAnswers = function (ans) {
+      function createAnswers (ans) {
         ans = ans || {}
         ans.frameworks = ans.frameworks || []
         ans.files = ans.files || []

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -86,7 +86,7 @@ describe('middleware.karma', () => {
     return req
   }
 
-  var callHandlerWith = function (urlPath, next) {
+  function callHandlerWith (urlPath, next) {
     var promise = handler(normalizedHttpRequest(urlPath), response, next || nextSpy)
     if (promise && promise.done) promise.done()
   }

--- a/test/unit/middleware/source_files.spec.js
+++ b/test/unit/middleware/source_files.spec.js
@@ -32,7 +32,7 @@ describe('middleware.source_files', function () {
 
   var serveFile = createServeFile(fsMock, null)
 
-  var createServer = function (f, s, basePath) {
+  function createServer (f, s, basePath) {
     var handler = createSourceFilesMiddleware(f.promise, s, basePath)
     return http.createServer(function (req, res) {
       next = sinon.spy(function (err) {
@@ -59,7 +59,7 @@ describe('middleware.source_files', function () {
     return next.reset()
   })
 
-  var servedFiles = function (list) {
+  function servedFiles (list) {
     return files.resolve({included: [], served: list})
   }
 


### PR DESCRIPTION
Since we started to declare functions in

    function name (parameters) {}

 way instead of 
    
    var name = function (parameters) {}

it would be nice to follow this style everywhere.