### PR TITLE
test(config): Check for the correct symbolic link before test:client

### DIFF
--- a/test/client/karma.conf.js
+++ b/test/client/karma.conf.js
@@ -1,3 +1,5 @@
+const fs = require('fs')
+
 var TRAVIS_WITHOUT_BS = process.env.TRAVIS_SECURE_ENV_VARS === 'false'
 
 var launchers = {
@@ -42,6 +44,27 @@ var launchers = {
     os_version: '7'
   }
 }
+
+// Verify the install. This will run async but that's ok we'll see the log.
+fs.lstat('node_modules/karma', (err, stats) => {
+  if (err) {
+    console.error('Cannot verify installation', err.stack || err)
+  }
+  if (stats && stats.isSymbolicLink()) {
+    return
+  }
+
+  console.log('**** Incorrect directory layout for karma self-tests ****')
+  console.log(`
+    $ npm install
+    $ rm -rf node_modules/karma
+    $ cd node_modules
+    $ ln -s ../ karma
+    $ cd ../
+    $ grunt browserify
+  `)
+  process.exit(1)
+})
 
 var browsers = []
 


### PR DESCRIPTION
I've hit this a couple of times but many months apart, enough time to forget. The error is quite
puzzling without some hints.

Fixes #3391