### PR TITLE
chore: remove unused `grunt lint` command

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -42,22 +42,6 @@ module.exports = function (grunt) {
         ]
       }
     },
-    eslint: {
-      options: {
-        quiet: true
-      },
-      target: [
-        '<%= files.server %>',
-        '<%= files.grunt %>',
-        '<%= files.scripts %>',
-        '<%= files.client %>',
-        '<%= files.common %>',
-        '<%= files.context %>',
-        'static/debug.js',
-        'test/**/*.js',
-        'gruntfile.js'
-      ]
-    },
     'npm-publish': {
       options: {
         requires: ['build'],
@@ -110,9 +94,8 @@ module.exports = function (grunt) {
   grunt.loadTasks('tasks')
   require('load-grunt-tasks')(grunt)
 
-  grunt.registerTask('lint', ['eslint'])
   grunt.registerTask('build', ['browserify:client'])
-  grunt.registerTask('default', ['build', 'lint', 'test'])
+  grunt.registerTask('default', ['build', 'test'])
   grunt.registerTask('test-appveyor', ['test:unit', 'test:client'])
 
   grunt.registerTask('release', 'Build, bump and publish to NPM.', function (type) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6380,16 +6380,6 @@
         }
       }
     },
-    "grunt-eslint": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-21.1.0.tgz",
-      "integrity": "sha512-TN1C4BV947eUB/XrROUQ/QFTufWgH6wdfaxhlfmpjE70bFTp5q+Q2LgIZ5Y//+Rn1BWrXmm44sxegijNN6WR/A==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.1.0",
-        "eslint": "^5.16.0"
-      }
-    },
     "grunt-known-options": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -440,7 +440,6 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-conventional-changelog": "^6.0.1",
     "grunt-conventional-github-releaser": "^1.0.0",
-    "grunt-eslint": "^21.0.0",
     "grunt-mocha-test": "^0.13.2",
     "grunt-npm": "0.0.2",
     "http2": "^3.3.6",


### PR DESCRIPTION
Use `npm run lint` instead.