### PR TITLE
fix(ci): poll every 10s to avoid rate limit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -446,7 +446,7 @@
     "husky": "^0.14.3",
     "jasmine-core": "^3.4.0",
     "karma-browserify": "^6.0.0",
-    "karma-browserstack-launcher": "^1.4.0",
+    "karma-browserstack-launcher": "^1.5.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-firefox-launcher": "*",

--- a/test/client/karma.conf.js
+++ b/test/client/karma.conf.js
@@ -41,22 +41,6 @@ var launchers = {
     os: 'Windows',
     os_version: '7'
   }
-  // TODO: Figure out why these fail on browserstack
-  // ,
-  // bs_ie_8: {
-  //   base: 'BrowserStack',
-  //   browser: 'ie',
-  //   browser_version: '8.0',
-  //   os: 'Windows',
-  //   os_version: '7'
-  // },
-  // bs_ie_7: {
-  //   base: 'BrowserStack',
-  //   browser: 'ie',
-  //   browser_version: '7.0',
-  //   os: 'Windows',
-  //   os_version: 'XP'
-  // }
 }
 
 var browsers = []
@@ -157,7 +141,11 @@ module.exports = function (config) {
     forceJSONP: true,
 
     browserStack: {
-      project: 'Karma'
+      project: 'Karma',
+      // The karma-browserstack-launcher polls for each browser.
+      // With many browsers the 120 requests per minute limit is hit
+      // resulting in fails Error: 403 Forbidden (Rate Limit Exceeded)
+      pollingTimeout: 10000
     }
   })
 }


### PR DESCRIPTION
Return to v1.5 karma-browserstack-launcher

