### PR TITLE
chore(release): fix documentation update task

### DIFF
--- a/tools/update-docs.js
+++ b/tools/update-docs.js
@@ -11,7 +11,7 @@ const success = async (pluginConfig, { nextRelease, logger }) => {
   // button on GitHub. The only added part is GH_TOKEN value in the `userinfo`
   // part of the URL (https://en.wikipedia.org/wiki/URL), which allows GitHub
   // to authenticate a user and authorise the push to the repository.
-  const repoOrigin = `https://${process.env.GH_TOKEN}@github.com/karma/karma-runner.github.com.git`
+  const repoOrigin = `https://${process.env.GH_TOKEN}@github.com/karma-runner/karma-runner.github.com.git`
 
   const options = { encoding: 'utf8', cwd: docsPath }
 


### PR DESCRIPTION
The task has never succeeded because there was a typo in the repository URL.
See https://travis-ci.org/github/karma-runner/karma/jobs/722815882#L1324

But build has never failed either, because "The exit code of after_success, after_failure, after_script, after_deploy and subsequent stages do not affect the build result." according to Travis [documentation](https://docs.travis-ci.com/user/job-lifecycle/#breaking-the-build) and this code was run in `after_success` stage. This should be fixed in a separate PR though.