### PR TITLE
refactor(lib): use assert library instead of throwing error directly

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const path = require('path')
+const assert = require('assert')
 const optimist = require('optimist')
 const fs = require('graceful-fs')
 
@@ -23,12 +24,10 @@ function processArgs (argv, options, fs, path) {
   Object.getOwnPropertyNames(argv).forEach(function (name) {
     let argumentValue = argv[name]
     if (name !== '_' && name !== '$0') {
-      if (name.includes('_')) {
-        throw new Error(`Bad argument: ${name} did you mean ${name.replace('_', '-')}`)
-      }
+      assert(!name.includes('_'), `Bad argument: ${name} did you mean ${name.replace('_', '-')}`)
+
       if (Array.isArray(argumentValue)) {
-        // If the same argument is defined multiple times, override.
-        argumentValue = argumentValue.pop()
+        argumentValue = argumentValue.pop() // If the same argument is defined multiple times, override.
       }
       options[helper.dashToCamel(name)] = argumentValue
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const path = require('path')
+const assert = require('assert')
 
 const logger = require('./logger')
 const log = logger.create('config')
@@ -191,24 +192,24 @@ function normalizeConfig (config, configFilePath) {
     config.reporters = config.reporters.split(',')
   }
 
-  if (config.client && config.client.args && !Array.isArray(config.client.args)) {
-    throw new Error('Invalid configuration: client.args must be an array of strings')
+  if (config.client && config.client.args) {
+    assert(Array.isArray(config.client.args), 'Invalid configuration: client.args must be an array of strings')
   }
 
-  if (config.browsers && Array.isArray(config.browsers) === false) {
-    throw new TypeError('Invalid configuration: browsers option must be an array')
+  if (config.browsers) {
+    assert(Array.isArray(config.browsers), 'Invalid configuration: browsers option must be an array')
   }
 
-  if (config.formatError && !helper.isFunction(config.formatError)) {
-    throw new TypeError('Invalid configuration: formatError option must be a function.')
+  if (config.formatError) {
+    assert(helper.isFunction(config.formatError), 'Invalid configuration: formatError option must be a function.')
   }
 
-  if (config.processKillTimeout && !helper.isNumber(config.processKillTimeout)) {
-    throw new TypeError('Invalid configuration: processKillTimeout option must be a number.')
+  if (config.processKillTimeout) {
+    assert(helper.isNumber(config.processKillTimeout), 'Invalid configuration: processKillTimeout option must be a number.')
   }
 
-  if (config.browserSocketTimeout && !helper.isNumber(config.browserSocketTimeout)) {
-    throw new TypeError('Invalid configuration: browserSocketTimeout option must be a number.')
+  if (config.browserSocketTimeout) {
+    assert(helper.isNumber(config.browserSocketTimeout), 'Invalid configuration: browserSocketTimeout option must be a number.')
   }
 
   const defaultClient = config.defaultClient || {}

--- a/test/unit/cli.spec.js
+++ b/test/unit/cli.spec.js
@@ -196,7 +196,7 @@ describe('cli', () => {
       } catch (e) {
         expectedException = e
       } finally {
-        expect(expectedException + '').to.equal('Error: Bad argument: no_browsers did you mean no-browsers')
+        expect(expectedException + '').to.includes('Bad argument: no_browsers did you mean no-browsers')
       }
     })
   })


### PR DESCRIPTION
NodeJS includes [assertion library](https://nodejs.org/api/assert.html) natively, and it's syntax seems to be more elegant that throwing errors directly.