### PR TITLE
fix(proxy): use keepAlive agent

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -1,4 +1,6 @@
 const url = require('url')
+const { Agent: httpAgent } = require('http')
+const { Agent: httpsAgent } = require('https')
 const httpProxy = require('http-proxy')
 const _ = require('lodash')
 
@@ -42,11 +44,14 @@ function parseProxyConfig (proxies, config) {
       port = config.port
     }
     const changeOrigin = proxyConfiguration.changeOrigin || false
+    const Agent = https ? httpsAgent : httpAgent
+    const agent = new Agent({ keepAlive: true })
     const proxy = httpProxy.createProxyServer({
       target: { host: hostname, port, https, protocol },
       xfwd: true,
       changeOrigin: changeOrigin,
-      secure: config.proxyValidateSSL
+      secure: config.proxyValidateSSL,
+      agent
     })
 
     ;['proxyReq', 'proxyRes'].forEach(function (name) {
@@ -66,7 +71,7 @@ function parseProxyConfig (proxies, config) {
       res.destroy()
     })
 
-    return { path: proxyPath, baseUrl: pathname, host: hostname, port, https, proxy }
+    return { path: proxyPath, baseUrl: pathname, host: hostname, port, https, proxy, agent }
   }), 'path').reverse()
 }
 
@@ -112,6 +117,14 @@ function createProxyHandler (proxies, urlRoot) {
   return createProxy
 }
 
-exports.create = function (/* config */config, /* config.proxies */proxies) {
-  return createProxyHandler(parseProxyConfig(proxies, config), config.urlRoot)
+exports.create = function (/* config */config, /* config.proxies */proxies, /* emitter */emitter) {
+  const proxyRecords = parseProxyConfig(proxies, config)
+  emitter.on('exit', (done) => {
+    log.debug('Destroying proxy agents')
+    proxyRecords.forEach((proxyRecord) => {
+      proxyRecord.agent.destroy()
+    })
+    done()
+  })
+  return createProxyHandler(proxyRecords, config.urlRoot)
 }

--- a/test/unit/middleware/proxy.spec.js
+++ b/test/unit/middleware/proxy.spec.js
@@ -352,4 +352,24 @@ describe('middleware.proxy', () => {
   it('should handle empty proxy config', () => {
     expect(m.parseProxyConfig({})).to.deep.equal([])
   })
+
+  it('should use http agent with keepAlive=true', () => {
+    const proxy = { '/base': 'http://localhost:8000/proxy' }
+    const parsedProxyConfig = m.parseProxyConfig(proxy, {})
+    expect(parsedProxyConfig).to.have.length(1)
+    expect(parsedProxyConfig[0].proxy.options.agent).to.containSubset({
+      keepAlive: true,
+      protocol: 'http:'
+    })
+  })
+
+  it('should use https agent with keepAlive=true', () => {
+    const proxy = { '/base': 'https://localhost:8000/proxy' }
+    const parsedProxyConfig = m.parseProxyConfig(proxy, {})
+    expect(parsedProxyConfig).to.have.length(1)
+    expect(parsedProxyConfig[0].proxy.options.agent).to.containSubset({
+      keepAlive: true,
+      protocol: 'https:'
+    })
+  })
 })


### PR DESCRIPTION
Using an agent with keepAlive improves performance as the socket is
reused across multiple requests.