### PR TITLE
fix(file-list): do not preprocess up-to-date files

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -102,6 +102,12 @@ class FileList {
           return Promise.resolve(file)
         }
 
+        const prevFile = this._findFile(path, patternObject)
+        if (prevFile && file.mtime <= prevFile.mtime) {
+          log.debug(`Not preprocessing "${path}" as file hasn't been changed since the last preprocessing`)
+          return Promise.resolve(prevFile)
+        }
+
         return this._preprocess(file).then(() => file)
       })
         .then((files) => {

--- a/test/unit/file-list.spec.js
+++ b/test/unit/file-list.spec.js
@@ -375,9 +375,15 @@ describe('FileList', () => {
         })
     })
 
-    it('preprocesses all files', () => {
+    it('preprocesses new and/or changed files', () => {
       return list.refresh().then((files) => {
         expect(preprocess.callCount).to.be.eql(5)
+        preprocess.resetHistory()
+        mg.statCache['/some/a.js'].mtime++
+        return list.refresh().then((files) => {
+          expect(preprocess.callCount).to.be.eql(1)
+          mg.statCache['/some/a.js'].mtime--
+        })
       })
     })
 


### PR DESCRIPTION
It improves performance of "karma run" command which refreshes fileList.

Closes #2829