### PR TITLE
fix(client): fix issue with loaded on safari 10

### DIFF
--- a/context/karma.js
+++ b/context/karma.js
@@ -6,6 +6,7 @@ function ContextKarma (callParentKarmaMethod) {
   // Define local variables
   var hasError = false
   var self = this
+  var isLoaded = false
 
   // Define our loggers
   // DEV: These are intentionally repeated in client and context
@@ -36,7 +37,8 @@ function ContextKarma (callParentKarmaMethod) {
   // all files loaded, let's start the execution
   this.loaded = function () {
     // has error -> cancel
-    if (!hasError) {
+    if (!hasError && !isLoaded) {
+      isLoaded = true
       try {
         this.start(this.config)
       } catch (error) {

--- a/test/client/karma.spec.js
+++ b/test/client/karma.spec.js
@@ -433,5 +433,20 @@ describe('Karma', function () {
 
       assert.equal(iframe.src, CURRENT_URL)
     })
+
+    it('should accept multiple calls to loaded', function () {
+      // support for Safari 10 since it supports type=module but not nomodule.
+      var config = ck.config = {
+        useIframe: true
+      }
+
+      socket.emit('execute', config)
+      assert(!startSpy.called)
+
+      ck.loaded()
+      ck.loaded()
+      assert(startSpy.calledWith(config))
+      assert(startSpy.getCalls().length === 1)
+    })
   })
 })


### PR DESCRIPTION
fix(client): fix issue with loaded on safari 10

Safari 10 supports type=module but ignores nomodule which causes loaded() to execute twice.

Fixes #3198
