### PR TITLE
refactor: use native Promise instead of Bluebird

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -1,9 +1,10 @@
 'use strict'
 
-const Promise = require('bluebird')
+const { promisify } = require('util')
 const mm = require('minimatch')
 const Glob = require('glob').Glob
-const fs = Promise.promisifyAll(require('graceful-fs'))
+const fs = require('graceful-fs')
+fs.statAsync = promisify(fs.stat)
 const pathLib = require('path')
 const _ = require('lodash')
 
@@ -60,8 +61,8 @@ class FileList {
     const matchedFiles = new Set()
 
     let lastCompletedRefresh = this._refreshing
-    lastCompletedRefresh = Promise
-      .map(this._patterns, async ({ pattern, type, nocache, isBinary }) => {
+    lastCompletedRefresh = Promise.all(
+      this._patterns.map(async ({ pattern, type, nocache, isBinary }) => {
         if (helper.isUrlAbsolute(pattern)) {
           this.buckets.set(pattern, [new Url(pattern, type)])
           return
@@ -86,7 +87,7 @@ class FileList {
         if (nocache) {
           log.debug(`Not preprocessing "${pattern}" due to nocache`)
         } else {
-          await Promise.map(files, (file) => this._preprocess(file))
+          await Promise.all(files.map((file) => this._preprocess(file)))
         }
 
         this.buckets.set(pattern, files)
@@ -97,6 +98,7 @@ class FileList {
           log.warn(`All files matched by "${pattern}" were excluded or matched by prior matchers.`)
         }
       })
+    )
       .then(() => {
         // When we return from this function the file processing chain will be
         // complete. In the case of two fast refresh() calls, the second call
@@ -202,7 +204,7 @@ class FileList {
 
     if (!file) {
       log.debug(`Changed file "${path}" ignored. Does not match any file in the list.`)
-      return Promise.resolve(this.files)
+      return this.files
     }
 
     const [stat] = await Promise.all([fs.statAsync(path), this._refreshing])

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -4,7 +4,6 @@ const fs = require('graceful-fs')
 const path = require('path')
 const _ = require('lodash')
 const useragent = require('useragent')
-const Promise = require('bluebird')
 const mm = require('minimatch')
 
 exports.browserFullNameToShort = (fullName) => {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Promise = require('bluebird')
 const Jobs = require('qjobs')
 
 const log = require('./logger').create('launcher')

--- a/lib/launchers/base.js
+++ b/lib/launchers/base.js
@@ -1,6 +1,5 @@
 const KarmaEventEmitter = require('../events').EventEmitter
 const EventEmitter = require('events').EventEmitter
-const Promise = require('bluebird')
 
 const log = require('../logger').create('launcher')
 const helper = require('../helper')

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,7 +3,6 @@
 const SocketIO = require('socket.io')
 const di = require('di')
 const util = require('util')
-const Promise = require('bluebird')
 const spawn = require('child_process').spawn
 const tmp = require('tmp')
 const fs = require('fs')

--- a/lib/utils/bundle-utils.js
+++ b/lib/utils/bundle-utils.js
@@ -1,7 +1,6 @@
 'use strict'
 const PathUtils = require('./path-utils')
 const fs = require('fs')
-const Promise = require('bluebird')
 
 const BundleUtils = {
   bundleResource (inPath, outPath) {

--- a/lib/utils/net-utils.js
+++ b/lib/utils/net-utils.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Promise = require('bluebird')
 const net = require('net')
 
 const NetUtils = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1281,7 +1281,8 @@
     "bluebird": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+      "dev": true
     },
     "bn.js": {
       "version": "4.11.8",
@@ -2014,7 +2015,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -4236,7 +4238,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -4265,6 +4268,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6660,6 +6664,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -9721,7 +9726,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "yaml": {
       "version": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -390,7 +390,6 @@
     "Karl Lindmark <karl.lindmark@ninetwozero.com>"
   ],
   "dependencies": {
-    "bluebird": "^3.3.0",
     "body-parser": "^1.16.1",
     "braces": "^3.0.2",
     "chokidar": "^3.0.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -4,8 +4,7 @@
   },
   "globals": {
     "expect": true,
-    "sinon": true,
-    "scheduleNextTick": true
+    "sinon": true
   },
   "rules": {
     "no-unused-expressions": "off"

--- a/test/unit/file-list.spec.js
+++ b/test/unit/file-list.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Promise = require('bluebird')
 const EventEmitter = require('events').EventEmitter
 const mocks = require('mocks')
 const proxyquire = require('proxyquire')
@@ -448,8 +447,7 @@ describe('FileList', () => {
         helper: helper,
         glob: glob,
         'graceful-fs': mockFs,
-        path: pathLib.posix,
-        bluebird: Promise
+        path: pathLib.posix
       })
 
       list = new List(patterns('/some/*.js', '*.txt'), ['/secret/*.txt'], emitter, preprocess, 100)
@@ -457,7 +455,6 @@ describe('FileList', () => {
 
     afterEach(() => {
       clock.restore()
-      Promise.setScheduler((fn) => process.nextTick(fn))
     })
 
     it('does not add excluded files', () => {
@@ -514,14 +511,14 @@ describe('FileList', () => {
 
       return list.refresh().then(() => {
         preprocess.resetHistory()
-        sinon.spy(mockFs, 'stat')
+        sinon.spy(mockFs, 'statAsync')
 
         return Promise.all([
           list.addFile('/some/d.js'),
           list.addFile('/some/d.js')
         ]).then(() => {
           expect(preprocess).to.have.been.calledOnce
-          expect(mockFs.stat).to.have.been.calledOnce
+          expect(mockFs.statAsync).to.have.been.calledOnce
         })
       })
     })
@@ -555,7 +552,6 @@ describe('FileList', () => {
     beforeEach(() => {
       patternList = PATTERN_LIST
       mg = MG
-      Promise.setScheduler((fn) => fn())
 
       emitter = new EventEmitter()
 
@@ -576,8 +572,7 @@ describe('FileList', () => {
         helper: helper,
         glob: glob,
         'graceful-fs': mockFs,
-        path: pathLib.posix,
-        bluebird: Promise
+        path: pathLib.posix
       })
 
       mockFs._touchFile('/some/a.js', '2012-04-04')
@@ -586,7 +581,6 @@ describe('FileList', () => {
 
     afterEach(() => {
       clock.restore()
-      Promise.setScheduler((fn) => process.nextTick(fn))
     })
 
     it('updates mtime and fires "file_list_modified"', () => {
@@ -680,7 +674,6 @@ describe('FileList', () => {
     beforeEach(() => {
       patternList = PATTERN_LIST
       mg = MG
-      Promise.setScheduler((fn) => fn())
 
       emitter = new EventEmitter()
 
@@ -701,8 +694,7 @@ describe('FileList', () => {
         helper: helper,
         glob: glob,
         'graceful-fs': mockFs,
-        path: pathLib.posix,
-        bluebird: Promise
+        path: pathLib.posix
       })
 
       modified = sinon.stub()
@@ -711,7 +703,6 @@ describe('FileList', () => {
 
     afterEach(() => {
       clock.restore()
-      Promise.setScheduler((fn) => process.nextTick(fn))
     })
 
     it('removes the file from the list and fires "file_list_modified"', () => {
@@ -762,7 +753,6 @@ describe('FileList', () => {
     beforeEach(() => {
       patternList = PATTERN_LIST
       mg = MG
-      Promise.setScheduler((fn) => { fn() })
 
       emitter = new EventEmitter()
 
@@ -786,14 +776,12 @@ describe('FileList', () => {
         helper: helper,
         glob: glob,
         'graceful-fs': mockFs,
-        path: pathLib.posix,
-        bluebird: Promise
+        path: pathLib.posix
       })
     })
 
     afterEach(() => {
       clock.restore()
-      Promise.setScheduler((fn) => process.nextTick(fn))
     })
 
     it('debounces calls to emitModified', () => {

--- a/test/unit/launcher.spec.js
+++ b/test/unit/launcher.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Promise = require('bluebird')
 const di = require('di')
 
 const events = require('../../lib/events')
@@ -64,14 +63,6 @@ describe('launcher', () => {
   // mock out id generator
   let lastGeneratedId = null
   launcher.Launcher.generateId = () => ++lastGeneratedId
-
-  before(() => {
-    Promise.setScheduler((fn) => fn())
-  })
-
-  after(() => {
-    Promise.setScheduler((fn) => process.nextTick(fn))
-  })
 
   beforeEach(() => {
     lastGeneratedId = 0
@@ -252,7 +243,7 @@ describe('launcher', () => {
         expect(browser.forceKill).to.have.been.called
       })
 
-      it('should call callback when all processes killed', () => {
+      it('should call callback when all processes killed', (done) => {
         const exitSpy = sinon.spy()
 
         l.launch(['Fake', 'Fake'], 1)
@@ -264,18 +255,17 @@ describe('launcher', () => {
         let browser = FakeBrowser._instances.pop()
         browser.forceKill.resolve()
 
-        scheduleNextTick(() => {
+        setImmediate(() => {
           expect(exitSpy).not.to.have.been.called
-        })
 
-        scheduleNextTick(() => {
           // finish the second browser
           browser = FakeBrowser._instances.pop()
           browser.forceKill.resolve()
-        })
 
-        scheduleNextTick(() => {
-          expect(exitSpy).to.have.been.called
+          setImmediate(() => {
+            expect(exitSpy).to.have.been.called
+            done()
+          })
         })
       })
 

--- a/test/unit/launchers/capture_timeout.spec.js
+++ b/test/unit/launchers/capture_timeout.spec.js
@@ -38,7 +38,7 @@ describe('launchers/capture_timeout.js', () => {
     expect(launcher.kill).not.to.have.been.called
   })
 
-  it('should clear timeout between restarts', (done) => {
+  it('should clear timeout between restarts', async () => {
     CaptureTimeoutLauncher.call(launcher, timer, 10)
 
     // simulate process finished
@@ -49,12 +49,10 @@ describe('launchers/capture_timeout.js', () => {
 
     launcher.start()
     timer.wind(8)
-    launcher.kill().done(() => {
-      launcher.kill.resetHistory()
-      launcher.start()
-      timer.wind(8)
-      expect(launcher.kill).not.to.have.been.called
-      done()
-    })
+    await launcher.kill()
+    launcher.kill.resetHistory()
+    launcher.start()
+    timer.wind(8)
+    expect(launcher.kill).not.to.have.been.called
   })
 })

--- a/test/unit/launchers/process.spec.js
+++ b/test/unit/launchers/process.spec.js
@@ -133,7 +133,7 @@ describe('launchers/process.js', () => {
     })
 
     // the most common scenario, when everything works fine
-    it('start -> capture -> kill', (done) => {
+    it('start -> capture -> kill', async () => {
       // start the browser
       launcher.start('http://localhost/')
       expect(mockSpawn).to.have.been.calledWith(BROWSER_PATH, ['http://localhost/?id=fake-id'])
@@ -150,10 +150,9 @@ describe('launchers/process.js', () => {
       mockSpawn._processes[0].emit('exit', 0)
       mockTempDir.remove.callArg(1)
 
-      killingLauncher.done(() => {
-        expect(launcher.state).to.equal(launcher.STATE_FINISHED)
-        done()
-      })
+      await killingLauncher
+
+      expect(launcher.state).to.equal(launcher.STATE_FINISHED)
     })
 
     // when the browser fails to get captured in default timeout, it should restart

--- a/test/unit/middleware/runner.spec.js
+++ b/test/unit/middleware/runner.spec.js
@@ -1,7 +1,6 @@
 const path = require('path')
 const EventEmitter = require('events').EventEmitter
 const mocks = require('mocks')
-const Promise = require('bluebird')
 const _ = require('lodash')
 
 const Browser = require('../../../lib/browser')
@@ -37,14 +36,6 @@ describe('middleware.runner', () => {
       config
     )
   }
-
-  before(() => {
-    Promise.setScheduler((fn) => fn())
-  })
-
-  after(() => {
-    Promise.setScheduler((fn) => process.nextTick(fn))
-  })
 
   beforeEach(() => {
     mockReporter = {

--- a/test/unit/mocha-globals.js
+++ b/test/unit/mocha-globals.js
@@ -2,8 +2,6 @@ const sinon = require('sinon')
 const chai = require('chai')
 const logger = require('../../lib/logger')
 
-require('bluebird').longStackTraces()
-
 // publish globals that all specs can use
 global.expect = chai.expect
 global.should = chai.should()
@@ -45,39 +43,4 @@ chai.use((chai, utils) => {
     this.assert(response._body === null,
       `expected response body to not be set, it was '${response._body}'`)
   })
-})
-
-// TODO(vojta): move it somewhere ;-)
-const nextTickQueue = []
-const nextTickCallback = () => {
-  if (!nextTickQueue.length) throw new Error('Nothing scheduled!')
-  nextTickQueue.shift()()
-
-  if (nextTickQueue.length) process.nextTick(nextTickCallback)
-}
-global.scheduleNextTick = (action) => {
-  nextTickQueue.push(action)
-
-  if (nextTickQueue.length === 1) process.nextTick(nextTickCallback)
-}
-const nextQueue = []
-const nextCallback = () => {
-  // if not nextQueue.length then throw new Error 'Nothing scheduled!'
-  nextQueue.shift()()
-}
-
-global.scheduleNextTick = (action) => {
-  nextTickQueue.push(action)
-
-  if (nextTickQueue.length === 1) process.nextTick(nextTickCallback)
-}
-global.scheduleNext = (action) => {
-  nextQueue.push(action)
-}
-
-global.next = nextCallback
-
-beforeEach(() => {
-  nextTickQueue.length = 0
-  nextQueue.length = 0
 })

--- a/test/unit/utils/net-utils.spec.js
+++ b/test/unit/utils/net-utils.spec.js
@@ -22,6 +22,7 @@ describe('NetUtils.bindAvailablePort', () => {
         const port = boundServer.address().port
         expect(port).to.be.equal(9877)
         expect(boundServer).not.to.be.null
+        boundServer.close()
         server.close(done)
       })
     })


### PR DESCRIPTION
All supported Node versions support native promises and async/await, current code has a minimal usage of Bluebird-specific methods, so dropping a third-party library in favor of native Promises.

Tests were using `Promise.setScheduler()` from Bluebird, which allowed to customize how Promises are scheduled and made test work very different from the real code, which created tricky issues (like https://github.com/karma-runner/karma/pull/3060#discussion_r284797390). Affected tests were updated to not rely on `Promise.setScheduler()`, which improved readability in some situations. Also removed some test helpers as they are not necessary and not used anymore.

The only drawback I can think of is that Bluebird potentially provides better stack traces for async calls, which are only supported in [Node 12](https://thecodebarbarian.com/async-stack-traces-in-node-js-12). I don't think this should be a big problem in practice.

BREAKING CHANGE: Karma plugins which rely on the fact that Karma uses Bluebird promises may break as Bluebird-specific API is no longer available on Promises returned by the Karma core