### PR TITLE
ci: update documentation after publishing a release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@
 tmp
 test
 tasks
+/tools/
 docs
 client
 logo

--- a/release.config.js
+++ b/release.config.js
@@ -17,6 +17,7 @@ module.exports = {
     '@semantic-release/github'
   ],
   success: [
-    '@semantic-release/github'
+    '@semantic-release/github',
+    './tools/update-docs'
   ]
 }

--- a/tools/update-docs.js
+++ b/tools/update-docs.js
@@ -1,0 +1,24 @@
+const { execSync } = require('child_process')
+const { dirSync } = require('tmp')
+
+const success = async (pluginConfig, { nextRelease, logger }) => {
+  const [major, minor] = nextRelease.version.split('.')
+  const docsVersion = `${major}.${minor}`
+
+  const { name: docsPath } = dirSync()
+
+  // This is a regular repository remote one would get if they click a Clone
+  // button on GitHub. The only added part is GH_TOKEN value in the `userinfo`
+  // part of the URL (https://en.wikipedia.org/wiki/URL), which allows GitHub
+  // to authenticate a user and authorise the push to the repository.
+  const repoOrigin = `https://${process.env.GH_TOKEN}@github.com/karma/karma-runner.github.com.git`
+
+  const options = { encoding: 'utf8', cwd: docsPath }
+
+  logger.log(execSync(`git clone ${repoOrigin} .`, options))
+  logger.log(execSync('npm ci', options))
+  logger.log(execSync(`./sync-docs.sh "${nextRelease.gitTag}" "${docsVersion}"`, options))
+  logger.log(execSync('git push origin master', options))
+}
+
+module.exports = { success }


### PR DESCRIPTION
This will automatically update the documentation after publishing a new release.

Example: https://github.com/devoto13/karma-runner.github.com/commits/master

I don't have a way to test it on Travis before merging... But it works locally. So as long as `GH_TOKEN` with push access to https://github.com/karma-runner/karma-runner.github.com is available and Travis does not do anything funny with the temporary directory handing this should work on Travis as well.