### PR TITLE
fix(browser): allow updating total specs count

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -61,7 +61,9 @@ class Browser {
     if (helper.isDefined(info.log)) {
       this.emitter.emit('browser_log', this, info.log, info.type)
     } else if (helper.isDefined(info.total)) {
-      this.lastResult.total = info.total
+      if (this.state === EXECUTING) {
+        this.lastResult.total = info.total
+      }
     } else if (!helper.isDefined(info.dump)) {
       this.emitter.emit('browser_info', this, info)
     }

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -60,6 +60,8 @@ class Browser {
 
     if (helper.isDefined(info.log)) {
       this.emitter.emit('browser_log', this, info.log, info.type)
+    } else if (helper.isDefined(info.total)) {
+      this.lastResult.total = info.total
     } else if (!helper.isDefined(info.dump)) {
       this.emitter.emit('browser_info', this, info)
     }

--- a/test/unit/browser.spec.js
+++ b/test/unit/browser.spec.js
@@ -123,12 +123,19 @@ describe('Browser', () => {
       expect(spy).to.have.been.calledWith(browser, infoData)
     })
 
-    it('should ignore if browser not executing', () => {
+    it('should update total specs count during execution', () => {
+      browser.state = Browser.STATE_EXECUTING
+      browser.onInfo({total: 20})
+
+      expect(browser.lastResult.total).to.equal(20)
+    })
+
+    it('should ignore update total if not executing', () => {
       const spy = sinon.spy()
-      emitter.on('browser_dump', spy)
+      emitter.on('browser_log', spy)
+      emitter.on('browser_info', spy)
 
       browser.state = Browser.STATE_CONNECTED
-      browser.onInfo({dump: 'something'})
       browser.onInfo({total: 20})
 
       expect(browser.lastResult.total).to.equal(0)


### PR DESCRIPTION
This change allows providing the total specs count after the tests have
been started.
The count will be updated in case it has been provided already.
This can be uselful for some adapters where the total specs count can
not be determined before starting the first test.

**Regarding tests**
I wanted to update the tests and/or create a test case but the `onInfo` tests are not clear to me:
- 'browser_dump' doesn't seem to be a valid event
- I'm not sure whether the behavior of the tests is really expected or just works by chance.

So I would be happy to get feedback from you before writing a test case.
https://github.com/karma-runner/karma/blob/c277a6bd130531702e2529f0410aa441328f187e/test/unit/browser.spec.js#L102-L137
