### PR TITLE
docs: Fix simple typo, overriden -> overridden

### DIFF
--- a/context/karma.js
+++ b/context/karma.js
@@ -49,7 +49,7 @@ function ContextKarma (callParentKarmaMethod) {
     // remove reference to child iframe
     this.start = UNIMPLEMENTED_START
   }
-  // supposed to be overriden by the context
+  // supposed to be overridden by the context
   // TODO(vojta): support multiple callbacks (queue)
   this.start = UNIMPLEMENTED_START
 

--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -800,7 +800,7 @@ proxyRes: function(proxyRes, req, res) {
 
 **Description:** For use when the Karma server needs to be run behind a proxy that changes the base url, etc
 
-If set then the following fields will be defined and can be overriden:
+If set then the following fields will be defined and can be overridden:
 
 ### path
 **Type:** String

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -164,7 +164,7 @@ describe('config', () => {
       expect(patternsFrom(config.files)).to.deep.equal([resolveWinPath('/home/tests/unit.spec.js')])
     })
 
-    it('should resolve files and excludes to overriden basePath from cli', () => {
+    it('should resolve files and excludes to overridden basePath from cli', () => {
       const config = e.parseConfig('/conf/both.js', { port: 456, autoWatch: false, basePath: '/xxx' })
 
       expect(config.basePath).to.equal(resolveWinPath('/xxx'))
@@ -247,7 +247,7 @@ describe('config', () => {
       const config = e.parseConfig(null, { basePath: '/some' })
 
       expect(logSpy).not.to.have.been.called
-      expect(config.basePath).to.equal(resolveWinPath('/some')) // overriden by CLI
+      expect(config.basePath).to.equal(resolveWinPath('/some')) // overridden by CLI
       expect(config.urlRoot).to.equal('/')
     }) // default value
 


### PR DESCRIPTION
There is a small typo in context/karma.js, docs/config/01-configuration-file.md, test/unit/config.spec.js.

Should read `overridden` rather than `overriden`.

