### PR TITLE
feat(runner): Config option to prevent logging to the console twice

### DIFF
--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -129,6 +129,17 @@ runner.run({port: 9876}, function(exitCode) {
 })
 ```
 
+`runner.run()` returns an `EventEmitter` which emits a `progress` event passing
+the reporter output as a `Buffer` object.
+
+You may listen for that event to print the reporter output to the console:
+
+```javascript
+runner.run({port: 9876}).on('progress', function(data) {
+  process.stdout.write(data)
+})
+```
+
 ## karma.stopper
 
 ### **stopper.stop(options, [callback=process.exit])**

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -240,6 +240,10 @@ function describeCompletion () {
     .describe('help', 'Print usage.')
 }
 
+function printRunnerProgress (data) {
+  process.stdout.write(data)
+}
+
 exports.process = function () {
   const argv = optimist.parse(argsBeforeDoubleDash(process.argv.slice(2)))
   const options = {
@@ -291,7 +295,9 @@ exports.run = function () {
       new Server(config).start()
       break
     case 'run':
-      require('./runner').run(config)
+      require('./runner')
+        .run(config)
+        .on('progress', printRunnerProgress)
       break
     case 'stop':
       require('./stopper').stop(config)

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -3,6 +3,7 @@
 const http = require('http')
 
 const constant = require('./constants')
+const EventEmitter = require('events').EventEmitter
 const helper = require('./helper')
 const cfg = require('./config')
 const logger = require('./logger')
@@ -40,6 +41,7 @@ function run (config, done) {
   config = cfg.parseConfig(config.configFile, config)
 
   let exitCode = 1
+  let emitter = new EventEmitter()
   const options = {
     hostname: config.hostname,
     path: config.urlRoot + 'run',
@@ -54,6 +56,7 @@ function run (config, done) {
     response.on('data', function (buffer) {
       const parsedResult = parseExitCode(buffer, exitCode, config.failOnEmptyTestSuite)
       exitCode = parsedResult.exitCode
+      emitter.emit('progress', parsedResult.buffer)
       process.stdout.write(parsedResult.buffer)
     })
 
@@ -77,6 +80,8 @@ function run (config, done) {
     refresh: config.refresh,
     colors: config.colors
   }))
+
+  return emitter
 }
 
 exports.run = run

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -57,7 +57,6 @@ function run (config, done) {
       const parsedResult = parseExitCode(buffer, exitCode, config.failOnEmptyTestSuite)
       exitCode = parsedResult.exitCode
       emitter.emit('progress', parsedResult.buffer)
-      process.stdout.write(parsedResult.buffer)
     })
 
     response.on('end', () => done(exitCode))


### PR DESCRIPTION
This might be the case when Karma.run() is called inside the same
process/terminal as the server is running in (e.g. development
servers).

Fixes #2121, #2799
