### PR TITLE
Remove logged output

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -63,8 +63,6 @@ class Server extends KarmaEventEmitter {
 
     const config = cfg.parseConfig(cliOptions.configFile, cliOptions)
 
-    this.log.debug('Final config', JSON.stringify(config, null, 2))
-
     let modules = [{
       helper: ['value', helper],
       logger: ['value', logger],


### PR DESCRIPTION
This line throws `TypeError: Converting circular structure to JSON` and there's no way to disable it, even though the config that's used it perfectly valid.

Check that your description matches the automatic change-log format:
http://karma-runner.github.io/latest/dev/git-commit-msg.html
then delete this reminder.
