### PR TITLE
Fixed `EADDRINUSE` issue for tests running in parallel

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -116,9 +116,10 @@ class Server extends KarmaEventEmitter {
       BundleUtils.bundleResourceIfNotExist('client/main.js', 'static/karma.js'),
       BundleUtils.bundleResourceIfNotExist('context/main.js', 'static/context.js')
     ])
-      .then(() => NetUtils.getAvailablePort(config.port, config.listenAddress))
-      .then((port) => {
-        config.port = port
+      .then(() => NetUtils.bindAvailablePort(config.port, config.listenAddress))
+      .then((boundServer) => {
+        config.port = boundServer.address().port
+        this._boundServer = boundServer
         this._injector.invoke(this._start, this)
       })
       .catch(this.dieOnError.bind(this))
@@ -156,7 +157,7 @@ class Server extends KarmaEventEmitter {
         this._injector.invoke(watcher.watch)
       }
 
-      webServer.listen(config.port, config.listenAddress, () => {
+      webServer.listen(this._boundServer, () => {
         this.log.info(`Karma v${constant.VERSION} server started at ${config.protocol}//${config.listenAddress}:${config.port}${config.urlRoot}`)
 
         this.emit('listening', config.port)

--- a/lib/utils/net-utils.js
+++ b/lib/utils/net-utils.js
@@ -4,29 +4,24 @@ const Promise = require('bluebird')
 const net = require('net')
 
 const NetUtils = {
-  isPortAvailable (port, listenAddress) {
+  bindAvailablePort (port, listenAddress) {
     return new Promise((resolve, reject) => {
       const server = net.createServer()
 
-      server.unref()
-      server.on('error', (err) => {
-        server.close()
-        if (err.code === 'EADDRINUSE' || err.code === 'EACCES') {
-          resolve(false)
-        } else {
-          reject(err)
-        }
-      })
-
-      server.listen(port, listenAddress, () => {
-        server.close(() => resolve(true))
-      })
+      server
+        .on('error', (err) => {
+          server.close()
+          if (err.code === 'EADDRINUSE' || err.code === 'EACCES') {
+            server.listen(++port, listenAddress)
+          } else {
+            reject(err)
+          }
+        })
+        .on('listening', () => {
+          resolve(server)
+        })
+        .listen(port, listenAddress)
     })
-  },
-
-  getAvailablePort (port, listenAddress) {
-    return NetUtils.isPortAvailable(port, listenAddress)
-      .then((available) => available ? port : NetUtils.getAvailablePort(port + 1, listenAddress))
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "Samuel Marks <samuelmarks@gmail.com>",
     "Saugat Acharya <mesaugat@gmail.com>",
     "Schmulik Raskin <schmuli@gmail.com>",
+    "Sergei Startsev <sergei.startsev@gmail.com>",
     "Sergey Kruk <sergey.kruk@gmail.com>",
     "Sergey Simonchik <sergey.simonchik@jetbrains.com>",
     "Seth Rhodes <seth@thinkpixbit.com>",

--- a/test/unit/utils/net-utils.spec.js
+++ b/test/unit/utils/net-utils.spec.js
@@ -4,46 +4,33 @@ const NetUtils = require('../../../lib/utils/net-utils')
 const connect = require('connect')
 const net = require('net')
 
-describe('NetUtils.isPortAvailable', () => {
-  it('it is possible to run server on available port', (done) => {
-    NetUtils.isPortAvailable(9876, '127.0.0.1').then((available) => {
-      expect(available).to.be.true
-      const server = net
-        .createServer(connect())
-        .listen(9876, '127.0.0.1', () => {
-          server.close(done)
-        })
-    })
-  })
-
-  it('resolves with false when port is used', (done) => {
-    const server = net
-      .createServer(connect())
-      .listen(9876, '127.0.0.1', () => {
-        NetUtils.isPortAvailable(9876, '127.0.0.1').then((available) => {
-          expect(available).to.be.false
-          server.close(done)
-        })
+describe('NetUtils.bindAvailablePort', () => {
+  it('resolves server with bound port when it is available', (done) => {
+    NetUtils.bindAvailablePort(9876, '127.0.0.1').then((boundServer) => {
+      const port = boundServer.address().port
+      expect(port).to.be.equal(9876)
+      expect(boundServer).not.to.be.null
+      const server = net.createServer(connect()).listen(boundServer, () => {
+        server.close(done)
       })
-  })
-})
-
-describe('NetUtils.getAvailablePort', () => {
-  it('resolves with port when is available', (done) => {
-    NetUtils.getAvailablePort(9876, '127.0.0.1').then((port) => {
-      expect(port).to.equal(9876)
-      done()
     })
   })
 
   it('resolves with next available port', (done) => {
-    const stub = sinon.stub(NetUtils, 'isPortAvailable')
-    stub.withArgs(9876).resolves(false)
-    stub.withArgs(9877).resolves(false)
-    stub.withArgs(9878).resolves(true)
+    const server = net.createServer(connect()).listen(9876, '127.0.0.1', () => {
+      NetUtils.bindAvailablePort(9876, '127.0.0.1').then((boundServer) => {
+        const port = boundServer.address().port
+        expect(port).to.be.equal(9877)
+        expect(boundServer).not.to.be.null
+        server.close(done)
+      })
+    })
+  })
 
-    NetUtils.getAvailablePort(9876, '127.0.0.1').then((port) => {
-      expect(port).to.equal(9878)
+  it('rejects if a critical error occurs', (done) => {
+    const incorrectAddress = '123.321'
+    NetUtils.bindAvailablePort(9876, incorrectAddress).catch((err) => {
+      expect(err).not.to.be.null
       done()
     })
   })


### PR DESCRIPTION
Fixed #3065 by passing `handle` that has already been bound to a port, see [server.listen](https://nodejs.org/api/net.html#net_server_listen_handle_backlog_callback).