### PR TITLE
refactor(test): migrate Proxy to ES2015

### DIFF
--- a/test/e2e/support/proxy.js
+++ b/test/e2e/support/proxy.js
@@ -1,51 +1,50 @@
 const http = require('http')
 const httpProxy = require('http-proxy')
 
-function Proxy () {
-  const self = this
-  self.running = false
+module.exports = class Proxy {
+  constructor () {
+    this.running = false
 
-  self.proxy = httpProxy.createProxyServer({
-    target: 'http://localhost:9876'
-  })
+    this.proxy = httpProxy.createProxyServer({
+      target: 'http://localhost:9876'
+    })
 
-  self.proxy.on('error', function proxyError (err, req, res) {
-    console.log('support/proxy onerror', err)
-  })
+    this.proxy.on('error', (err) => {
+      console.log('support/proxy onerror', err)
+    })
 
-  self.server = http.createServer(function (req, res) {
-    const url = req.url
-    const match = url.match(self.proxyPathRegExp)
-    if (match) {
-      req.url = '/' + match[1]
-      self.proxy.web(req, res)
-    } else {
-      res.statusCode = 404
-      res.statusMessage = 'Not found'
-      res.end()
-    }
-  })
+    this.server = http.createServer((req, res) => {
+      const url = req.url
+      const match = url.match(this.proxyPathRegExp)
+      if (match) {
+        req.url = '/' + match[1]
+        this.proxy.web(req, res)
+      } else {
+        res.statusCode = 404
+        res.statusMessage = 'Not found'
+        res.end()
+      }
+    })
 
-  self.server.on('clientError', (err, socket) => {
-    console.log('support/proxy clientError', err)
-  })
+    this.server.on('clientError', (err) => {
+      console.log('support/proxy clientError', err)
+    })
+  }
 
-  self.start = function (port, proxyPath, callback) {
-    self.proxyPathRegExp = new RegExp('^' + proxyPath + '(.*)')
-    self.server.listen(port, function (error) {
-      self.running = !error
+  start (port, proxyPath, callback) {
+    this.proxyPathRegExp = new RegExp('^' + proxyPath + '(.*)')
+    this.server.listen(port, (error) => {
+      this.running = !error
       callback(error)
     })
   }
 
-  self.stop = function (callback) {
-    if (self.running) {
-      self.running = false
-      self.server.close(callback)
+  stop (callback) {
+    if (this.running) {
+      this.running = false
+      this.server.close(callback)
     } else {
       callback()
     }
   }
 }
-
-module.exports = new Proxy()

--- a/test/e2e/support/world.js
+++ b/test/e2e/support/world.js
@@ -5,10 +5,11 @@ const hasher = require('crypto').createHash
 const mkdirp = require('mkdirp')
 const _ = require('lodash')
 const { setWorldConstructor } = require('cucumber')
+const Proxy = require('./proxy')
 
 class World {
   constructor () {
-    this.proxy = require('./proxy')
+    this.proxy = new Proxy()
     this.template = _.template(`process.env.CHROME_BIN = require('puppeteer').executablePath(); module.exports = function (config) {\n  config.set(\n    <%= content %>\n  );\n};`)
 
     this.configFile = {


### PR DESCRIPTION
We used to share single instance of this class between all scenarios, but this is not necessary as each scenario starts proxy on demand and stops it in [After hook](https://github.com/karma-runner/karma/blob/master/test/e2e/step_definitions/hooks.js#L7). It should be cleaner to have an independent instance for each scenario.