### PR TITLE
refactor(test): reduce execKarma to a reasonable size

### DIFF
--- a/test/e2e/browser_console.feature
+++ b/test/e2e/browser_console.feature
@@ -183,7 +183,12 @@ Feature: Browser Console Configuration
       ];
       singleRun = false;
       """
-    When I run Karma
+    When I start a server in background
+    And I wait until server output contains:
+      """
+      Executed 1 of 1 SUCCESS
+      """
+    And I run Karma
     Then it passes with like:
       """
       LOG: 'foo'

--- a/test/e2e/error.feature
+++ b/test/e2e/error.feature
@@ -18,6 +18,7 @@ Feature: Error Display
       """
       SyntaxError: Unexpected token '}'
       """
+
   Scenario: Not single-run Syntax Error in a test file
     Given a configuration with:
       """
@@ -29,7 +30,12 @@ Feature: Error Display
       ];
       singleRun = false;
       """
-    When I run Karma
+    When I start a server in background
+    And I wait until server output contains:
+      """
+      Executed 2 of 2 (1 FAILED)
+      """
+    And I run Karma
     Then it fails with like:
       """
       SyntaxError: Unexpected token '}'

--- a/test/e2e/pass-opts.feature
+++ b/test/e2e/pass-opts.feature
@@ -15,7 +15,12 @@ Feature: Passing Options
       singleRun = false;
       """
     And command line arguments of: "-- arg1 arg2"
-    When I run Karma
+    When I start a server in background
+    And I wait until server output contains:
+      """
+      Executed 1 of 1 (1 FAILED)
+      """
+    And I run Karma
     Then it passes with no debug:
       """
       .

--- a/test/e2e/step_definitions/utils.js
+++ b/test/e2e/step_definitions/utils.js
@@ -1,0 +1,15 @@
+const { promisify } = require('util')
+
+const sleep = promisify(setTimeout)
+
+module.exports.waitForCondition = async (evaluateCondition, timeout = 1000) => {
+  let remainingTime = timeout
+  while (!evaluateCondition()) {
+    if (remainingTime > 0) {
+      await sleep(50)
+      remainingTime -= 50
+    } else {
+      throw new Error(`Condition not fulfilled, waited ${timeout}ms`)
+    }
+  }
+}


### PR DESCRIPTION
Finally!

Introduced extra step "I wait until server output contains" instead of hard-coded timeout. It will regularly evaluate a condition until it fulfills. This approach should potentially perform a little bit better than the previous solution.