### PR TITLE
fix(dep): Bump useragent to fix HeadlessChrome version

### DIFF
--- a/package.json
+++ b/package.json
@@ -395,7 +395,7 @@
     "socket.io": "2.1.1",
     "source-map": "^0.6.1",
     "tmp": "0.0.33",
-    "useragent": "2.2.1"
+    "useragent": "2.3.0"
   },
   "devDependencies": {
     "LiveScript": "^1.3.0",

--- a/test/unit/helper.spec.js
+++ b/test/unit/helper.spec.js
@@ -5,7 +5,7 @@ const path = require('path')
 describe('helper', () => {
   const helper = require('../../lib/helper')
 
-  describe('browserFullNameToShort', () => {
+  describe.only('browserFullNameToShort', () => {
     // helper function
     const expecting = (name) => expect(helper.browserFullNameToShort(name))
 
@@ -75,7 +75,7 @@ describe('helper', () => {
         'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; WOW64; SLCC1; ' +
         '.NET CLR 2.0.50727; .NET4.0C; .NET4.0E)'
       )
-        .to.be.equal('IE 7.0.0 (Windows Vista 0.0.0)')
+        .to.be.equal('IE 7.0.0 (Windows Vista.0.0)')
     })
 
     it('should parse IE8', () => {
@@ -83,7 +83,7 @@ describe('helper', () => {
         'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; ' +
         'SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E; InfoPath.3)"'
       )
-        .to.be.equal('IE 8.0.0 (Windows 7 0.0.0)')
+        .to.be.equal('IE 8.0.0 (Windows 7.0.0)')
     })
 
     it('should parse IE9', () => {
@@ -91,7 +91,7 @@ describe('helper', () => {
         'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0; ' +
         '.NET CLR 2.0.50727; SLCC2; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)'
       )
-        .to.be.equal('IE 9.0.0 (Windows 7 0.0.0)')
+        .to.be.equal('IE 9.0.0 (Windows 7.0.0)')
     })
 
     it('should parse IE10', () => {
@@ -99,7 +99,7 @@ describe('helper', () => {
         'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0; ' +
         '.NET4.0E; .NET4.0C)'
       )
-        .to.be.equal('IE 10.0.0 (Windows 8 0.0.0)')
+        .to.be.equal('IE 10.0.0 (Windows 8.0.0)')
     })
 
     it('should parse PhantomJS', () => {
@@ -117,6 +117,14 @@ describe('helper', () => {
         'AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
       )
         .to.be.equal('Android 4.2.0 (Android 4.2.0)')
+    })
+
+    it('should parse Headless Chrome', () => {
+      expecting(
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+        'HeadlessChrome/70.0.3538.77 Safari/537.36'
+      )
+        .to.be.equal('HeadlessChrome 70.0.3538 (Linux 0.0.0)')
     })
   })
 


### PR DESCRIPTION
Bump useragent to `2.3.0` to pull in ua-parser/uap-core#263 in which Headless Chrome version detected to be `0.0.0`.
Update tests to reflect latest `useragent` OS major version string identifiers.

Per https://github.com/ua-parser/uap-core/pull/286 , `useragent` purposely sets the Windows Vista `family` to `Windows` and `major` version to `Vista`. The change to `useragent` was intentional, and the maintainer advises upstream consumers to update tests to reflect the change.

Per https://github.com/3rd-Eden/useragent/issues/120 , there is an open question to change the stringified OS to not include `0` for missing version numbers. For example:
```
family: 'Windows'
major: 'Vista'
minor:
patch:
patch_minor:
```
would display as `"Windows Vista"` instead of `"Windows Vista.0.0"`.

That open question not withstanding, this commit is an incremental improvement: You can now see both Chrome Headless version and Windows version information in your console output. In general, `useragent` [consumers that perform `int()` conversions on `'major'`](https://github.com/ua-parser/uap-core/issues/351#issue-368103777) should be aware.

Fixes #2762
