### PR TITLE
feat(docs): document `DEFAULT_LISTEN_ADDR` constant

### DIFF
--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -184,6 +184,10 @@ The default port used for the karma server
 
 The default hostname used for the karma server
 
+### **constants.DEFAULT_LISTEN_ADDR**
+
+The default address use for the karma server to listen on
+
 ### **constants.LOG_DISABLE**
 
 The value for disabling logs


### PR DESCRIPTION
This docs update was missing in the #2479 that added option for configurable
listening address.

Thanks!