### PR TITLE
fix(reporter): avoid duplicate messages

### DIFF
--- a/lib/reporters/dots.js
+++ b/lib/reporters/dots.js
@@ -32,15 +32,9 @@ function DotsReporter (formatError, reportSlow, useColors, browserConsoleLogOpti
     this.writeCommonMsg(this.renderBrowser(browser) + '\n')
   }
 
-  this.onRunComplete = function (browsers, results) {
-    if (browsers.length > 1 && !results.disconnected && !results.error) {
-      if (!results.failed) {
-        this.write(this.TOTAL_SUCCESS, results.success)
-      } else {
-        this.write(this.TOTAL_FAILED, results.failed, results.success)
-      }
-    }
-  }
+  this.onRunComplete = function (browsers, results) {}
+
+  this.specFailure = (browser, result) => {}
 }
 
 // PUBLISH

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -33,6 +33,10 @@ function ProgressReporter (formatError, reportSlow, useColors, browserConsoleLog
     this.write(this._refresh())
   }
 
+  this.onRunComplete = (browsers, results) => {}
+
+  this.specFailure = (browser, result) => {}
+
   this._remove = function () {
     if (!this._isRendered) {
       return ''

--- a/test/unit/reporters/dots.spec.js
+++ b/test/unit/reporters/dots.spec.js
@@ -1,0 +1,29 @@
+describe('reporter', function () {
+  var DotsReporter = require('../../../lib/reporters/dots')
+
+  describe('Dots', function () {
+    var reporter
+    var formatError
+
+    beforeEach(function () {
+      formatError = sinon.spy()
+      reporter = new DotsReporter(formatError, null, false, {terminal: true})
+    })
+
+    it('should not log messages when complete', () => {
+      const writeSpy = sinon.spy(reporter, 'write')
+      const mockResults = {error: false, disconnected: false}
+
+      reporter.onRunComplete(['Chrome'], mockResults)
+      return writeSpy.should.not.have.been.called
+    })
+
+    it('should not log messages when fail', () => {
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+      const mockResult = {description: 'description', suite: ['suite name'], log: []}
+
+      reporter.specFailure('Chrome', mockResult)
+      return writeSpy.should.not.have.been.called
+    })
+  })
+})

--- a/test/unit/reporters/progress.spec.js
+++ b/test/unit/reporters/progress.spec.js
@@ -36,6 +36,22 @@ describe('reporter', function () {
       }).to.not.throw()
     })
 
+    it('should not log messages when complete', () => {
+      const writeSpy = sinon.spy(reporter, 'write')
+      const mockResults = {error: false, disconnected: false}
+
+      reporter.onRunComplete(['Chrome'], mockResults)
+      return writeSpy.should.not.have.been.called
+    })
+
+    it('should not log messages when fail', () => {
+      const writeSpy = sinon.spy(reporter, 'writeCommonMsg')
+      const mockResult = {description: 'description', suite: ['suite name'], log: []}
+
+      reporter.specFailure('Chrome', mockResult)
+      return writeSpy.should.not.have.been.called
+    })
+
     function createBrowserMock () {
       return {}
     }


### PR DESCRIPTION
For the dots and process reporter, should not log duplicate messages for `specFailure` and `runComplete`, as they all have been handled by the base reporter
