### PR TITLE
server: Avoid warning, when running bluebird.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -121,6 +121,7 @@ class Server extends KarmaEventEmitter {
         config.port = boundServer.address().port
         this._boundServer = boundServer
         this._injector.invoke(this._start, this)
+        return boundServer
       })
       .catch(this.dieOnError.bind(this))
   }


### PR DESCRIPTION
Bluebird currently complains since version 2.0.3 with the following warning:

> Warning: a promise was created in a handler at [...]/node_modules/karma/lib/server.js:123:24 but was not returned from it, see http://goo.gl/rRqMUw

Returning the passed in promise result resolves the issue.