### PR TITLE
fix(BaseReporter): log message correctly with just one browser

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -136,7 +136,7 @@ const BaseReporter = function (formatError, reportSlow, useColors, browserConsol
   }
 
   this.onRunComplete = (browsers, results) => {
-    if (browsers.length > 1 && !results.error && !results.disconnected) {
+    if (browsers.length >= 1 && !results.error && !results.disconnected) {
       if (!results.failed) {
         this.write(this.TOTAL_SUCCESS, results.success)
       } else {

--- a/test/unit/reporters/base.spec.js
+++ b/test/unit/reporters/base.spec.js
@@ -3,7 +3,7 @@
 describe('reporter', () => {
   const BaseReporter = require('../../../lib/reporters/base')
 
-  describe('Progress', () => {
+  describe('Base', () => {
     let reporter
     let adapter = reporter = null
 
@@ -181,13 +181,21 @@ describe('reporter', () => {
       return writeSpy.should.have.been.called
     })
 
-    return it('should format log messages correctly for multi browsers', () => {
+    it('should format log messages correctly for multi browsers', () => {
       const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
 
       reporter._browsers = ['Chrome', 'Firefox']
       reporter.onBrowserLog('Chrome', 'Message', 'LOG')
 
       return expect(writeSpy).to.have.been.calledWith('Chrome LOG: Message\n')
+    })
+
+    it('should log messages correctly when complete with just one browser', () => {
+      const writeSpy = sinon.spy(reporter, 'write')
+      const mockResults = {error: false, disconnected: false}
+
+      reporter.onRunComplete(['Chrome'], mockResults)
+      return writeSpy.should.have.been.called
     })
   })
 })


### PR DESCRIPTION
Fix an issue that when the run completes with just one browser, the log message is missing.