### PR TITLE
fix: check for available port before start server (fix #1476, fix #3011)

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -9,6 +9,7 @@ const tmp = require('tmp')
 const fs = require('fs')
 const path = require('path')
 const BundleUtils = require('./utils/bundle-utils')
+const NetUtils = require('./utils/net-utils')
 const root = global || window || this
 
 const cfg = require('./config')
@@ -95,8 +96,24 @@ class Server extends KarmaEventEmitter {
     this._injector = new di.Injector(modules)
   }
 
+  dieOnError (error) {
+    this.log.error(error)
+    process.exitCode = 1
+    process.kill(process.pid, 'SIGINT')
+  }
+
   start () {
-    this._injector.invoke(this._start, this)
+    const config = this.get('config')
+    return Promise.all([
+      BundleUtils.bundleResourceIfNotExist('client/main.js', 'static/karma.js'),
+      BundleUtils.bundleResourceIfNotExist('context/main.js', 'static/context.js')
+    ])
+      .then(() => NetUtils.getAvailablePort(config.port, config.listenAddress))
+      .then((port) => {
+        config.port = port
+        this._injector.invoke(this._start, this)
+      })
+      .catch(this.dieOnError.bind(this))
   }
 
   get (token) {
@@ -124,47 +141,26 @@ class Server extends KarmaEventEmitter {
     const singleRunBrowsers = new BrowserCollection(new EventEmitter())
     let singleRunBrowserNotCaptured = false
 
-    webServer.on('error', (e) => {
-      if (e.code === 'EADDRINUSE') {
-        this.log.warn('Port %d in use', config.port)
-        config.port++
-        webServer.listen(config.port, config.listenAddress)
-      } else {
-        throw e
-      }
-    })
+    webServer.on('error', this.dieOnError.bind(this))
 
     const afterPreprocess = () => {
       if (config.autoWatch) {
         this._injector.invoke(watcher.watch)
       }
 
-      return Promise.all([
-        BundleUtils.bundleResourceIfNotExist('client/main.js', 'static/karma.js'),
-        BundleUtils.bundleResourceIfNotExist('context/main.js', 'static/context.js')
-      ])
-        .then(() => {
-          webServer.listen(config.port, config.listenAddress, () => {
-            this.log.info(`Karma v${constant.VERSION} server started at ${config.protocol}//${config.listenAddress}:${config.port}${config.urlRoot}`)
+      webServer.listen(config.port, config.listenAddress, () => {
+        this.log.info(`Karma v${constant.VERSION} server started at ${config.protocol}//${config.listenAddress}:${config.port}${config.urlRoot}`)
 
-            this.emit('listening', config.port)
-            if (config.browsers && config.browsers.length) {
-              this._injector.invoke(launcher.launch, launcher).forEach((browserLauncher) => {
-                singleRunDoneBrowsers[browserLauncher.id] = false
-              })
-            }
-            if (this.loadErrors.length > 0) {
-              this.log.error('Found %d load error%s', this.loadErrors.length, this.loadErrors.length === 1 ? '' : 's')
-              process.exitCode = 1
-              process.kill(process.pid, 'SIGINT')
-            }
+        this.emit('listening', config.port)
+        if (config.browsers && config.browsers.length) {
+          this._injector.invoke(launcher.launch, launcher).forEach((browserLauncher) => {
+            singleRunDoneBrowsers[browserLauncher.id] = false
           })
-        })
-        .catch((error) => {
-          this.log.error('Front-end script compile failed with error: ' + error)
-          process.exitCode = 1
-          process.kill(process.pid, 'SIGINT')
-        })
+        }
+        if (this.loadErrors.length > 0) {
+          this.dieOnError(new Error(`Found ${this.loadErrors.length} load error${this.loadErrors.length === 1 ? '' : 's'}`))
+        }
+      })
     }
 
     fileList.refresh().then(afterPreprocess, afterPreprocess)

--- a/lib/utils/net-utils.js
+++ b/lib/utils/net-utils.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const Promise = require('bluebird')
+const net = require('net')
+
+const NetUtils = {
+  isPortAvailable (port, listenAddress) {
+    return new Promise((resolve, reject) => {
+      const server = net.createServer()
+
+      server.unref()
+      server.on('error', (err) => {
+        server.close()
+        if (err.code === 'EADDRINUSE' || err.code === 'EACCES') {
+          resolve(false)
+        } else {
+          reject(err)
+        }
+      })
+
+      server.listen(port, listenAddress, () => {
+        server.close(() => resolve(true))
+      })
+    })
+  },
+
+  getAvailablePort (port, listenAddress) {
+    return NetUtils.isPortAvailable(port, listenAddress)
+      .then((available) => available ? port : NetUtils.getAvailablePort(port + 1, listenAddress))
+  }
+}
+
+module.exports = NetUtils

--- a/test/unit/utils/net-utils.spec.js
+++ b/test/unit/utils/net-utils.spec.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const NetUtils = require('../../../lib/utils/net-utils')
+const connect = require('connect')
+const net = require('net')
+
+describe('NetUtils.isPortAvailable', () => {
+  it('it is possible to run server on available port', (done) => {
+    NetUtils.isPortAvailable(9876, '127.0.0.1').then((available) => {
+      expect(available).to.be.true
+      const server = net
+        .createServer(connect())
+        .listen(9876, '127.0.0.1', () => {
+          server.close(done)
+        })
+    })
+  })
+
+  it('resolves with false when port is used', (done) => {
+    const server = net
+      .createServer(connect())
+      .listen(9876, '127.0.0.1', () => {
+        NetUtils.isPortAvailable(9876, '127.0.0.1').then((available) => {
+          expect(available).to.be.false
+          server.close(done)
+        })
+      })
+  })
+})
+
+describe('NetUtils.getAvailablePort', () => {
+  it('resolves with port when is available', (done) => {
+    NetUtils.getAvailablePort(9876, '127.0.0.1').then((port) => {
+      expect(port).to.equal(9876)
+      done()
+    })
+  })
+
+  it('resolves with next available port', (done) => {
+    const stub = sinon.stub(NetUtils, 'isPortAvailable')
+    stub.withArgs(9876).resolves(false)
+    stub.withArgs(9877).resolves(false)
+    stub.withArgs(9878).resolves(true)
+
+    NetUtils.getAvailablePort(9876, '127.0.0.1').then((port) => {
+      expect(port).to.equal(9878)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
- create NetUtils with `isPortAvailable` and `getAvailablePort` methods
- use NetUtils to search for available port before starting server and build middlewares
- remove handler for `EADDRINUSE` error - with `NetUtils.getAvailablePort` we'll know that port is available for sure, so this error would no raise