### PR TITLE
feat(server): allow 'exit' listeners to set exit code

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -142,6 +142,35 @@ class Server extends KarmaEventEmitter {
     return this._fileList ? this._fileList.changeFile(path) : Promise.resolve()
   }
 
+  emitExitAsync (code) {
+    const name = 'exit'
+    let pending = this.listeners(name).length
+    const deferred = helper.defer()
+
+    function resolve () {
+      deferred.resolve(code)
+    }
+
+    try {
+      this.emit(name, (newCode) => {
+        if (newCode && typeof newCode === 'number') {
+          // Only update code if it is given and not zero
+          code = newCode
+        }
+        if (!--pending) {
+          resolve()
+        }
+      })
+
+      if (!pending) {
+        resolve()
+      }
+    } catch (err) {
+      deferred.reject(err)
+    }
+    return deferred.promise
+  }
+
   async _start (config, launcher, preprocess, fileList, capturedBrowsers, executor, done) {
     if (config.detached) {
       this._detach(config, done)
@@ -296,7 +325,8 @@ class Server extends KarmaEventEmitter {
 
     this.on('stop', function (done) {
       this.log.debug('Received stop event, exiting.')
-      return disconnectBrowsers().then(done)
+      disconnectBrowsers()
+      done()
     })
 
     if (config.singleRun) {
@@ -354,28 +384,29 @@ class Server extends KarmaEventEmitter {
         }
       })
 
-      let removeAllListenersDone = false
-      const removeAllListeners = () => {
-        if (removeAllListenersDone) {
-          return
+      this.emitExitAsync(code).catch((err) => {
+        this.log.error('Error while calling exit event listeners\n' + err.stack || err)
+        return 1
+      }).then((code) => {
+        socketServer.sockets.removeAllListeners()
+        socketServer.close()
+
+        let removeAllListenersDone = false
+        const removeAllListeners = () => {
+          if (removeAllListenersDone) {
+            return
+          }
+          removeAllListenersDone = true
+          webServer.removeAllListeners()
+          processWrapper.removeAllListeners()
+          done(code || 0)
         }
-        removeAllListenersDone = true
-        webServer.removeAllListeners()
-        processWrapper.removeAllListeners()
-        done(code || 0)
-      }
 
-      return this.emitAsync('exit').then(() => {
-        return new Promise((resolve, reject) => {
-          socketServer.sockets.removeAllListeners()
-          socketServer.close()
-          const closeTimeout = setTimeout(removeAllListeners, webServerCloseTimeout)
+        const closeTimeout = setTimeout(removeAllListeners, webServerCloseTimeout)
 
-          webServer.close(() => {
-            clearTimeout(closeTimeout)
-            removeAllListeners()
-            resolve()
-          })
+        webServer.close(() => {
+          clearTimeout(closeTimeout)
+          removeAllListeners()
         })
       })
     }


### PR DESCRIPTION
Currently it seems that it's not possible for reporters to set the exit code asynchronously.
Within the "onRunComplete" event, the `results.exitCode` must be modified synchronously, otherwise the updated value is not taken into account.

With this change, the reporters (or any other plugin) can pass an exit code to the callback of the 'exit' event.

This is the only existing place I've found to be leveraged without creating a lot of new code and APIs.

### Todos

- [x] Add tests
- [x] Remove `chore(npm): update npmignore to allow install via GH url` commit before merge

### Context / background

This is currently a problem in the `karma-coverage` plugin.
See https://github.com/karma-runner/karma-coverage/issues/418 and https://github.com/matz3/issue-karma-coverage-threshold-exit-code