### PR TITLE
revert: back to version 0.6.x of source-map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14779,9 +14779,9 @@
       }
     },
     "source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -420,7 +420,7 @@
     "range-parser": "^1.2.1",
     "rimraf": "^3.0.2",
     "socket.io": "^2.3.0",
-    "source-map": "^0.7.3",
+    "source-map": "~0.6.1",
     "tmp": "0.2.1",
     "ua-parser-js": "0.7.21",
     "yargs": "^15.3.1"


### PR DESCRIPTION
source-map 0.7.0 has breaking change. As a temporary workaround, this
commit reverts to using version 0.6.x of source-map. See
https://github.com/karma-runner/karma/issues/3557 for details.