### PR TITLE
feat(server): Add support for encoded source files

### DIFF
--- a/docs/dev/05-plugins.md
+++ b/docs/dev/05-plugins.md
@@ -18,6 +18,17 @@ Karma can be extended through plugins. A plugin is essentially an NPM module. Ty
 - use NPM keywords `karma-plugin`, `karma-launcher`
 
 ## Preprocessors
+
+A preprocessor is a function that accepts three arguments (`content`, `file`, and `next`), mutates the content in some way, and passes it on to the next preprocessor.
+
+- arguments passed to preprocessor plugins:
+  - **`content`** of the file being processed
+  - **`file`** object describing the file being processed
+     - **path:** the current file, mutable file path. e. g. `some/file.coffee` -> `some/file.coffee.js` _This path is mutable and may not actually exist._
+     - **originalPath:** the original, unmutated path
+     - **encodings:** A mutable, keyed object where the keys are a valid encoding type ('gzip', 'compress', 'br', etc.) and the values are the encoded content. Encoded content should be stored here and not resolved using `next(null, encodedContent)`
+     - **type:** the pattern used to match the file
+  - **`next`** function to be called when preprocessing is complete, should be called as `next(null, processedContent)` or `next(error)`
 - example plugins: [karma-coffee-preprocessor], [karma-ng-html2js-preprocessor]
 - use naming convention is `karma-*-preprocessor`
 - user NPM keywords `karma-plugin`, `karma-preprocessor`

--- a/lib/file.js
+++ b/lib/file.js
@@ -14,6 +14,10 @@ class File {
     // where the content is stored (processed)
     this.contentPath = path
 
+    // encodings format {[encodingType]: encodedContent}
+    //   example: {gzip: <Buffer 1f 8b 08...>}
+    this.encodings = Object.create(null)
+
     this.mtime = mtime
     this.isUrl = false
 

--- a/lib/middleware/source_files.js
+++ b/lib/middleware/source_files.js
@@ -35,13 +35,22 @@ function createSourceFilesMiddleware (filesPromise, serveFile, basePath, urlRoot
       const rangeHeader = request.headers['range']
 
       if (file) {
+        const acceptEncodingHeader = request.headers['accept-encoding']
+        const matchedEncoding = Object.keys(file.encodings).find(
+          (encoding) => new RegExp(`(^|.*, ?)${encoding}(,|$)`).test(acceptEncodingHeader)
+        )
+        const content = file.encodings[matchedEncoding] || file.content
+
         serveFile(file.contentPath || file.path, rangeHeader, response, function () {
           if (/\?\w+/.test(request.url)) {
             common.setHeavyCacheHeaders(response) // files with timestamps - cache one year, rely on timestamps
           } else {
             common.setNoCacheHeaders(response) // without timestamps - no cache (debug)
           }
-        }, file.content, file.doNotCache)
+          if (matchedEncoding) {
+            response.setHeader('Content-Encoding', matchedEncoding)
+          }
+        }, content, file.doNotCache)
       } else {
         next()
       }


### PR DESCRIPTION
This change allows preprocessors to specify an encoding for files. Currently, if a preprocessor encodes a file in a format such as gzip or Brotli, the file is served with the wrong encoding. The only workaround for this is to also include a plugin ([example](https://github.com/GreenGremlin/karma-gzip/blob/master/lib/Plugin.js)) that removes encoded files from `files.served` and serves them manually using a custom file handler. This approach is a gross hack that unnecessarily complicates the encoding plugin's logic.

With this change, a preprocessor encodes the contents and stores them in the File class' new `encodings` property. The `encodings` property is a keyed object where the keys are the encoding type ('gzip', 'compress', 'br', etc.) and the values are the encoded content. This pattern has the advantage of allowing multiple encoders and serving the encoding that best matches the request. It also allows the unencoded content to be served, when no encoding matches the request.

I know there has been [pushback on adding encoding support](https://github.com/karma-runner/karma/issues/1241), but I'm hoping this approach is an acceptable compromise. This solution leaves pretty much all encoding logic to the preprocessors and minimizes karma's role as much as possible.