### PR TITLE
fix(browser): print browser name, not object.

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -37,7 +37,7 @@ const BaseReporter = function (formatError, reportSlow, useColors, browserConsol
   this.renderBrowser = (browser) => {
     const results = browser.lastResult
     const totalExecuted = results.success + results.failed
-    let msg = `${browser}: Executed ${totalExecuted} of ${results.total}`
+    let msg = `${browser.name}: Executed ${totalExecuted} of ${results.total}`
 
     if (results.failed) {
       msg += util.format(this.X_FAILED, results.failed)


### PR DESCRIPTION
Fixes #3305
