### PR TITLE
fix(init): add "ChromeHeadless" to the browsers' options for "init" command

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -13,7 +13,7 @@ const options = {
     '--no-colors': BOOLEAN,
     '--reporters': ['dots', 'progress'],
     '--no-reporters': BOOLEAN,
-    '--browsers': ['Chrome', 'ChromeCanary', 'Firefox', 'PhantomJS', 'Safari', 'Opera'],
+    '--browsers': ['Chrome', 'ChromeHeadless', 'ChromeCanary', 'Firefox', 'PhantomJS', 'Safari', 'Opera'],
     '--no-browsers': BOOLEAN,
     '--single-run': BOOLEAN,
     '--no-single-run': BOOLEAN,

--- a/lib/init.js
+++ b/lib/init.js
@@ -100,7 +100,7 @@ var questions = [{
   id: 'browsers',
   question: 'Do you want to capture any browsers automatically ?',
   hint: 'Press tab to list possible options. Enter empty string to move to the next question.',
-  options: ['Chrome', 'ChromeCanary', 'Firefox', 'Safari', 'PhantomJS', 'Opera', 'IE', ''],
+  options: ['Chrome', 'ChromeHeadless', 'ChromeCanary', 'Firefox', 'Safari', 'PhantomJS', 'Opera', 'IE', ''],
   validate: validateBrowser,
   multiple: true
 }, {


### PR DESCRIPTION
We can add `ChromeHeadless` in the options for `browsers` when using `karma init`