### PR TITLE
fix(file-list): do not define fs.statAsync

### DIFF
--- a/lib/file-list.js
+++ b/lib/file-list.js
@@ -4,7 +4,7 @@ const { promisify } = require('util')
 const mm = require('minimatch')
 const Glob = require('glob').Glob
 const fs = require('graceful-fs')
-fs.statAsync = promisify(fs.stat)
+const statAsync = promisify(fs.stat.bind(fs))
 const pathLib = require('path')
 const _ = require('lodash')
 
@@ -189,7 +189,7 @@ class FileList {
     const file = new File(path)
     this._getFilesByPattern(pattern.pattern).push(file)
 
-    const [stat] = await Promise.all([fs.statAsync(path), this._refreshing])
+    const [stat] = await Promise.all([statAsync(path), this._refreshing])
     file.mtime = stat.mtime
     await this._preprocess(file)
 
@@ -207,7 +207,7 @@ class FileList {
       return this.files
     }
 
-    const [stat] = await Promise.all([fs.statAsync(path), this._refreshing])
+    const [stat] = await Promise.all([statAsync(path), this._refreshing])
     if (force || stat.mtime > file.mtime) {
       file.mtime = stat.mtime
       await this._preprocess(file)

--- a/test/unit/file-list.spec.js
+++ b/test/unit/file-list.spec.js
@@ -442,6 +442,10 @@ describe('FileList', () => {
       clock = sinon.useFakeTimers()
       // This hack is needed to ensure lodash is using the fake timers
       // from sinon
+
+      // fs.stat needs to be spied before file-list is required
+      sinon.spy(mockFs, 'stat')
+
       List = proxyquire('../../lib/file-list', {
         lodash: _.runInContext(),
         helper: helper,
@@ -455,6 +459,7 @@ describe('FileList', () => {
 
     afterEach(() => {
       clock.restore()
+      mockFs.stat.restore()
     })
 
     it('does not add excluded files', () => {
@@ -511,14 +516,13 @@ describe('FileList', () => {
 
       return list.refresh().then(() => {
         preprocess.resetHistory()
-        sinon.spy(mockFs, 'statAsync')
 
         return Promise.all([
           list.addFile('/some/d.js'),
           list.addFile('/some/d.js')
         ]).then(() => {
           expect(preprocess).to.have.been.calledOnce
-          expect(mockFs.statAsync).to.have.been.calledOnce
+          expect(mockFs.stat).to.have.been.calledOnce
         })
       })
     })


### PR DESCRIPTION
Defining fs.statAsync affects other modules such as bluebird which
throws an error because of the 'Async'-suffix:

> Cannot promisify an API that has normal methods with 'Async'-suffix
> See http://goo.gl/MqrFmX

Fixes: https://github.com/karma-runner/karma/issues/3466