### PR TITLE
fix(file-list): revert "do not preprocess up-to-date files" (#3226)

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -102,12 +102,6 @@ class FileList {
           return Promise.resolve(file)
         }
 
-        const prevFile = this._findFile(path, patternObject)
-        if (prevFile && file.mtime <= prevFile.mtime) {
-          log.debug(`Not preprocessing "${path}" as file hasn't been changed since the last preprocessing`)
-          return Promise.resolve(prevFile)
-        }
-
         return this._preprocess(file).then(() => file)
       })
         .then((files) => {

--- a/test/unit/file-list.spec.js
+++ b/test/unit/file-list.spec.js
@@ -375,15 +375,9 @@ describe('FileList', () => {
         })
     })
 
-    it('preprocesses new and/or changed files', () => {
+    it('preprocesses all files', () => {
       return list.refresh().then((files) => {
         expect(preprocess.callCount).to.be.eql(5)
-        preprocess.resetHistory()
-        mg.statCache['/some/a.js'].mtime++
-        return list.refresh().then((files) => {
-          expect(preprocess.callCount).to.be.eql(1)
-          mg.statCache['/some/a.js'].mtime--
-        })
       })
     })
 


### PR DESCRIPTION
This reverts commit 5334d1a8
karma-webpack preprocessor updates bundle when needed, but karma's fileList consists of a single entry file which is usually unmodified. In this case, fileList.refresh() should always call preprocessor for the single entry file, avoiding preprocessing of unmodified files is done on karma-webpack side.