### PR TITLE
fix: Preprocessors may return promises, but not resolve to 'content'.

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -24,7 +24,34 @@ function executeProcessor (process, file, content) {
       }
     }
   })
-  return process(content, file, done) || donePromise
+
+  /* The original API for Preprocessors assumed callback.
+   * Now promises are a valid return.
+   * If an implementer returns a promise from `process`
+   * but only resolves content via the callback,
+   * then while the result of `process` is a promise,
+   * it will not resolve to the intended content.
+   * An easy example is for `process` to be an `async` function.
+   * e.g.
+   * ```
+   * async function process(content, file, done) {
+   *   const newContent = await magic(content)
+   *   done(newContent)
+   * }
+   * ```
+   */
+  const result = process(content, file, done)
+  return result && result.then
+    ? result.then(intendedToReturnContentInPromise)
+    : donePromise
+
+  function intendedToReturnContentInPromise (content) {
+    if (content) {
+      return content
+    } else {
+      return donePromise
+    }
+  }
 }
 
 async function runProcessors (preprocessors, file, content) {


### PR DESCRIPTION
The original API for Preprocessors assumed callback.
Now promises are a valid return.
If an implementer returns a promise from `process`
but only resolves content via the callback,
then while the result of `process` is a promise,
it will not resolve to the intended content.
An easy example is for `process` to be an `async` function.
e.g. 
```
async function process(content, file, done) {
   const newContent = await magic(content)
   done(newContent)
}
```

