### PR TITLE
Debug Child Processes exit signal

### DIFF
--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -79,8 +79,8 @@ function ProcessLauncher (spawn, tempDir, timer, processKillTimeout) {
 
     self._process.stderr.on('data', self._onStderr)
 
-    self._process.on('exit', function (code) {
-      self._onProcessExit(code, errorOutput)
+    self._process.on('exit', function (code, signal) {
+      self._onProcessExit(code, signal, errorOutput)
     })
 
     self._process.on('error', function (err) {
@@ -100,8 +100,8 @@ function ProcessLauncher (spawn, tempDir, timer, processKillTimeout) {
     })
   }
 
-  this._onProcessExit = function (code, errorOutput) {
-    log.debug(`Process ${self.name} exited with code ${code}`)
+  this._onProcessExit = function (code, signal, errorOutput) {
+    log.debug(`Process ${self.name} exited with code ${code} and signal ${signal}`)
 
     let error = null
 
@@ -156,7 +156,7 @@ function ProcessLauncher (spawn, tempDir, timer, processKillTimeout) {
     // for a zombie child process to exit.
     self._killTimer = timer.setTimeout(function () {
       log.warn(`${self.name} was not killed by SIGKILL in ${killTimeout} ms, continuing.`)
-      self._onProcessExit(-1, '')
+      self._onProcessExit(-1, null, '')
     }, killTimeout)
   }
 }


### PR DESCRIPTION
The Child Processes Event: 'exit' has two parameters: `code` and `signal` (https://nodejs.org/api/child_process.html#child_process_event_exit)

> One of the two will always be non-null.

This helps debugging cases where code is null.