### PR TITLE
fix(reporters): output browser name instead of object

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -79,7 +79,7 @@ const BaseReporter = function (formatError, reportSlow, useColors, browserConsol
   }
 
   this.onBrowserError = (browser, error) => {
-    this.writeCommonMsg(util.format(this.ERROR, browser) + formatError(error, '  '))
+    this.writeCommonMsg(util.format(this.ERROR, String(browser)) + formatError(error, '  '))
   }
 
   this.onBrowserLog = (browser, log, type) => {
@@ -96,7 +96,7 @@ const BaseReporter = function (formatError, reportSlow, useColors, browserConsol
     if (this._browsers && this._browsers.length === 1) {
       this.writeCommonMsg(util.format(this.LOG_SINGLE_BROWSER, type, log))
     } else {
-      this.writeCommonMsg(util.format(this.LOG_MULTI_BROWSER, browser, type, log))
+      this.writeCommonMsg(util.format(this.LOG_MULTI_BROWSER, String(browser), type, log))
     }
   }
 
@@ -113,7 +113,7 @@ const BaseReporter = function (formatError, reportSlow, useColors, browserConsol
       const specName = result.suite.join(' ') + ' ' + result.description
       const time = helper.formatTimeInterval(result.time)
 
-      this.writeCommonMsg(util.format(this.SPEC_SLOW, browser, time, specName))
+      this.writeCommonMsg(util.format(this.SPEC_SLOW, String(browser), time, specName))
     }
   }
 
@@ -125,7 +125,7 @@ const BaseReporter = function (formatError, reportSlow, useColors, browserConsol
 
   this.specFailure = (browser, result) => {
     const specName = result.suite.join(' ') + ' ' + result.description
-    let msg = util.format(this.SPEC_FAILURE, browser, specName)
+    let msg = util.format(this.SPEC_FAILURE, String(browser), specName)
 
     result.log.forEach((log) => {
       msg += formatError(log, '\t')


### PR DESCRIPTION
Explicitly convert borwser objects to string when passing to util.format.

Fixes: #3301

