### PR TITLE
chore: travis - upgrade on new version Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ addons:
     packages:
       - g++-4.8
 
+services:
+  - xvfb
+
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3 # Give xvfb time to to start
   - npm run init
   - export $(openssl aes-256-cbc -pass env:CREDENTIALS_PASS -d -in credentials)
   - echo "TRAVIS_COMMIT $TRAVIS_COMMIT"
@@ -44,5 +44,3 @@ before_script:
 
 script:
   - npm run travis
-
-dist: trusty # Impacts this script, eg xvfb


### PR DESCRIPTION
Since of May 2019 by default start Ubuntu Xenial 16.04
https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment
and also since Ubuntu 16.04 you can start xvfb as services
https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
