### PR TITLE
fix(server): log error when file loading or preprocessing fails

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -191,7 +191,10 @@ class Server extends KarmaEventEmitter {
       })
     }
 
-    fileList.refresh().then(afterPreprocess, afterPreprocess)
+    fileList.refresh().then(afterPreprocess, (err) => {
+      this.log.error('Error during file loading or preprocessing\n' + err.stack || err)
+      afterPreprocess()
+    })
 
     this.on('browsers_change', () => socketServer.sockets.emit('info', capturedBrowsers.serialize()))
 


### PR DESCRIPTION
Previously the error has been fully ignored.

### Context / background

This has been detected within [SAP/openui5](https://github.com/SAP/openui5) where we start a local server in parallel to karma. When upgrading to karma v5 we faced some issues mainly on Windows. It turned out that the root cause is `EMFILE, too many open files`, probably because internal timings have changed by switching from bluebird to native Promises.
As the actual error hasn't been logged, it took me some time to find out where the error comes from.

We solved the problem on our side by starting the server as part of an async framework plugin, instead of just `require`ing it from the `karma.conf.js` (see https://github.com/SAP/openui5/commit/e77a49a64d3fed1da65689b1f8eb1674297f6602). This ensures that it doesn't get executed while karma is preprocessing all the project files. IMO it's anyway a better approach as it is ensured that the server is up and running before karma starts.
