### PR TITLE
chore: fix broken HTML markup in the changelog file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -932,7 +932,7 @@ to match this new format.
 
 
 
-<a name"0.13.3"></a>
+<a name="0.13.3"></a>
 ### 0.13.3 (2015-07-22)
 
 
@@ -946,7 +946,7 @@ to match this new format.
 * **preprocessor:** Capital letters in binary files extenstions ([1688689d](https://github.com/karma-runner/karma/commit/1688689d), closes [#1508](https://github.com/karma-runner/karma/issues/1508))
 
 
-<a name"0.13.2"></a>
+<a name="0.13.2"></a>
 ### 0.13.2 (2015-07-17)
 
 
@@ -957,7 +957,7 @@ to match this new format.
 * **server:** Add public api to force a file list refresh. ([b3c462a5](https://github.com/karma-runner/karma/commit/b3c462a5))
 
 
-<a name"0.13.1"></a>
+<a name="0.13.1"></a>
 ### 0.13.1 (2015-07-16)
 
 
@@ -968,7 +968,7 @@ to match this new format.
   * Normalize glob patterns ([fb841a79](https://github.com/karma-runner/karma/commit/fb841a79), closes [#1494](https://github.com/karma-runner/karma/issues/1494))
 
 
-<a name"0.13.0"></a>
+<a name="0.13.0"></a>
 ## 0.13.0 (2015-07-15)
 
 
@@ -1025,7 +1025,7 @@ to match this new format.
 
 
 
-<a name"0.12.37"></a>
+<a name="0.12.37"></a>
 ### 0.12.37 (2015-06-24)
 
 
@@ -1036,7 +1036,7 @@ to match this new format.
 * **middleware:** Actually serve the favicon. ([f12db639](https://github.com/karma-runner/karma/commit/f12db639))
 
 
-<a name"0.12.36"></a>
+<a name="0.12.36"></a>
 ### 0.12.36 (2015-06-04)
 
 
@@ -1046,7 +1046,7 @@ to match this new format.
 * **preprocessor:** Lookup patterns once invoked ([00a27813](https://github.com/karma-runner/karma/commit/00a27813), closes [#1340](https://github.com/karma-runner/karma/issues/1340))
 
 
-<a name"0.12.35"></a>
+<a name="0.12.35"></a>
 ### 0.12.35 (2015-05-29)
 
 
@@ -1055,7 +1055,7 @@ to match this new format.
 * **server:** Start webserver and browsers after preprocessing completed ([e0d2d239](https://github.com/karma-runner/karma/commit/e0d2d239))
 
 
-<a name"0.12.34"></a>
+<a name="0.12.34"></a>
 ### 0.12.34 (2015-05-29)
 
 
@@ -1071,7 +1071,7 @@ to match this new format.
 * **runner:** Use favicon in static runner pages ([6cded4f8](https://github.com/karma-runner/karma/commit/6cded4f8))
 
 
-<a name"0.12.33"></a>
+<a name="0.12.33"></a>
 ### 0.12.33 (2015-05-26)
 
 


### PR DESCRIPTION
I'm trying to update a Markdown parser for the documentation website and it fails on this broken markup.