### PR TITLE
fix(logging): Use flatten only if config is circular.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -11,7 +11,6 @@ const path = require('path')
 
 const BundleUtils = require('./utils/bundle-utils')
 const NetUtils = require('./utils/net-utils')
-const JsonUtils = require('./utils/json-utils')
 const root = global || window || this
 
 const cfg = require('./config')
@@ -65,7 +64,7 @@ class Server extends KarmaEventEmitter {
 
     const config = cfg.parseConfig(cliOptions.configFile, cliOptions)
 
-    this.log.debug('Final config', JsonUtils.stringify(config, null, 2))
+    this.log.debug('Final config', util.inspect(config, false, /** depth **/ null))
 
     let modules = [{
       helper: ['value', helper],


### PR DESCRIPTION
While flatten is accurate and works with circular data, it's too hard to read.
By using vanilla json for most cases the log will be clearer.

