### PR TITLE
refactor: add 'md' to FILE_TYPES

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -31,7 +31,8 @@ const FILE_TYPES = [
   'js',
   'dart',
   'module',
-  'dom'
+  'dom',
+  'md'
 ]
 
 function filePathToUrlPath (filePath, basePath, urlRoot, proxyPath) {


### PR DESCRIPTION
when I use Chai Plugin for Snapshot Testing with Karma, run script 'karma start', there will show some warning like this in terminal: '[middleware:karma]: Invalid file type (md), defaulting to js.'
this change could clear the warning
![image](https://user-images.githubusercontent.com/23518009/80694819-9e97c580-8b07-11ea-8eb8-18ee2b2b0da2.png)