### PR TITLE
refactor(lib): coffe script support

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,14 +13,6 @@ let COFFEE_SCRIPT_AVAILABLE = false
 let LIVE_SCRIPT_AVAILABLE = false
 let TYPE_SCRIPT_AVAILABLE = false
 
-// Coffee is required here to enable config files written in coffee-script.
-// It's not directly used in this file.
-try {
-  require('coffee-script').register()
-  COFFEE_SCRIPT_AVAILABLE = true
-} catch (e) {}
-
-// CoffeeScript lost the hyphen in the module name a long time ago, all new version are named this:
 try {
   require('coffeescript').register()
   COFFEE_SCRIPT_AVAILABLE = true
@@ -367,7 +359,7 @@ function parseConfig (configFilePath, cliOptions) {
 
         const extension = path.extname(configFilePath)
         if (extension === '.coffee' && !COFFEE_SCRIPT_AVAILABLE) {
-          log.error('You need to install CoffeeScript.\n  npm install coffee-script --save-dev')
+          log.error('You need to install CoffeeScript.\n  npm install coffeescript --save-dev')
         } else if (extension === '.ls' && !LIVE_SCRIPT_AVAILABLE) {
           log.error('You need to install LiveScript.\n  npm install LiveScript --save-dev')
         } else if (extension === '.ts' && !TYPE_SCRIPT_AVAILABLE) {

--- a/lib/init.js
+++ b/lib/init.js
@@ -225,7 +225,7 @@ exports.init = function (config) {
     const testMainFilePath = path.resolve(cwd, testMainFile)
 
     if (isCoffee) {
-      installPackage('coffee-script')
+      installPackage('coffeescript')
     }
 
     if (processedAnswers.generateTestMain) {


### PR DESCRIPTION
- use 'coffeescript' as a dependency instead of 'coffee-script'

This pull request duplicates https://github.com/karma-runner/karma/pull/2973, but fixes some issues from it. 