### PR TITLE
refactor(test): move execKarma into the World

### DIFF
--- a/test/e2e/pass-opts.feature
+++ b/test/e2e/pass-opts.feature
@@ -14,13 +14,12 @@ Feature: Passing Options
       ];
       singleRun = false;
       """
-    And command line arguments of: "-- arg1 arg2"
     When I start a server in background
     And I wait until server output contains:
       """
       Executed 1 of 1 (1 FAILED)
       """
-    And I run Karma
+    And I run Karma with additional arguments: "-- arg1 arg2"
     Then it passes with no debug:
       """
       .

--- a/test/e2e/stop.feature
+++ b/test/e2e/stop.feature
@@ -38,7 +38,7 @@ Feature: Stop karma
       singleRun = false;
       """
     When I start a server in background
-    And I stop Karma with log-level info
+    And I stop Karma with additional arguments: "--log-level info"
     Then it passes with like:
     """
     Server stopped.

--- a/test/e2e/support/world.js
+++ b/test/e2e/support/world.js
@@ -1,4 +1,4 @@
-const { spawn } = require('child_process')
+const { exec, spawn } = require('child_process')
 const fs = require('fs')
 const vm = require('vm')
 const path = require('path')
@@ -42,6 +42,7 @@ class World {
       frameworks: ['jasmine'],
       basePath: this.workDir,
       colors: false,
+      logLevel: 'warn',
       // Current approach uses vm.runInNewContext() method to apply
       // configuration overrides. With this approach config object is used as an
       // evaluation context and as result none of the regular node module
@@ -144,6 +145,17 @@ module.exports = (config) => {
           .kill()
       })
     }
+  }
+
+  async runForegroundProcess (args) {
+    return new Promise((resolve) => {
+      exec(`${this.karmaExecutable} ${args}`, { cwd: this.workDir }, (error, stdout, stderr) => {
+        this.lastRun.error = error
+        this.lastRun.stdout = stdout.toString()
+        this.lastRun.stderr = stderr.toString()
+        resolve()
+      })
+    })
   }
 }
 

--- a/test/e2e/upstream-proxy.feature
+++ b/test/e2e/upstream-proxy.feature
@@ -18,7 +18,7 @@ Feature: UpstreamProxy
       };
       """
     And a proxy on port 9875 that prepends '/__proxy__/' to the base path
-    When I start Karma with log-level debug
+    When I start Karma with additional arguments: "--log-level debug"
     Then it passes with regexp:
       """
       Chrome Headless.*Executed.*SUCCESS


### PR DESCRIPTION
Also generalize a step to accept any CLI arguments instead of only log-level. This should make this step more flexible. After the recent changes the removed step was not very clear as to which command (foreground or background) it applies to and is fully covered with expanded "I {command} Karma ..." step.