### PR TITLE
fix: remove vulnerable dependency expand-braces

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const mm = require('minimatch')
-const expandBraces = require('expand-braces')
+const braces = require('braces')
 const PatternUtils = require('./utils/pattern-utils')
 
 const helper = require('./helper')
@@ -10,7 +10,11 @@ const log = require('./logger').create('watcher')
 const DIR_SEP = require('path').sep
 
 function watchPatterns (patterns, watcher) {
-  expandBraces(patterns) // expand ['a/{b,c}'] to ['a/b', 'a/c']
+  let expandedPatterns = []
+  patterns.map((pattern) => {
+    expandedPatterns = expandedPatterns.concat(braces.expand(pattern)) // expand ['a/{b,c}'] to ['a/b', 'a/c']
+  })
+  expandedPatterns
     .map(PatternUtils.getBaseDir)
     .filter((path, index, paths) => paths.indexOf(path) === index) // filter unique values
     .forEach((path, index, paths) => {

--- a/package.json
+++ b/package.json
@@ -380,6 +380,7 @@
   "dependencies": {
     "bluebird": "^3.3.0",
     "body-parser": "^1.16.1",
+    "braces": "^2.3.2",
     "chokidar": "^2.0.3",
     "colors": "^1.1.0",
     "combine-lists": "^1.0.0",
@@ -387,7 +388,6 @@
     "core-js": "^2.2.0",
     "di": "^0.0.1",
     "dom-serialize": "^2.2.0",
-    "expand-braces": "^0.1.1",
     "flatted": "^2.0.0",
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.2",


### PR DESCRIPTION
Remove `expand-braces` as a dependency. Use `braces.expand` instead
now.

Fixes #3268
Fixes #3269

Check that your description matches the automatic change-log format:
http://karma-runner.github.io/latest/dev/git-commit-msg.html
then delete this reminder.
