### PR TITLE
feat(preprocessor): obey Pattern.isBinary when set

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -32,7 +32,7 @@ try {
 } catch (e) {}
 
 class Pattern {
-  constructor (pattern, served, included, watched, nocache, type) {
+  constructor (pattern, served, included, watched, nocache, type, isBinary) {
     this.pattern = pattern
     this.served = helper.isDefined(served) ? served : true
     this.included = helper.isDefined(included) ? included : true
@@ -40,6 +40,7 @@ class Pattern {
     this.nocache = helper.isDefined(nocache) ? nocache : false
     this.weight = helper.mmPatternWeight(pattern)
     this.type = type
+    this.isBinary = isBinary
   }
 
   compare (other) {

--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -61,7 +61,7 @@ class FileList {
 
     let lastCompletedRefresh = this._refreshing
     lastCompletedRefresh = Promise
-      .map(this._patterns, async ({ pattern, type, nocache }) => {
+      .map(this._patterns, async ({ pattern, type, nocache, isBinary }) => {
         if (helper.isUrlAbsolute(pattern)) {
           this.buckets.set(pattern, [new Url(pattern, type)])
           return
@@ -81,7 +81,7 @@ class FileList {
               return true
             }
           })
-          .map((path) => new File(path, mg.statCache[path].mtime, nocache, type))
+          .map((path) => new File(path, mg.statCache[path].mtime, nocache, type, isBinary))
 
         if (nocache) {
           log.debug(`Not preprocessing "${pattern}" due to nocache`)

--- a/lib/file.js
+++ b/lib/file.js
@@ -4,7 +4,7 @@
  * File object used for tracking files in `file-list.js`.
  */
 class File {
-  constructor (path, mtime, doNotCache, type) {
+  constructor (path, mtime, doNotCache, type, isBinary) {
     // used for serving (processed path, eg some/file.coffee -> some/file.coffee.js)
     this.path = path
 
@@ -24,6 +24,9 @@ class File {
     this.doNotCache = doNotCache === undefined ? false : doNotCache
 
     this.type = type
+
+    // Tri state: null means probe file for binary.
+    this.isBinary = isBinary === undefined ? null : isBinary
   }
 
   toString () {

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -102,7 +102,11 @@ function createPriorityPreprocessor (config = {}, preprocessorPriority, basePath
 
   return async function preprocess (file) {
     const buffer = await tryToRead(file.originalPath, log)
-    const isBinary = await isBinaryFile(buffer, buffer.length)
+    let isBinary = file.isBinary
+    if (isBinary == null) {
+      // Pattern did not specify, probe for it.
+      isBinary = await isBinaryFile(buffer, buffer.length)
+    }
 
     const preprocessorNames = Object.keys(config).reduce((ppNames, pattern) => {
       if (mm(file.originalPath, pattern, { dot: true })) {


### PR DESCRIPTION
Add support for isBinary. If set, use it and don't probe file to detect binary status.
Fixes #3405

