### PR TITLE
chore: increase step timeout to prevent flakiness

### DIFF
--- a/test/e2e/step_definitions/core_steps.js
+++ b/test/e2e/step_definitions/core_steps.js
@@ -31,7 +31,14 @@ When('I start a server in background', async function () {
 })
 
 When('I wait until server output contains:', async function (expectedOutput) {
-  await waitForCondition(() => this.backgroundProcess.stdout.includes(expectedOutput))
+  await waitForCondition(
+    () => this.backgroundProcess.stdout.includes(expectedOutput),
+    5000,
+    () => new Error(
+      'Expected server output to contain the above text within 5000ms, but got:\n\n' +
+      this.backgroundProcess.stdout
+    )
+  )
 })
 
 defineParameterType({

--- a/test/e2e/step_definitions/utils.js
+++ b/test/e2e/step_definitions/utils.js
@@ -2,14 +2,18 @@ const { promisify } = require('util')
 
 const sleep = promisify(setTimeout)
 
-module.exports.waitForCondition = async (evaluateCondition, timeout = 1000) => {
+module.exports.waitForCondition = async (evaluateCondition, timeout = 1000, customError = null) => {
   let remainingTime = timeout
   while (!evaluateCondition()) {
     if (remainingTime > 0) {
       await sleep(50)
       remainingTime -= 50
     } else {
-      throw new Error(`Condition not fulfilled, waited ${timeout}ms`)
+      if (customError != null) {
+        throw customError()
+      } else {
+        throw new Error(`Condition not fulfilled, waited ${timeout}ms`)
+      }
     }
   }
 }


### PR DESCRIPTION
Also added a custom error logic, so actual output is printed if condition times out.

Example https://travis-ci.org/github/karma-runner/karma/jobs/688421469#L643