### PR TITLE
fix(runner): remove explicit error on all tests failed

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -87,10 +87,6 @@ class Browser {
       this.setState(CONNECTED)
       this.lastResult.totalTimeEnd()
 
-      if (!this.lastResult.success) {
-        this.lastResult.error = true
-      }
-
       this.emitter.emit('browsers_change', this.collection)
       this.emitter.emit('browser_complete', this, result)
 

--- a/test/unit/browser.spec.js
+++ b/test/unit/browser.spec.js
@@ -213,13 +213,6 @@ describe('Browser', () => {
 
       expect(browser.lastResult.totalTime).to.equal(2)
     })
-
-    it('should error the result if zero tests executed', () => {
-      browser.state = Browser.STATE_EXECUTING
-      browser.onComplete()
-
-      expect(browser.lastResult.error).to.equal(true)
-    })
   })
 
   describe('onDisconnect', () => {


### PR DESCRIPTION
There are failOnFailingTestSuite and failOnEmptyTestSuite, so in this there is no necessity

Fixes #3367
