### PR TITLE
feat(config): add appendsha option for files

### DIFF
--- a/docs/config/02-files.md
+++ b/docs/config/02-files.md
@@ -72,6 +72,11 @@ includes the file content in the page, used, for example, to test components com
 * **Default.** `false`
 * **Description.** Should the files be served from disk on each request by Karma's webserver?
 
+### `appendsha`
+* **Type.** Boolean
+* **Default.** `true`
+* **Description.** Should the files be served with a query string of the file's SHA?
+
 
 ## Preprocessor transformations
 Depending on preprocessor configuration, be aware that files loaded may be transformed and no longer available in
@@ -101,6 +106,9 @@ files: [
 
   // this file will be served on demand from disk and will be ignored by the watcher
   {pattern: 'compiled/app.js.map', included: false, served: true, watched: false, nocache: true}
+
+  // these files will be included without a cache-busting query string appended to them
+  {pattern: 'compiled/app.js.map', included: true, served: true, appendsha: false}
 ],
 ```
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -32,7 +32,7 @@ try {
 } catch (e) {}
 
 class Pattern {
-  constructor (pattern, served, included, watched, nocache, type) {
+  constructor (pattern, served, included, watched, nocache, type, appendsha) {
     this.pattern = pattern
     this.served = helper.isDefined(served) ? served : true
     this.included = helper.isDefined(included) ? included : true
@@ -40,6 +40,7 @@ class Pattern {
     this.nocache = helper.isDefined(nocache) ? nocache : false
     this.weight = helper.mmPatternWeight(pattern)
     this.type = type
+    this.appendsha = helper.isDefined(appendsha) ? appendsha : true
   }
 
   compare (other) {
@@ -49,7 +50,7 @@ class Pattern {
 
 class UrlPattern extends Pattern {
   constructor (url, type) {
-    super(url, false, true, false, false, type)
+    super(url, false, true, false, false, type, true)
   }
 }
 
@@ -61,10 +62,10 @@ function createPatternObject (pattern) {
   } else if (helper.isObject(pattern) && pattern.pattern && helper.isString(pattern.pattern)) {
     return helper.isUrlAbsolute(pattern.pattern)
       ? new UrlPattern(pattern.pattern, pattern.type)
-      : new Pattern(pattern.pattern, pattern.served, pattern.included, pattern.watched, pattern.nocache, pattern.type)
+      : new Pattern(pattern.pattern, pattern.served, pattern.included, pattern.watched, pattern.nocache, pattern.type, pattern.appendsha)
   } else {
     log.warn(`Invalid pattern ${pattern}!\n\tExpected string or object with "pattern" property.`)
-    return new Pattern(null, false, false, false, false)
+    return new Pattern(null, false, false, false, false, false)
   }
 }
 

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -61,7 +61,7 @@ class FileList {
 
     let lastCompletedRefresh = this._refreshing
     lastCompletedRefresh = Promise
-      .map(this._patterns, async ({ pattern, type, nocache }) => {
+      .map(this._patterns, async ({ pattern, type, nocache, appendsha }) => {
         if (helper.isUrlAbsolute(pattern)) {
           this.buckets.set(pattern, [new Url(pattern, type)])
           return
@@ -81,7 +81,7 @@ class FileList {
               return true
             }
           })
-          .map((path) => new File(path, mg.statCache[path].mtime, nocache, type))
+          .map((path) => new File(path, mg.statCache[path].mtime, nocache, type, appendsha))
 
         if (nocache) {
           log.debug(`Not preprocessing "${pattern}" due to nocache`)

--- a/lib/file.js
+++ b/lib/file.js
@@ -4,7 +4,7 @@
  * File object used for tracking files in `file-list.js`.
  */
 class File {
-  constructor (path, mtime, doNotCache, type) {
+  constructor (path, mtime, doNotCache, type, appendSha) {
     // used for serving (processed path, eg some/file.coffee -> some/file.coffee.js)
     this.path = path
 
@@ -24,6 +24,8 @@ class File {
     this.doNotCache = doNotCache === undefined ? false : doNotCache
 
     this.type = type
+
+    this.appendSha = appendSha === undefined ? true : appendSha
   }
 
   toString () {

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -173,7 +173,7 @@ function createKarmaMiddleware (
             if (!file.isUrl) {
               filePath = filePathToUrlPath(filePath, basePath, urlRoot, proxyPath)
 
-              if (requestUrl === '/context.html') {
+              if (isRequestingContextFile && file.appendSha) {
                 filePath += '?' + file.sha
               }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2014,7 +2014,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -4236,7 +4237,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -4265,6 +4267,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6660,6 +6663,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -9721,7 +9725,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "yaml": {
       "version": "1.7.2",

--- a/test/unit/file-list.spec.js
+++ b/test/unit/file-list.spec.js
@@ -142,6 +142,27 @@ describe('FileList', () => {
       })
     })
 
+    it('marks append SHA files', () => {
+      var files = [
+        new config.Pattern('/a.*'), // appendsha: true
+        new config.Pattern('/some/*.js', true, true, true, true, 'js', false) // appendsha: false
+      ]
+
+      list = new List(files, [], emitter, preprocess)
+
+      return list.refresh().then(() => {
+        expect(pathsFrom(list.files.served)).to.deep.equal([
+          '/a.txt',
+          '/some/a.js',
+          '/some/b.js'
+        ])
+        expect(preprocess).to.have.been.calledOnce
+        expect(list.files.served[0].appendSha).to.be.true
+        expect(list.files.served[1].appendSha).to.be.false
+        expect(list.files.served[2].appendSha).to.be.false
+      })
+    })
+
     it('returns a flat array of included files', () => {
       const files = [
         new config.Pattern('/a.*', true, false), // included: false


### PR DESCRIPTION
This allows users to prevent the file SHA query string from being added to included files by specifying 'appendsha: false'. This is to prevent files from being loaded twice, which can occur if a file is included by Karma and then later referenced by another file in the code (such as an HTML import)

Follow-up to #2760 

Closes #2756
