### PR TITLE
fix(browser): make sure that empty results array is still recognized

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -152,9 +152,8 @@ class Browser {
   }
 
   onResult (result) {
-    if (result.length) {
+    if (Array.isArray(result)) {
       result.forEach(this.onResult, this)
-      return
     } else if (this.isNotConnected()) {
       this.lastResult.add(result)
       this.emitter.emit('spec_complete', this, result)


### PR DESCRIPTION
Otherwise empty array is treated as a single value, which causes issues down the road.