### PR TITLE
fix(reporter): format stack with 1-based column

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -60,11 +60,13 @@ function createErrorFormatter (config, emitter, SourceMapConsumer) {
         const bias = column ? SourceMapConsumer.GREATEST_LOWER_BOUND : SourceMapConsumer.LEAST_UPPER_BOUND
 
         try {
-          const original = getSourceMapConsumer(file.sourceMap).originalPositionFor({ line, column: (column || 0), bias })
+          const zeroBasedColumn = Math.max(0, (column || 1) - 1)
+          const original = getSourceMapConsumer(file.sourceMap).originalPositionFor({ line, column: zeroBasedColumn, bias })
 
           // Source maps often only have a local file name, resolve to turn into a full path if
           // the path is not absolute yet.
-          return `${PathUtils.formatPathMapping(resolve(path, original.source), original.line, original.column)} <- ${PathUtils.formatPathMapping(path, line, column)}`
+          const oneBasedOriginalColumn = original.column == null ? original.column : original.column + 1
+          return `${PathUtils.formatPathMapping(resolve(path, original.source), original.line, oneBasedOriginalColumn)} <- ${PathUtils.formatPathMapping(path, line, column)}`
         } catch (e) {
           log.warn(`SourceMap position not found for trace: ${input}`)
         }

--- a/test/unit/reporter.spec.js
+++ b/test/unit/reporter.spec.js
@@ -195,7 +195,7 @@ describe('reporter', () => {
 
         _.defer(() => {
           const ERROR = 'at http://localhost:123/base/b.js:2'
-          expect(formatError(ERROR)).to.equal('at /original/b.js:4:2 <- b.js:2\n')
+          expect(formatError(ERROR)).to.equal('at /original/b.js:4:3 <- b.js:2\n')
           done()
         })
       })


### PR DESCRIPTION
Columns in original stack are 1-based, but
SourceMapConsumer.prototype.originalPositionFor(generatedPosition)
accepts 0-based column and returns 0-based column too.
This change converts columns from 1-based to 0-based forth and back.

Closes #3324