### PR TITLE
fix(test/client): revert const/let changes.

### DIFF
--- a/test/client/karma.conf.js
+++ b/test/client/karma.conf.js
@@ -1,6 +1,6 @@
-const TRAVIS_WITHOUT_BS = process.env.TRAVIS_SECURE_ENV_VARS === 'false'
+var TRAVIS_WITHOUT_BS = process.env.TRAVIS_SECURE_ENV_VARS === 'false'
 
-const launchers = {
+var launchers = {
   bs_chrome: {
     base: 'BrowserStack',
     browser: 'chrome',
@@ -59,7 +59,7 @@ const launchers = {
   // }
 }
 
-let browsers = []
+var browsers = []
 
 if (process.env.TRAVIS) {
   if (TRAVIS_WITHOUT_BS) {

--- a/test/client/karma.spec.js
+++ b/test/client/karma.spec.js
@@ -1,15 +1,15 @@
 // shim all the things
 require('core-js/es5')
 global.JSON = require('json3')
-const sinon = require('sinon')
-const assert = require('assert')
+var sinon = require('sinon')
+var assert = require('assert')
 
-const ClientKarma = require('../../client/karma')
-const ContextKarma = require('../../context/karma')
-const MockSocket = require('./mocks').Socket
+var ClientKarma = require('../../client/karma')
+var ContextKarma = require('../../context/karma')
+var MockSocket = require('./mocks').Socket
 
 describe('Karma', function () {
-  let socket, k, ck, windowNavigator, windowLocation, windowStub, startSpy, iframe, clientWindow
+  var socket, k, ck, windowNavigator, windowLocation, windowStub, startSpy, iframe, clientWindow
 
   function setTransportTo (transportName) {
     socket._setTransportNameTo(transportName)
@@ -33,7 +33,7 @@ describe('Karma', function () {
   })
 
   it('should start execution when all files loaded and pass config', function () {
-    const config = ck.config = {
+    var config = ck.config = {
       useIframe: true
     }
 
@@ -45,7 +45,7 @@ describe('Karma', function () {
   })
 
   it('should open a new window when useIFrame is false', function () {
-    const config = ck.config = {
+    var config = ck.config = {
       useIframe: false,
       runInParent: false
     }
@@ -85,13 +85,13 @@ describe('Karma', function () {
   })
 
   it('should not set up context if there was an error', function () {
-    const config = ck.config = {
+    var config = ck.config = {
       clearContext: true
     }
 
     socket.emit('execute', config)
 
-    const mockWindow = {}
+    var mockWindow = {}
 
     ck.error('page reload')
     ck.setupContext(mockWindow)
@@ -101,13 +101,13 @@ describe('Karma', function () {
   })
 
   it('should setup context if there was error but clearContext config is false', function () {
-    const config = ck.config = {
+    var config = ck.config = {
       clearContext: false
     }
 
     socket.emit('execute', config)
 
-    const mockWindow = {}
+    var mockWindow = {}
 
     ck.error('page reload')
     ck.setupContext(mockWindow)
@@ -118,11 +118,11 @@ describe('Karma', function () {
 
   it('should error out if a script attempted to reload the browser after setup', function () {
     // Perform setup
-    const config = ck.config = {
+    var config = ck.config = {
       clearContext: true
     }
     socket.emit('execute', config)
-    const mockWindow = {}
+    var mockWindow = {}
     ck.setupContext(mockWindow)
 
     // Spy on our error handler
@@ -136,7 +136,7 @@ describe('Karma', function () {
   })
 
   it('should report navigator name', function () {
-    const spyInfo = sinon.spy(function (info) {
+    var spyInfo = sinon.spy(function (info) {
       assert(info.name === 'Fake browser name')
     })
 
@@ -153,7 +153,7 @@ describe('Karma', function () {
     socket = new MockSocket()
     k = new ClientKarma(socket, {}, windowStub, windowNavigator, windowLocation)
 
-    const spyInfo = sinon.spy(function (info) {
+    var spyInfo = sinon.spy(function (info) {
       assert(info.id === '567')
     })
 
@@ -165,13 +165,13 @@ describe('Karma', function () {
 
   describe('result', function () {
     it('should buffer results when polling', function () {
-      const spyResult = sinon.stub()
+      var spyResult = sinon.stub()
       socket.on('result', spyResult)
 
       setTransportTo('polling')
 
       // emit 49 results
-      for (let i = 1; i < 50; i++) {
+      for (var i = 1; i < 50; i++) {
         ck.result({id: i})
       }
 
@@ -183,13 +183,13 @@ describe('Karma', function () {
     })
 
     it('should buffer results when polling', function () {
-      const spyResult = sinon.stub()
+      var spyResult = sinon.stub()
       socket.on('result', spyResult)
 
       setTransportTo('polling')
 
       // emit 40 results
-      for (let i = 1; i <= 40; i++) {
+      for (var i = 1; i <= 40; i++) {
         ck.result({id: i})
       }
 
@@ -199,7 +199,7 @@ describe('Karma', function () {
     })
 
     it('should emit "start" with total specs count first', function () {
-      const log = []
+      var log = []
 
       socket.on('result', function () {
         log.push('result')
@@ -217,13 +217,13 @@ describe('Karma', function () {
     })
 
     it('should not emit "start" if already done by the adapter', function () {
-      const log = []
+      var log = []
 
-      const spyStart = sinon.spy(function () {
+      var spyStart = sinon.spy(function () {
         log.push('start')
       })
 
-      const spyResult = sinon.spy(function () {
+      var spyResult = sinon.spy(function () {
         log.push('result')
       })
 
@@ -243,7 +243,7 @@ describe('Karma', function () {
     it('should capture alert', function () {
       sinon.spy(ck, 'log')
 
-      const mockWindow = {
+      var mockWindow = {
         alert: function () {
           throw new Error('Alert was not patched!')
         }
@@ -256,9 +256,9 @@ describe('Karma', function () {
 
     it('should capture confirm', function () {
       sinon.spy(ck, 'log')
-      let confirmCalled = false
+      var confirmCalled = false
 
-      const mockWindow = {
+      var mockWindow = {
         confirm: function () {
           confirmCalled = true
           return true
@@ -266,7 +266,7 @@ describe('Karma', function () {
       }
 
       ck.setupContext(mockWindow)
-      const confirmResult = mockWindow.confirm('What?')
+      var confirmResult = mockWindow.confirm('What?')
       assert(ck.log.calledWith('confirm', ['What?']))
       assert.equal(confirmCalled, true)
       assert.equal(confirmResult, true)
@@ -274,9 +274,9 @@ describe('Karma', function () {
 
     it('should capture prompt', function () {
       sinon.spy(ck, 'log')
-      let promptCalled = false
+      var promptCalled = false
 
-      const mockWindow = {
+      var mockWindow = {
         prompt: function () {
           promptCalled = true
           return 'user-input'
@@ -284,7 +284,7 @@ describe('Karma', function () {
       }
 
       ck.setupContext(mockWindow)
-      const promptResult = mockWindow.prompt('What is your favorite color?', 'blue')
+      var promptResult = mockWindow.prompt('What is your favorite color?', 'blue')
       assert(ck.log.calledWith('prompt', ['What is your favorite color?', 'blue']))
       assert.equal(promptCalled, true)
       assert.equal(promptResult, 'user-input')
@@ -292,7 +292,7 @@ describe('Karma', function () {
   })
 
   describe('complete', function () {
-    let clock
+    var clock
 
     before(function () {
       clock = sinon.useFakeTimers()
@@ -303,13 +303,13 @@ describe('Karma', function () {
     })
 
     it('should clean the result buffer before completing', function () {
-      const spyResult = sinon.stub()
+      var spyResult = sinon.stub()
       socket.on('result', spyResult)
 
       setTransportTo('polling')
 
       // emit 40 results
-      for (let i = 0; i < 40; i++) {
+      for (var i = 0; i < 40; i++) {
         ck.result({id: i})
       }
 
@@ -347,7 +347,7 @@ describe('Karma', function () {
       sinon.spy(ck, 'log')
       ck.config.captureConsole = true
 
-      const mockWindow = {
+      var mockWindow = {
         console: {
           log: function () {}
         }
@@ -363,7 +363,7 @@ describe('Karma', function () {
       sinon.spy(ck, 'log')
       ck.config.captureConsole = false
 
-      const mockWindow = {
+      var mockWindow = {
         console: {
           log: function () {}
         }
@@ -375,12 +375,12 @@ describe('Karma', function () {
     })
 
     it('should clear context window upon complete when clearContext config is true', function () {
-      const config = ck.config = {
+      var config = ck.config = {
         clearContext: true
       }
 
       socket.emit('execute', config)
-      const CURRENT_URL = iframe.src
+      var CURRENT_URL = iframe.src
 
       ck.complete()
 
@@ -392,12 +392,12 @@ describe('Karma', function () {
     })
 
     it('should not clear context window upon complete when clearContext config is false', function () {
-      const config = ck.config = {
+      var config = ck.config = {
         clearContext: false
       }
 
       socket.emit('execute', config)
-      const CURRENT_URL = iframe.src
+      var CURRENT_URL = iframe.src
 
       ck.complete()
 

--- a/test/client/mocks.js
+++ b/test/client/mocks.js
@@ -1,5 +1,5 @@
 function Emitter () {
-  const listeners = {}
+  var listeners = {}
 
   this.on = function (event, fn) {
     if (!listeners[event]) {
@@ -10,11 +10,11 @@ function Emitter () {
   }
 
   this.emit = function (event) {
-    const eventListeners = listeners[event]
+    var eventListeners = listeners[event]
 
     if (!eventListeners) return
 
-    let i = 0
+    var i = 0
     while (i < eventListeners.length) {
       eventListeners[i].apply(null, Array.prototype.slice.call(arguments, 1))
       i++
@@ -27,7 +27,7 @@ function MockSocket () {
 
   this.socket = {transport: {name: 'websocket'}}
 
-  let transportName = 'websocket'
+  var transportName = 'websocket'
 
   this.io = {
     engine: {

--- a/test/client/stringify.spec.js
+++ b/test/client/stringify.spec.js
@@ -1,7 +1,7 @@
 /* global __karma__ */
-const assert = require('assert')
+var assert = require('assert')
 
-const stringify = require('../../common/stringify')
+var stringify = require('../../common/stringify')
 
 describe('stringify', function () {
   if (window && window.Symbol) {
@@ -30,15 +30,15 @@ describe('stringify', function () {
     function abc (a, b, c) { return 'whatever' }
     function def (d, e, f) { return 'whatever' }
 
-    const abcString = stringify(abc)
-    const partsAbc = ['function', 'abc', '(a, b, c)', '{ ... }']
-    const partsDef = ['function', '(d, e, f)', '{ ... }']
+    var abcString = stringify(abc)
+    var partsAbc = ['function', 'abc', '(a, b, c)', '{ ... }']
+    var partsDef = ['function', '(d, e, f)', '{ ... }']
 
     partsAbc.forEach(function (part) {
       assert(abcString.indexOf(part) > -1)
     })
 
-    const defString = stringify(def)
+    var defString = stringify(def)
     partsDef.forEach(function (part) {
       assert(defString.indexOf(part) > -1)
     })
@@ -48,7 +48,7 @@ describe('stringify', function () {
   //   http://caniuse.com/#feat=proxy
   if (window.Proxy) {
     it('should serialize proxied functions', function () {
-      const defProxy = new Proxy(function (d, e, f) { return 'whatever' }, {})
+      var defProxy = new Proxy(function (d, e, f) { return 'whatever' }, {})
       assert.deepEqual(stringify(defProxy), 'function () { ... }')
     })
   }
@@ -58,7 +58,7 @@ describe('stringify', function () {
   })
 
   it('should serialize objects', function () {
-    let obj
+    var obj
 
     obj = {a: 'a', b: 'b', c: null, d: true, e: false}
     assert(stringify(obj).indexOf("{a: 'a', b: 'b', c: null, d: true, e: false}") > -1)
@@ -73,7 +73,7 @@ describe('stringify', function () {
     obj = {constructor: null}
 
     // IE 7 serializes this to Object{}
-    const s = stringify(obj)
+    var s = stringify(obj)
     assert(s.indexOf('{constructor: null}') > -1 || s.indexOf('Object{}') > -1)
 
     obj = Object.create(null)
@@ -83,7 +83,7 @@ describe('stringify', function () {
   })
 
   it('should serialize html', function () {
-    const div = document.createElement('div')
+    var div = document.createElement('div')
 
     assert.deepEqual(stringify(div).trim().toLowerCase(), '<div></div>')
 
@@ -92,21 +92,21 @@ describe('stringify', function () {
   })
 
   it('should serialize error', function () {
-    const error = new TypeError('Error description')
+    var error = new TypeError('Error description')
     assert(stringify(error).indexOf('Error description') > -1)
   })
 
   it('should serialize DOMParser objects', function () {
     if (typeof DOMParser !== 'undefined') {
       // Test only works in IE 9 and above
-      const parser = new DOMParser()
-      const doc = parser.parseFromString('<test></test>', 'application/xml')
+      var parser = new DOMParser()
+      var doc = parser.parseFromString('<test></test>', 'application/xml')
       assert.deepEqual(stringify(doc), '<test></test>')
     }
   })
 
   it('should serialize across iframes', function () {
-    const div = document.createElement('div')
+    var div = document.createElement('div')
     assert.deepEqual(__karma__.stringify(div).trim().toLowerCase(), '<div></div>')
 
     assert.deepEqual(__karma__.stringify([1, 2]), '[1, 2]')

--- a/test/client/util.spec.js
+++ b/test/client/util.spec.js
@@ -1,9 +1,10 @@
-const assert = require('assert')
-const util = require('../../common/util')
+var assert = require('assert')
+
+var util = require('../../common/util')
 
 describe('util', function () {
   it('parseQueryParams', function () {
-    const params = util.parseQueryParams('?id=123&return_url=http://whatever.com')
+    var params = util.parseQueryParams('?id=123&return_url=http://whatever.com')
 
     assert.deepEqual(params, {id: '123', return_url: 'http://whatever.com'})
   })


### PR DESCRIPTION
We still test in IE9/10 where the `var` is king.

