### PR TITLE
fix(init): Support ChromeHeadless in `validateBrowser`

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -69,7 +69,7 @@ function validatePattern (pattern) {
 
 function validateBrowser (name) {
   // TODO(vojta): check if the path resolves to a binary
-  installPackage('karma-' + name.toLowerCase().replace('canary', '') + '-launcher')
+  installPackage('karma-' + name.toLowerCase().replace('headless', '').replace('canary', '') + '-launcher')
 }
 
 function validateFramework (name) {


### PR DESCRIPTION
Looks like this was missed in #3096.