### PR TITLE
chore(deps): Bump useragent to 2.3.0 to fix #2762

### DIFF
--- a/package.json
+++ b/package.json
@@ -395,7 +395,7 @@
     "socket.io": "2.1.1",
     "source-map": "^0.6.1",
     "tmp": "0.0.33",
-    "useragent": "2.2.1"
+    "useragent": "2.3.0"
   },
   "devDependencies": {
     "LiveScript": "^1.3.0",


### PR DESCRIPTION
Bump useragent `2.3.0` to pull in https://github.com/ua-parser/uap-core/pull/263/ in which Headless Chrome version detected to be `0.0.0`.

Fixes #2762
