### PR TITLE
fix(launcher): Only markCaptured browsers that are launched.

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -173,8 +173,10 @@ function Launcher (server, emitter, injector) {
 
   this.markCaptured = (id) => {
     const browser = getBrowserById(id)
-    browser.markCaptured()
-    log.debug(`${browser.name} (id ${browser.id}) captured in ${(Date.now() - lastStartTime) / 1000} secs`)
+    if (browser) {
+      browser.markCaptured()
+      log.debug(`${browser.name} (id ${browser.id}) captured in ${(Date.now() - lastStartTime) / 1000} secs`)
+    }
   }
 
   emitter.on('exit', this.killAll)

--- a/test/unit/launcher.spec.js
+++ b/test/unit/launcher.spec.js
@@ -306,6 +306,12 @@ describe('launcher', () => {
       })
     })
 
+    describe('markCaptured', () => {
+      it('should not fail if an un-launched browser attaches', () => {
+        expect(() => l.markCaptured('not-a-thing')).to.not.throw()
+      })
+    })
+
     describe('onExit', () => {
       it('should kill all browsers', (done) => {
         l.launch(['Fake', 'Fake'], 1)


### PR DESCRIPTION
This is a regression in 2.0.3: if karma server is started and a users browser attached, the launch throws