### PR TITLE
docs: mention that `html` include type does not work anymore

### DIFF
--- a/docs/config/02-files.md
+++ b/docs/config/02-files.md
@@ -27,17 +27,14 @@ Each pattern is either a simple string or an object with the following propertie
 ### `type`
 * **Type.** String
 * **Default.** Will attempt to determine type based on file extension. If that fails, defaults to `js`.
-* **Description.** Choose the type to use when including a file.
 * **Possible Values:**
-  * `css`
-  * `html`
-  * `js`
-  * `dart`
-  * `module`
-  * `dom`
-* **Description.** The type determines the mechanism for including the file. The `css` and `html` types
-create `link` elements; the `js`, `dart`, and `module` elements create `script` elements. The `dom` type
-includes the file content in the page, used, for example, to test components combining HTML and JS.
+  * `css` - Include using `<link rel="stylesheet">` tag.
+  * `html` - Include using [HTML Imports](https://developer.mozilla.org/en-US/docs/Web/Web_Components/HTML_Imports). Note that this feature is obsolete and does not work in the modern browsers. 
+  * `js` - Include using `<script></script>` tag.
+  * `dart` - Include using `<script type="application/dart"></script>` tag. Note that this does not work in the modern browsers.
+  * `module` - Include using `<script type="module"></script>` tag.
+  * `dom` - Inline content of the file in the page. This can be used, for example, to test components combining HTML and JS.
+* **Description.** The type determines the mechanism for including the file.
 
 ### `watched`
 * **Type.** Boolean


### PR DESCRIPTION
Also added similar note for `dart` include type.

Fixes #3419