### PR TITLE
refactor(watcher): Make watcher injectable to support 3rd-party watchers

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -73,6 +73,7 @@ class Server extends KarmaEventEmitter {
       done: ['value', done || process.exit],
       emitter: ['value', this],
       server: ['value', this],
+      watcher: ['value', watcher],
       launcher: ['type', Launcher],
       config: ['value', config],
       preprocess: ['factory', preprocessor.createPreprocessor],
@@ -164,7 +165,8 @@ class Server extends KarmaEventEmitter {
 
     const afterPreprocess = () => {
       if (config.autoWatch) {
-        this._injector.invoke(watcher.watch)
+        const watcher = this.get('watcher')
+        this._injector.invoke(watcher)
       }
 
       webServer.listen(this._boundServer, () => {

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const chokidar = require('chokidar')
 const mm = require('minimatch')
 const expandBraces = require('expand-braces')
 const PatternUtils = require('./utils/pattern-utils')
@@ -42,9 +41,11 @@ function getWatchedPatterns (patterns) {
     .map((pattern) => pattern.pattern)
 }
 
-exports.watch = function (patterns, excludes, fileList, usePolling, emitter) {
+function watch (patterns, excludes, fileList, usePolling, emitter) {
   const watchedPatterns = getWatchedPatterns(patterns)
-
+  // Lazy-load 'chokidar' to make the dependency optional. This is desired when
+  // third-party watchers are in use.
+  const chokidar = require('chokidar')
   const watcher = new chokidar.FSWatcher({
     usePolling: usePolling,
     ignorePermissionErrors: true,
@@ -68,10 +69,12 @@ exports.watch = function (patterns, excludes, fileList, usePolling, emitter) {
   return watcher
 }
 
-exports.watch.$inject = [
+watch.$inject = [
   'config.files',
   'config.exclude',
   'fileList',
   'config.usePolling',
   'emitter'
 ]
+
+module.exports = watch


### PR DESCRIPTION
Over the years, there has been several suggestions to make the default
watcher in Karma (that uses chokidar) dependency injectable so that
Karma could work well with third-party watchers.

Prior issues:
1. https://github.com/karma-runner/karma/issues/1468
2. https://github.com/karma-runner/karma/pull/2895

Candidate third-party watchers include:
1. Watcher for Broccoli
2. Watcher for Bazel
3. Watcher for Blaze (used internally at Google)

This commit makes the change to allow other Karma plugins to specify the
'watcher' value in the di system and Karma would use the supplied
watcher instead.

