### PR TITLE
fix(browser): emit 'browsers_change' in collection

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -37,7 +37,6 @@ class Browser {
 
     this.bindSocketEvents(this.socket)
     this.collection.add(this)
-    this.emitter.emit('browsers_change', this.collection) // TODO(vojta): move to collection
     this.emitter.emit('browser_register', this)
   }
 
@@ -128,7 +127,6 @@ class Browser {
       this.state = CONNECTED
 
       this.collection.add(this)
-      this.emitter.emit('browsers_change', this.collection) // TODO(vojta): move to collection
       this.emitter.emit('browser_register', this)
     }
 


### PR DESCRIPTION
BrowsersCollection.add emit `browsers_change` event, so there is no need to emit it once again from Browser instance.