### PR TITLE
refactor(launcher): use this directly instead assign to self variable in base launcher

### DIFF
--- a/lib/launchers/base.js
+++ b/lib/launchers/base.js
@@ -32,7 +32,6 @@ function BaseLauncher (id, emitter) {
   this.state = null
   this.error = null
 
-  const self = this
   let killingPromise
   let previousUrl
 
@@ -41,7 +40,7 @@ function BaseLauncher (id, emitter) {
 
     this.error = null
     this.state = BEING_CAPTURED
-    this.emit('start', url + '?id=' + this.id + (helper.isDefined(self.displayName) ? '&displayName=' + encodeURIComponent(self.displayName) : ''))
+    this.emit('start', url + '?id=' + this.id + (helper.isDefined(this.displayName) ? '&displayName=' + encodeURIComponent(this.displayName) : ''))
   }
 
   this.kill = function () {
@@ -50,8 +49,8 @@ function BaseLauncher (id, emitter) {
       return killingPromise
     }
 
-    killingPromise = this.emitAsync('kill').then(function () {
-      self.state = FINISHED
+    killingPromise = this.emitAsync('kill').then(() => {
+      this.state = FINISHED
     })
 
     this.state = BEING_KILLED
@@ -75,17 +74,17 @@ function BaseLauncher (id, emitter) {
       killingPromise = this.emitAsync('kill')
     }
 
-    killingPromise.then(function () {
-      if (self.state === BEING_FORCE_KILLED) {
-        self.state = FINISHED
+    killingPromise.then(() => {
+      if (this.state === BEING_FORCE_KILLED) {
+        this.state = FINISHED
       } else {
         killingPromise = null
-        log.debug('Restarting %s', self.name)
-        self.start(previousUrl)
+        log.debug('Restarting %s', this.name)
+        this.start(previousUrl)
       }
     })
 
-    self.state = RESTARTING
+    this.state = RESTARTING
   }
 
   this.markCaptured = function () {


### PR DESCRIPTION
This pull request is the first step that should help us to transform `BaseLauncher` to be ES6 class