### PR TITLE
fix(ci): stop the proxy before killing the child

### DIFF
--- a/test/e2e/step_definitions/hooks.js
+++ b/test/e2e/step_definitions/hooks.js
@@ -4,12 +4,13 @@ cucumber.defineSupportCode((a) => {
   a.After(function (scenario, callback) {
     const running = this.child != null && typeof this.child.kill === 'function'
 
-    if (running) {
-      this.child.kill()
-      this.child = null
-    }
-
     // stop the proxy if it was started
-    this.proxy.stop(callback)
+    this.proxy.stop(() => {
+      if (running) {
+        this.child.kill()
+        this.child = null
+      }
+      callback()
+    })
   })
 })


### PR DESCRIPTION
This should fix #3464, hopefully. Since the test is flaky and only on Travis
we can't be sure until we try for a while.