### PR TITLE
feat(preprocessor): Allow preprocessor to handle binary files

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -98,12 +98,7 @@ function createPreprocessor (config, basePath, injector) {
         var preprocessorNames = []
         for (var i = 0; i < patterns.length; i++) {
           if (mm(file.originalPath, patterns[i], {dot: true})) {
-            if (thisFileIsBinary) {
-              log.warn('Ignoring preprocessing (%s) %s because it is a binary file.',
-                config[patterns[i]].join(', '), file.originalPath)
-            } else {
-              preprocessorNames = combineLists(preprocessorNames, config[patterns[i]])
-            }
+            preprocessorNames = combineLists(preprocessorNames, config[patterns[i]])
           }
         }
 
@@ -125,7 +120,12 @@ function createPreprocessor (config, basePath, injector) {
           }
 
           instances[name] = p
-          preprocessors.push(p)
+          if (!thisFileIsBinary || p.handleBinaryFiles) {
+            preprocessors.push(p)
+          } else {
+            log.warn('Ignored preprocessing %s because %s has handleBinaryFiles=false.',
+              file.originalPath, name)
+          }
         })
 
         nextPreprocessor(null, thisFileIsBinary ? buffer : buffer.toString())

--- a/test/unit/preprocessor.spec.js
+++ b/test/unit/preprocessor.spec.js
@@ -272,7 +272,7 @@ describe('preprocessor', () => {
       thirdCallback('error')
     })
 
-    it('should tbrow after 3 retries', (done) => {
+    it('should throw after 3 retries', (done) => {
       var injector = new di.Injector([{}, emitterSetting])
 
       var pp = m.createPreprocessor({'**/*.js': []}, null, injector)
@@ -288,7 +288,7 @@ describe('preprocessor', () => {
     })
   })
 
-  it('should not preprocess binary files', (done) => {
+  it('should not preprocess binary files by default', (done) => {
     var fakePreprocessor = sinon.spy((content, file, done) => {
       done(null, content)
     })
@@ -305,6 +305,29 @@ describe('preprocessor', () => {
       if (err) throw err
 
       expect(fakePreprocessor).not.to.have.been.called
+      expect(file.content).to.be.an.instanceof(Buffer)
+      done()
+    })
+  })
+
+  it('should preprocess binary files if handleBinaryFiles=true', (done) => {
+    const fakePreprocessor = sinon.spy((content, file, done) => {
+      done(null, content)
+    })
+    fakePreprocessor.handleBinaryFiles = true
+
+    var injector = new di.Injector([{
+      'preprocessor:fake': ['factory', function () { return fakePreprocessor }]
+    }, emitterSetting])
+
+    pp = m.createPreprocessor({'**/*': ['fake']}, null, injector)
+
+    const file = {originalPath: '/some/photo.png', path: 'path'}
+
+    pp(file, (err) => {
+      if (err) throw err
+
+      expect(fakePreprocessor).to.have.been.calledOnce
       expect(file.content).to.be.an.instanceof(Buffer)
       done()
     })


### PR DESCRIPTION
Karma currently detects whether a file is binary, and does not allow binary files to be passed on to preprocessors. This PR removes this restriction, and allows binary files to be handled by preprocessors.

See https://github.com/karma-runner/karma/issues/3046