### PR TITLE
fix(server): Resurrect static function Server.start() lost in 2.0.3

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -373,6 +373,10 @@ class Server extends KarmaEventEmitter {
     })
     child.unref()
   }
+
+  static start (cliOptions, done) {
+    return new Server(cliOptions, done)
+  }
 }
 
 Server.prototype._start.$inject = ['config', 'launcher', 'preprocess', 'fileList', 'capturedBrowsers', 'executor', 'done']

--- a/test/unit/server.spec.js
+++ b/test/unit/server.spec.js
@@ -241,4 +241,8 @@ describe('server', () => {
       }
     })
   })
+
+  it('static Server constructs a server', () => {
+    expect(Server.start(mockConfig) instanceof Server).to.be.true
+  })
 })


### PR DESCRIPTION

Fixes #3053