### PR TITLE
refactor: drop safe-buffer dependency in favor of native Buffer

### DIFF
--- a/lib/middleware/common.js
+++ b/lib/middleware/common.js
@@ -5,7 +5,6 @@
 
 const mime = require('mime')
 const parseRange = require('range-parser')
-const Buffer = require('safe-buffer').Buffer
 const log = require('../logger').create('web-server')
 
 function createServeFile (fs, directory, config) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8098,7 +8098,8 @@
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
     },
     "safe-json-parse": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -411,7 +411,6 @@
     "qjobs": "^1.1.4",
     "range-parser": "^1.2.0",
     "rimraf": "^2.6.0",
-    "safe-buffer": "^5.0.1",
     "socket.io": "2.1.1",
     "source-map": "^0.6.1",
     "tmp": "0.0.33",


### PR DESCRIPTION
This library is a polyfill for Buffer's static methods on ancient Node versions (new methods are available since [at least Node 4](https://nodejs.org/docs/latest-v4.x/api/buffer.html)). No reason to have this polyfill given that Karma support Node 10+.

When these methods are supported natively library exports native `Buffer` ([code](https://github.com/feross/safe-buffer/blob/master/index.js#L11)), so this removal should not affect anything.