### PR TITLE
refactor(test): add common method to start server in background

### DIFF
--- a/test/e2e/browser_console.feature
+++ b/test/e2e/browser_console.feature
@@ -183,7 +183,7 @@ Feature: Browser Console Configuration
       ];
       singleRun = false;
       """
-    When I runOut Karma
+    When I run Karma
     Then it passes with like:
       """
       LOG: 'foo'

--- a/test/e2e/error.feature
+++ b/test/e2e/error.feature
@@ -29,7 +29,7 @@ Feature: Error Display
       ];
       singleRun = false;
       """
-    When I runOut Karma
+    When I run Karma
     Then it fails with like:
       """
       SyntaxError: Unexpected token '}'

--- a/test/e2e/launcher-error.feature
+++ b/test/e2e/launcher-error.feature
@@ -13,7 +13,7 @@ Feature: Launcher error
         'karma-script-launcher'
       ];
       """
-    When I run Karma
+    When I start Karma
     Then it fails with like:
       """
       Missing fake dependency

--- a/test/e2e/pass-opts.feature
+++ b/test/e2e/pass-opts.feature
@@ -15,7 +15,7 @@ Feature: Passing Options
       singleRun = false;
       """
     And command line arguments of: "-- arg1 arg2"
-    When I runOut Karma
+    When I run Karma
     Then it passes with no debug:
       """
       .

--- a/test/e2e/step_definitions/hooks.js
+++ b/test/e2e/step_definitions/hooks.js
@@ -6,10 +6,5 @@ Before(function () {
 
 After(async function () {
   await this.proxy.stopIfRunning()
-
-  const running = this.child != null && typeof this.child.kill === 'function'
-  if (running) {
-    this.child.kill()
-    this.child = null
-  }
+  await this.stopBackgroundProcessIfRunning()
 })

--- a/test/e2e/timeout.feature
+++ b/test/e2e/timeout.feature
@@ -14,7 +14,7 @@ Feature: Timeout
       ];
       captureTimeout = 100
       """
-    When I run Karma
+    When I start Karma
     Then it fails with like:
       """
       have not captured in 100 ms


### PR DESCRIPTION
The existing code had pretty confusing logic (old lines 33-36): when background server start fails it is actually considered a success, but child process is not started. Because of this `lastRun` contains result output of the `karma start`. This is no longer the case, hence two test cases had to be updated as they never executed `karma run` despite the statement and were asserting against `karma start` output. This should be more clear now.

As background server process now has its own variable to store output, there is no need for a dedicated runOut command and it can be removed.