### PR TITLE
fix(runner): Fix getting result by config

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -283,7 +283,7 @@ class Server extends KarmaEventEmitter {
 
     const emitRunCompleteIfAllBrowsersDone = () => {
       if (Object.keys(singleRunDoneBrowsers).every((key) => singleRunDoneBrowsers[key])) {
-        this.emit('run_complete', singleRunBrowsers, singleRunBrowsers.getResults(singleRunBrowserNotCaptured, config.failOnEmptyTestSuite, config.failOnFailingTestSuite))
+        this.emit('run_complete', singleRunBrowsers, singleRunBrowsers.getResults(singleRunBrowserNotCaptured, config))
       }
     }
 


### PR DESCRIPTION
Since Karma 4.4.0, there is problem with exit code with `failOn*` properties, because now `getResults` expect only `config`, but emitting include concrete properties from config.
So it seems that all the `failOn*` properties don't work in 4.4.0