### PR TITLE
fix(config): Wait 30s for browser activity per Travis.

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -156,11 +156,11 @@ a flaky network link between the Karma server and the browsers.
 ## browserNoActivityTimeout
 **Type:** Number
 
-**Default:** `20000`
+**Default:** `30000`
 
 **Description:** How long will Karma wait for a message from a browser before disconnecting from it (in ms).
 
-If, during test execution, Karma does not receive any message from a browser within `browserNoActivityTimeout`(ms), it will disconnect from the browser.
+If, during test execution, Karma does not receive any message from a browser within `browserNoActivityTimeout`(ms), it will disconnect from the browser. The default is the one recommended by Travis (https://docs.travis-ci.com/user/gui-and-headless-browsers/#karma-and-firefox-inactivity-timeouts)
 
 
 ## browsers

--- a/lib/config.js
+++ b/lib/config.js
@@ -343,7 +343,7 @@ class Config {
     }
     this.browserDisconnectTimeout = 2000
     this.browserDisconnectTolerance = 0
-    this.browserNoActivityTimeout = 20000
+    this.browserNoActivityTimeout = 30000
     this.processKillTimeout = 2000
     this.concurrency = Infinity
     this.failOnEmptyTestSuite = true


### PR DESCRIPTION
https://docs.travis-ci.com/user/gui-and-headless-browsers/#karma-and-firefox-inactivity-timeouts