### PR TITLE
Update this reference to self

### DIFF
--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -70,7 +70,7 @@ function ProcessLauncher (spawn, tempDir, timer, processKillTimeout) {
       return self._clearTempDirAndReportDone('no binary')
     }
 
-    cmd = this._normalizeCommand(cmd)
+    cmd = self._normalizeCommand(cmd)
 
     log.debug(cmd + ' ' + args.join(' '))
     self._process = spawn(cmd, args)


### PR DESCRIPTION
Hi there,

In `this._execCommand` at line 73 the `this` keyword is use instead of `self`. In case of _execCommand override or external call, `this` will be undefined.

This proposal just fix that.

Check that your description matches the automatic change-log format:
http://karma-runner.github.io/2.0/dev/git-commit-msg.html
then delete this reminder.
