### PR TITLE
chore(test): add test for flush resultsBuffer on engine upgrade

### DIFF
--- a/test/e2e/reporting.feature
+++ b/test/e2e/reporting.feature
@@ -1,0 +1,26 @@
+Feature: Results reporting
+  In order to use Karma
+  As a person who wants to write great tests
+  I want to Karma to report test results in the same order as they are executed.
+
+  Scenario: Results appear as tests are executed
+    Given a configuration with:
+      """
+      files = ['reporting/test.js'];
+      browsers = ['ChromeHeadlessNoSandbox'];
+      plugins = [
+        'karma-mocha',
+        'karma-mocha-reporter',
+        'karma-chrome-launcher'
+      ];
+      frameworks = ['mocha']
+      reporters = ['mocha']
+      """
+    When I start Karma
+    Then it passes with like:
+    """
+    START:
+      Reporting order
+        ✔ sync test
+        ✔ async test
+      """

--- a/test/e2e/support/reporting/test.js
+++ b/test/e2e/support/reporting/test.js
@@ -1,0 +1,9 @@
+describe('Reporting order', () => {
+  it('sync test', () => {
+    // pass
+  })
+
+  it('async test', (done) => {
+    setTimeout(done, 200)
+  })
+})


### PR DESCRIPTION
A test case to catch https://github.com/karma-runner/karma/pull/3212 regressions. It fails now, but will pass once the other PR is merged and test is rebased.