### PR TITLE
fix(config): remove ts-node register() call to allow custom configuration

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -64,7 +64,7 @@ require('ts-node').register({
     module: 'commonjs' 
   } 
 });
-require('./karma.conf.ts');
+module.exports = require('./karma.conf.ts');
 ```
 
 ## File Patterns

--- a/lib/config.js
+++ b/lib/config.js
@@ -27,7 +27,7 @@ try {
 } catch (e) {}
 
 try {
-  require('ts-node').register()
+  require('ts-node')
   TYPE_SCRIPT_AVAILABLE = true
 } catch (e) {}
 


### PR DESCRIPTION
Calling `require('ts-node').register()` to determine if `typescript` is available prevents the custom configuration of the `register` call described in the documentation. I removed the unnecessary `register` call and fixed the missing `module.exports` assignment in the documentation.