### PR TITLE
fix(middleware): Obey the Promise API.

### DIFF
--- a/lib/middleware/common.js
+++ b/lib/middleware/common.js
@@ -16,8 +16,7 @@ class PromiseContainer {
   }
 
   then (success, error) {
-    error = error || _.noop
-    return this.promise.then(success).catch(error)
+    return this.promise.then(success, error)
   }
 
   set (newPromise) {


### PR DESCRIPTION
Rather than catching and discarding the error if no error handler is passed, let the promise package chain it. This allows use to have a .catch() follow the then().