### PR TITLE
chore(ci): cleanup Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
-sudo: false
+os: linux
+dist: xenial
 language: node_js
 node_js:
   - 10
   - 12
 
-env:
-  global:
-  - SAUCE_USERNAME: karmarunnerbot
-  - CXX=g++-4.8
-matrix:
-  fast_finish: true
+jobs:
   include:
     - name: "Lint code and commit message format"
       node_js: "10"
@@ -17,16 +13,9 @@ matrix:
 
 before_install:
   - npm config set loglevel warn
-  - g++-4.8 --version
 
 addons:
-  firefox:
-    "latest"
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
+  firefox: "latest"
 
 services:
   - xvfb


### PR DESCRIPTION
- Fix warnings reported by Travis (https://travis-ci.org/github/karma-runner/karma/builds/677410665/config).
- Remove installation of g++-4.8 as it is no longer needed.
- Remove SAUCE_USERNAME variable as it is configured in the Travis UI now.
- Remove fast_finish as it only makes sense when some jobs are allowed to fail (https://docs.travis-ci.com/user/build-matrix/#fast-finishing). Which is not the case.