### PR TITLE
chore(test): remove @not-jenkins tag for Cucumber tests

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -5,8 +5,7 @@ const options = [
   '--require test/e2e/support/env.js',
   '--require test/e2e/support/world.js',
   '--require test/e2e/step_definitions/core_steps.js',
-  '--require test/e2e/step_definitions/hooks.js',
-  '--tags "not @not-jenkins"'
+  '--require test/e2e/step_definitions/hooks.js'
 ]
 
 module.exports = {

--- a/test/e2e/basic.feature
+++ b/test/e2e/basic.feature
@@ -19,23 +19,6 @@ Feature: Basic Testrunner
       ..
       Chrome Headless
       """
-  @not-jenkins
-  Scenario: Execute a test in Chrome
-    Given a configuration with:
-      """
-      files = ['basic/plus.js', 'basic/test.js']
-      browsers = ['Chrome']
-      plugins = [
-        'karma-jasmine',
-        'karma-chrome-launcher'
-      ]
-      """
-    When I start Karma
-    Then it passes with:
-      """
-      ..
-      Chrome
-      """
 
   Scenario: Execute a test in Firefox
     Given a configuration with:

--- a/test/e2e/runInParent.feature
+++ b/test/e2e/runInParent.feature
@@ -23,27 +23,6 @@ Feature: runInParent option
       ..
       Chrome Headless
       """
-  @not-jenkins
-  Scenario: Execute a test in Chrome
-    Given a configuration with:
-      """
-      files = ['basic/plus.js', 'basic/test.js']
-      browsers = ['Chrome']
-      plugins = [
-        'karma-jasmine',
-        'karma-chrome-launcher'
-      ]
-      client = {
-        useIframe: false,
-        runInParent: true
-      }
-      """
-    When I start Karma
-    Then it passes with:
-      """
-      ..
-      Chrome
-      """
 
   Scenario: Execute a test in Firefox
     Given a configuration with:

--- a/test/e2e/tag.feature
+++ b/test/e2e/tag.feature
@@ -19,12 +19,12 @@ Feature: JavaScript Tag
       .
       Firefox
       """
-  @not-jenkins
-  Scenario: Execute a test in Chrome with version, without JavaScript tag
+
+  Scenario: Execute a test in ChromeHeadless with version, without JavaScript tag
     Given a configuration with:
       """
       files = ['tag/tag.js', 'tag/test-with-version.js'];
-      browsers = ['Chrome'];
+      browsers = ['ChromeHeadlessNoSandbox'];
       plugins = [
         'karma-jasmine',
         'karma-chrome-launcher'
@@ -53,12 +53,12 @@ Feature: JavaScript Tag
       .
       Firefox
       """
-  @not-jenkins
-  Scenario: Execute a test in Chrome without version, without JavaScript tag
+
+  Scenario: Execute a test in ChromeHeadless without version, without JavaScript tag
     Given a configuration with:
       """
       files = ['tag/tag.js', 'tag/test-without-version.js'];
-      browsers = ['Chrome'];
+      browsers = ['ChromeHeadlessNoSandbox'];
       plugins = [
         'karma-jasmine',
         'karma-chrome-launcher'


### PR DESCRIPTION
This tag was useful long time ago, when most of the tests were run using PhantomJS. For a long time E2E tests use ChromeHeadless as a the main browser and it is not needed to mark tests using Google Chrome to only run locally. Two removed test cases have identical cases above them, which are run in the ChromeHeadless and other two were updated to run in ChromeHeadless instead of Chrome and will be run both in CI as well as locally.