### PR TITLE
fix(config): force user to provide valid urlRoot and upstreamProxy.path

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -6,6 +6,7 @@ const logger = require('./logger')
 const log = logger.create('config')
 const helper = require('./helper')
 const constant = require('./constants')
+const ValidationUtils = require('./utils/validation-utils')
 
 const _ = require('lodash')
 
@@ -75,38 +76,6 @@ function createPatternObject (pattern) {
   }
 }
 
-function normalizeUrl (url) {
-  if (!url.startsWith('/')) {
-    url = `/${url}`
-  }
-
-  if (!url.endsWith('/')) {
-    url = url + '/'
-  }
-
-  return url
-}
-
-function normalizeUrlRoot (urlRoot) {
-  const normalizedUrlRoot = normalizeUrl(urlRoot)
-
-  if (normalizedUrlRoot !== urlRoot) {
-    log.warn(`urlRoot normalized to "${normalizedUrlRoot}"`)
-  }
-
-  return normalizedUrlRoot
-}
-
-function normalizeProxyPath (proxyPath) {
-  const normalizedProxyPath = normalizeUrl(proxyPath)
-
-  if (normalizedProxyPath !== proxyPath) {
-    log.warn(`proxyPath normalized to "${normalizedProxyPath}"`)
-  }
-
-  return normalizedProxyPath
-}
-
 function normalizeConfig (config, configFilePath) {
   function basePathResolve (relativePath) {
     if (helper.isUrlAbsolute(relativePath)) {
@@ -143,13 +112,17 @@ function normalizeConfig (config, configFilePath) {
   config.customDebugFile = helper.normalizeWinPath(config.customDebugFile)
   config.customClientContextFile = helper.normalizeWinPath(config.customClientContextFile)
 
-  // normalize urlRoot
-  config.urlRoot = normalizeUrlRoot(config.urlRoot)
+  if (!ValidationUtils.isSurroundedWith(config.urlRoot, '/')) {
+    throw new Error('Invalid configuration: invalid urlRoot - must starts and ends with "/"')
+  }
 
   // normalize and default upstream proxy settings if given
   if (config.upstreamProxy) {
     const proxy = config.upstreamProxy
-    proxy.path = helper.isDefined(proxy.path) ? normalizeProxyPath(proxy.path) : '/'
+    if (helper.isDefined(proxy.path) && !ValidationUtils.isSurroundedWith(proxy.path, '/')) {
+      throw new Error('Invalid configuration: invalid upstreamProxy.path - must starts and ends with "/"')
+    }
+    proxy.path = helper.isDefined(proxy.path) ? proxy.path : '/'
     proxy.hostname = helper.isDefined(proxy.hostname) ? proxy.hostname : 'localhost'
     proxy.port = helper.isDefined(proxy.port) ? proxy.port : 9875
 

--- a/lib/utils/validation-utils.js
+++ b/lib/utils/validation-utils.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const ValidationUtils = {
+  isSurroundedWith (text, value) {
+    return text.startsWith(value) && text.endsWith(value)
+  }
+}
+
+module.exports = ValidationUtils

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -13,7 +13,7 @@ describe('config', () => {
   const resolveWinPath = (p) => helper.normalizeWinPath(path.resolve(p))
 
   const normalizeConfigWithDefaults = (cfg) => {
-    if (!cfg.urlRoot) cfg.urlRoot = ''
+    if (!helper.isDefined(cfg.urlRoot)) cfg.urlRoot = '/'
     if (!cfg.proxyPath) cfg.proxyPath = ''
     if (!cfg.files) cfg.files = []
     if (!cfg.exclude) cfg.exclude = []
@@ -175,21 +175,21 @@ describe('config', () => {
       ])
     })
 
-    it('should normalize urlRoot config', () => {
-      let config = normalizeConfigWithDefaults({urlRoot: ''})
-      expect(config.urlRoot).to.equal('/')
+    it('should validate that urlRoot starts and ends with "/"', () => {
+      expect(() => normalizeConfigWithDefaults({urlRoot: ''}))
+        .to.throw('Invalid configuration: invalid urlRoot - must starts and ends with "/"')
 
-      config = normalizeConfigWithDefaults({urlRoot: '/a/b'})
-      expect(config.urlRoot).to.equal('/a/b/')
+      expect(() => normalizeConfigWithDefaults({urlRoot: '/a/b'}))
+        .to.throw('Invalid configuration: invalid urlRoot - must starts and ends with "/"')
 
-      config = normalizeConfigWithDefaults({urlRoot: 'a/'})
-      expect(config.urlRoot).to.equal('/a/')
+      expect(() => normalizeConfigWithDefaults({urlRoot: 'a/'}))
+        .to.throw('Invalid configuration: invalid urlRoot - must starts and ends with "/"')
 
-      config = normalizeConfigWithDefaults({urlRoot: 'some/thing'})
-      expect(config.urlRoot).to.equal('/some/thing/')
+      expect(() => normalizeConfigWithDefaults({urlRoot: 'some/thing'}))
+        .to.throw('Invalid configuration: invalid urlRoot - must starts and ends with "/"')
     })
 
-    it('should normalize upstream proxy config', () => {
+    it('should validate and normalize upstream proxy config', () => {
       let config = normalizeConfigWithDefaults({})
       expect(config.upstreamProxy).to.be.undefined
 
@@ -208,14 +208,14 @@ describe('config', () => {
       config = normalizeConfigWithDefaults({upstreamProxy: {protocol: 'unknown'}})
       expect(config.upstreamProxy.protocol).to.equal('http:')
 
-      config = normalizeConfigWithDefaults({upstreamProxy: {path: '/a/b'}})
-      expect(config.upstreamProxy.path).to.equal('/a/b/')
+      expect(() => normalizeConfigWithDefaults({upstreamProxy: {path: '/a/b'}}))
+        .to.throw('Invalid configuration: invalid upstreamProxy.path - must starts and ends with "/"')
 
-      config = normalizeConfigWithDefaults({upstreamProxy: {path: 'a/'}})
-      expect(config.upstreamProxy.path).to.equal('/a/')
+      expect(() => normalizeConfigWithDefaults({upstreamProxy: {path: 'a/'}}))
+        .to.throw('Invalid configuration: invalid upstreamProxy.path - must starts and ends with "/"')
 
-      config = normalizeConfigWithDefaults({upstreamProxy: {path: 'some/thing'}})
-      expect(config.upstreamProxy.path).to.equal('/some/thing/')
+      expect(() => normalizeConfigWithDefaults({upstreamProxy: {path: 'some/thing'}}))
+        .to.throw('Invalid configuration: invalid upstreamProxy.path - must starts and ends with "/"')
     })
 
     it('should change autoWatch to false if singleRun', () => {

--- a/test/unit/utils/validation-utils.spec.js
+++ b/test/unit/utils/validation-utils.spec.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const ValidationUtils = require('../../../lib/utils/validation-utils')
+
+describe('ValidationUtils.isSurroundedWith', () => {
+  it('returns true when text start and ends with specified value', () => {
+    expect(ValidationUtils.isSurroundedWith('//Something//', '//')).to.be.true
+  })
+
+  it('returns false when text not ends with specified value', () => {
+    expect(ValidationUtils.isSurroundedWith('//Something/', '//')).to.be.false
+  })
+
+  it('returns false when text not starts with specified value', () => {
+    expect(ValidationUtils.isSurroundedWith('/Something//', '//')).to.be.false
+  })
+})


### PR DESCRIPTION
- [breaking change] - validate `urlRoot` and `upstreamProxy.path` config instead of normalization