### PR TITLE
fix(server): Exit clean on unhandledRejections.

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -236,14 +236,6 @@ function createKarmaMiddleware (
             .replace('%MAPPINGS%', mappings)
             .replace('\n%X_UA_COMPATIBLE%', getXUACompatibleMetaElement(request.url))
         })
-      }, function (errorFiles) {
-        serveStaticFile(requestUrl, response, function (data) {
-          common.setNoCacheHeaders(response)
-          return data.replace('%SCRIPTS%', '').replace('%CLIENT_CONFIG%', '').replace('%MAPPINGS%',
-            'window.__karma__.error("TEST RUN WAS CANCELLED because ' +
-            (errorFiles.length > 1 ? 'these files contain' : 'this file contains') +
-            ' some errors:\\n  ' + errorFiles.join('\\n  ') + '");')
-        })
       })
     } else if (requestUrl === '/context.json') {
       return filesPromise.then(function (files) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -353,6 +353,11 @@ class Server extends KarmaEventEmitter {
       this.log.error(error)
       disconnectBrowsers(1)
     })
+
+    processWrapper.on('unhandledRejection', (error) => {
+      this.log.error(error)
+      disconnectBrowsers(1)
+    })
   }
 
   _detach (config, done) {


### PR DESCRIPTION
Add a handler for unhandledRejections, log error and disconnect all, then exit.
Also remove broken, untested rejection handler in middleware. Prior to #3064,
this block was probably unreachable; the arguments to serveStaticFile are incorrect.