### PR TITLE
fix(server): actually call start().

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -375,7 +375,8 @@ class Server extends KarmaEventEmitter {
   }
 
   static start (cliOptions, done) {
-    return new Server(cliOptions, done)
+    console.warn('Deprecated static method to be removed in v3.0')
+    return new Server(cliOptions, done).start()
   }
 }
 

--- a/test/unit/server.spec.js
+++ b/test/unit/server.spec.js
@@ -241,8 +241,4 @@ describe('server', () => {
       }
     })
   })
-
-  it('static Server constructs a server', () => {
-    expect(Server.start(mockConfig) instanceof Server).to.be.true
-  })
 })


### PR DESCRIPTION
Warn that the function without a test will be removed.

Fixes #3061 by @GreenGremlin 
