### PR TITLE
Update ua-parser-js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15588,9 +15588,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+      "version": "0.7.22",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
+      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
     },
     "uglify-js": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -424,7 +424,7 @@
     "socket.io": "^2.3.0",
     "source-map": "^0.6.1",
     "tmp": "0.2.1",
-    "ua-parser-js": "0.7.21",
+    "ua-parser-js": "0.7.22",
     "yargs": "^15.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
As noted in [this issue](https://github.com/karma-runner/karma/issues/3562), `ua-parser-js` v0.7.21 has a [high severity issue](https://snyk.io/vuln/SNYK-JS-UAPARSERJS-610226).

This PR updates the dependency to correct the issue.