### PR TITLE
fix: remove circular reference in Browser

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -62,6 +62,19 @@ class Browser {
     return this.name
   }
 
+  toJSON () {
+    return {
+      id: this.id,
+      fullName: this.fullName,
+      name: this.name,
+      state: this.state,
+      lastResult: this.lastResult,
+      disconnectsCount: this.disconnectsCount,
+      noActivityTimeout: this.noActivityTimeout,
+      disconnectDelay: this.disconnectDelay
+    }
+  }
+
   onKarmaError (error) {
     if (this.isReady()) {
       return

--- a/test/unit/browser.spec.js
+++ b/test/unit/browser.spec.js
@@ -32,6 +32,14 @@ describe('Browser', () => {
     expect(browser.fullName).to.equal(fullName)
   })
 
+  it('should serialize to JSON', () => {
+    const fullName = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/535.7 ' + '(KHTML, like Gecko) Chrome/16.0.912.63 Safari/535.7'
+    browser = new Browser('id', fullName, collection, emitter, socket)
+    emitter.browser = browser
+    const json = JSON.stringify(browser)
+    expect(json).to.contain(fullName)
+  })
+
   describe('init', () => {
     it('should emit "browser_register"', () => {
       const spyRegister = sinon.spy()


### PR DESCRIPTION
After migrating the the `browser.js` file to ES2015, the `Browser` class has now fields with circular references (like `emitter`), which breaks the Karma JSON reporters available starting with Karma 2.0.1.

This commit removes the circular dependencies by adding a `toJSON()` method to the `Browser` class, which produces a similar result to the browser object before the migration.

Fixes #3075