### PR TITLE
fix(test): `test:client` silently failing on Travis

### DIFF
--- a/tasks/test.js
+++ b/tasks/test.js
@@ -26,7 +26,7 @@ module.exports = function (grunt) {
 
     function exec (args, failMsg) {
       spawnKarma(args, function (err, result, code) {
-        if (code) {
+        if (code || err) {
           console.error(err)
           grunt.fail.fatal(failMsg, code)
         } else {

--- a/test/e2e/error.feature
+++ b/test/e2e/error.feature
@@ -16,7 +16,7 @@ Feature: Error Display
     When I start Karma
     Then it fails with:
       """
-      SyntaxError: Unexpected token }
+      SyntaxError: Unexpected token '}'
       """
   Scenario: Not single-run Syntax Error in a test file
     Given a configuration with:
@@ -32,5 +32,5 @@ Feature: Error Display
     When I runOut Karma
     Then it fails with like:
       """
-      SyntaxError: Unexpected token }
+      SyntaxError: Unexpected token '}'
       """


### PR DESCRIPTION
It is not enough to check exit `code`, because when process crashes `code` is set to `null` and `err` is passed instead. Adjusted build script accordingly and forced new version of `natives` to make tests pass.

Example of failing tests, which didn't fail build:
https://travis-ci.org/karma-runner/karma/jobs/537027667#L1046