### PR TITLE
refactor: use colors/safe

### DIFF
--- a/lib/reporters/base_color.js
+++ b/lib/reporters/base_color.js
@@ -1,23 +1,23 @@
-require('colors')
+const { red, yellow, green, cyan } = require('colors/safe')
 
 function BaseColorReporter () {
   this.USE_COLORS = true
 
-  this.LOG_SINGLE_BROWSER = '%s: ' + '%s'.cyan + '\n'
-  this.LOG_MULTI_BROWSER = '%s %s: ' + '%s'.cyan + '\n'
+  this.LOG_SINGLE_BROWSER = '%s: ' + cyan('%s') + '\n'
+  this.LOG_MULTI_BROWSER = '%s %s: ' + cyan('%s') + '\n'
 
-  this.SPEC_FAILURE = '%s %s FAILED'.red + '\n'
-  this.SPEC_SLOW = '%s SLOW %s: %s'.yellow + '\n'
-  this.ERROR = '%s ERROR'.red + '\n'
+  this.SPEC_FAILURE = red('%s %s FAILED') + '\n'
+  this.SPEC_SLOW = yellow('%s SLOW %s: %s') + '\n'
+  this.ERROR = red('%s ERROR') + '\n'
 
-  this.FINISHED_ERROR = ' ERROR'.red
-  this.FINISHED_SUCCESS = ' SUCCESS'.green
-  this.FINISHED_DISCONNECTED = ' DISCONNECTED'.red
+  this.FINISHED_ERROR = red(' ERROR')
+  this.FINISHED_SUCCESS = green(' SUCCESS')
+  this.FINISHED_DISCONNECTED = red(' DISCONNECTED')
 
-  this.X_FAILED = ' (%d FAILED)'.red
+  this.X_FAILED = red(' (%d FAILED)')
 
-  this.TOTAL_SUCCESS = 'TOTAL: %d SUCCESS'.green + '\n'
-  this.TOTAL_FAILED = 'TOTAL: %d FAILED, %d SUCCESS'.red + '\n'
+  this.TOTAL_SUCCESS = green('TOTAL: %d SUCCESS') + '\n'
+  this.TOTAL_FAILED = red('TOTAL: %d FAILED, %d SUCCESS') + '\n'
 }
 
 // PUBLISH


### PR DESCRIPTION
This change switches use of the `color` module for `color/safe` to avoid mutating the shared primordials. Tools like [SES](https://github.com/Agoric/SES-shim/tree/master/packages/ses) make the primordials immutable to mitigate some kinds of supply-chain attacks.