### PR TITLE
refactor(test): write config file in its own steps

### DIFF
--- a/test/e2e/step_definitions/core_steps.js
+++ b/test/e2e/step_definitions/core_steps.js
@@ -9,8 +9,6 @@ let additionalArgs = []
 function execKarma (command, level, callback) {
   level = level || 'warn'
 
-  this.writeConfigFile()
-
   const configFile = this.configFile
   const runtimePath = this.karmaExecutable
   const baseDir = this.workDir
@@ -75,8 +73,13 @@ function execKarma (command, level, callback) {
   }
 }
 
+Given('a default configuration', function () {
+  this.writeConfigFile()
+})
+
 Given('a configuration with:', function (fileContent) {
   this.updateConfig(fileContent)
+  this.writeConfigFile()
 })
 
 Given('command line arguments of: {string}', function (args, callback) {

--- a/test/e2e/stop.feature
+++ b/test/e2e/stop.feature
@@ -4,6 +4,7 @@ Feature: Stop karma
   I want to be able to stop Karma.
 
   Scenario: A server can't be stopped if it isn't running
+    Given a default configuration
     When I stop Karma
     Then it fails with like:
       """


### PR DESCRIPTION
From the description of the steps it makes sense to write it straight away. Also this is more flexible and allows to introduce steps, which do not require config file in the future PR.