### PR TITLE
fix(package): bump lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -383,7 +383,7 @@
     "graceful-fs": "^4.1.2",
     "http-proxy": "^1.13.0",
     "isbinaryfile": "^3.0.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.5",
     "log4js": "^3.0.0",
     "mime": "^2.3.1",
     "minimatch": "^3.0.2",


### PR DESCRIPTION
Bumps lodash to 4.17.5 avoid medium severity vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2018-3721) found in 4.17.4.

Closes #3177.
