### PR TITLE
refactor(test): remove no debug matching option

### DIFF
--- a/test/e2e/pass-opts.feature
+++ b/test/e2e/pass-opts.feature
@@ -20,7 +20,7 @@ Feature: Passing Options
       Executed 1 of 1 (1 FAILED)
       """
     And I run Karma with additional arguments: "-- arg1 arg2"
-    Then it passes with no debug:
+    Then it passes with:
       """
       .
       """

--- a/test/e2e/step_definitions/core_steps.js
+++ b/test/e2e/step_definitions/core_steps.js
@@ -51,19 +51,11 @@ When('I execute Karma with arguments: {string}', async function (args) {
   await this.runForegroundProcess(args)
 })
 
-Then(/^it passes with(:? (no\sdebug|like|regexp))?:$/, { timeout: 10 * 1000 }, function (mode, expectedOutput, callback) {
-  const noDebug = mode === 'no debug'
+Then(/^it passes with(:? (like|regexp))?:$/, { timeout: 10 * 1000 }, function (mode, expectedOutput, callback) {
   const like = mode === 'like'
   const regexp = mode === 'regexp'
   let actualOutput = this.lastRun.stdout
-  let lines
 
-  if (noDebug) {
-    lines = actualOutput.split('\n').filter(function (line) {
-      return !line.match(/\[DEBUG\]/)
-    })
-    actualOutput = lines.join('\n')
-  }
   if (like && actualOutput.indexOf(expectedOutput) >= 0) {
     return callback()
   }


### PR DESCRIPTION
There is no need to filter out [DEBUG] logs as tests are run with logLevel = "warn" by default.