### PR TITLE
feat: add isDebug flag to karma client

### DIFF
--- a/static/debug.js
+++ b/static/debug.js
@@ -1,3 +1,6 @@
+// Add a flag for adapter code to determine if in debug mode
+window.__karma__.isDebug = true
+
 // Override the Karma setup for local debugging
 window.__karma__.info = function (info) {
   if (info.dump && window.console) window.console.log(info.dump)


### PR DESCRIPTION
That way test adapters and plugins can properly adapt behavior based on the context like karma does, e.g. customizing console logging