### PR TITLE
fix(client): Enable loading different file types when running in parent mode without iframe

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -81,7 +81,7 @@ function Karma (socket, iframe, opener, navigator, location) {
               var tmp = ele
               ele = document.createElement('script')
               ele.src = tmp.src
-              ele.crossOrigin = tmp.crossorigin
+              ele.crossOrigin = tmp.crossOrigin
             }
             ele.onload = function () {
               loadScript(idx + 1)

--- a/client/karma.js
+++ b/client/karma.js
@@ -67,15 +67,13 @@ function Karma (socket, iframe, opener, navigator, location) {
         var loadScript = function (idx) {
           if (idx < window.__karma__.scriptUrls.length) {
             var parser = new DOMParser()
-            // Browsers don't like character <> in string when assigning
-            // stringify json into a variable, so we replace them with escape
-            // hex
+            // Revert escaped characters with special roles in HTML before parsing
             var string = window.__karma__.scriptUrls[idx]
               .replace(/\\x3C/g, '<')
               .replace(/\\x3E/g, '>')
             var doc = parser.parseFromString(string, 'text/html')
             var ele = doc.head.firstChild || doc.body.firstChild
-            // script elements created by DomParser is marked as unexecutable,
+            // script elements created by DomParser are marked as unexecutable,
             // create a new script element manually and copy necessary properties
             // so it is executable
             if (ele.tagName && ele.tagName.toLowerCase() === 'script') {

--- a/client/karma.js
+++ b/client/karma.js
@@ -62,7 +62,8 @@ function Karma (socket, iframe, opener, navigator, location) {
           childWindow.close()
         }
         childWindow = opener(url)
-      // run context on parent element and dynamically loading scripts
+      // run context on parent element (client_with_context)
+      // using window.__karma__.scriptUrls to get the html element strings and load them dynamically
       } else if (url !== 'about:blank') {
         var loadScript = function (idx) {
           if (idx < window.__karma__.scriptUrls.length) {

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -205,6 +205,8 @@ function createKarmaMiddleware (
             }
           }
           for (const script of scriptTags) {
+            // Escape characters with special roles (tags) in HTML. Open angle brackets are parsed as tags
+            // immediately, even if it is within double quotations, in browsers
             scriptUrls.push(script.replace(/</g, '\\x3C').replace(/>/g, '\\x3E'))
           }
 

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -192,8 +192,6 @@ function createKarmaMiddleware (
               }
             }
 
-            scriptUrls.push(filePath)
-
             if (fileType === 'css') {
               scriptTags.push(`<link type="text/css" href="${filePath}" rel="stylesheet">`)
             } else if (fileType === 'dom') {
@@ -205,6 +203,9 @@ function createKarmaMiddleware (
               const crossOriginAttribute = includeCrossOriginAttribute ? 'crossorigin="anonymous"' : ''
               scriptTags.push(`<script type="${scriptType}" src="${filePath}" ${crossOriginAttribute}></script>`)
             }
+          }
+          for (const script of scriptTags) {
+            scriptUrls.push(script.replace(/</g, '\\x3C').replace(/>/g, '\\x3E'))
           }
 
           const mappings = data.includes('%MAPPINGS%') ? files.served.map((file) => {

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -207,8 +207,7 @@ function createKarmaMiddleware (
           const scriptUrls = []
           // For client_with_context, html elements are not added directly through an iframe.
           // Instead, scriptTags is stored to window.__karma__.scriptUrls first. Later, the
-          // client will read window.__karma__.scriptUrls and dynamically add them to the DOM
-          // using DOMParser.
+          // client will read window.__karma__.scriptUrls and dynamically add them to the DOM using DOMParser.
           if (requestUrl === '/client_with_context.html') {
             for (const script of scriptTags) {
               scriptUrls.push(

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -207,7 +207,8 @@ function createKarmaMiddleware (
           const scriptUrls = []
           // For client_with_context, html elements are not added directly through an iframe.
           // Instead, scriptTags is stored to window.__karma__.scriptUrls first. Later, the
-          // client will read window.__karma__.scriptUrls and dynamically add them to the DOM using DOMParser.
+          // client will read window.__karma__.scriptUrls and dynamically add them to the DOM
+          // using DOMParser.
           if (requestUrl === '/client_with_context.html') {
             for (const script of scriptTags) {
               scriptUrls.push(

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -175,7 +175,6 @@ function createKarmaMiddleware (
           common.setNoCacheHeaders(response)
 
           const scriptTags = []
-          const scriptUrls = []
           for (const file of files.included) {
             let filePath = file.path
             const fileType = file.type || path.extname(filePath).substring(1)
@@ -204,10 +203,19 @@ function createKarmaMiddleware (
               scriptTags.push(`<script type="${scriptType}" src="${filePath}" ${crossOriginAttribute}></script>`)
             }
           }
-          for (const script of scriptTags) {
-            // Escape characters with special roles (tags) in HTML. Open angle brackets are parsed as tags
-            // immediately, even if it is within double quotations, in browsers
-            scriptUrls.push(script.replace(/</g, '\\x3C').replace(/>/g, '\\x3E'))
+
+          const scriptUrls = []
+          // For client_with_context, html elements are not added directly through an iframe.
+          // Instead, scriptTags is stored to window.__karma__.scriptUrls first. Later, the
+          // client will read window.__karma__.scriptUrls and dynamically add them to the DOM
+          // using DOMParser.
+          if (requestUrl === '/client_with_context.html') {
+            for (const script of scriptTags) {
+              scriptUrls.push(
+                // Escape characters with special roles (tags) in HTML. Open angle brackets are parsed as tags
+                // immediately, even if it is within double quotations in browsers
+                script.replace(/</g, '\\x3C').replace(/>/g, '\\x3E'))
+            }
           }
 
           const mappings = data.includes('%MAPPINGS%') ? files.served.map((file) => {


### PR DESCRIPTION
Enable loading different file types when running in parent mode without iframe.

By default, the Karma middleware reads the included files and generates the corresponding HTML in string which eventually replaced the %SCRIPTS%. The client then later loads the iframe that embeds this context.html.

In #2542, I introduced a third option to run tests on lightweight browsers without iframe support. This is achieved by running test within the parent page and dynamically load all the files. I created a client_with_context.html which combines both client.html and context.html. The Karma middleware will concatenate all the included file paths, turns it to a long string with ',' separator and replace it with %SCRIPT_URL_ARRAY% in client_with_context.html. On the client side, it will read the %SCRIPT_URL_ARRAY% string and dynamically load the file one by one by creating script element. This is where the bug is introduced because I assume that all the included files are javascript, which actually covers most of the use cases in Karma.

Recently, we would like to run Karma for UI testing using a screenshot plugin and we see css files are actually not properly loaded. In this fix, instead of passing the files paths to client, we are passing the HTML element in string. The client reads the HTML in string and created the corresponding html element using DOMParser() and then it is appended to the DOM dynamically.

When I try out this new approach, one of the issue I see is script elements generated by DOMParser don't execute. Therefore, we have to use document.createElement for script elements.
