### PR TITLE
fix(context): do not error when karma is navigating

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -4,7 +4,7 @@ var util = require('../common/util')
 
 function Karma (socket, iframe, opener, navigator, location, document) {
   var startEmitted = false
-  var reloadingContext = false
+  var karmaNavigating = false
   var self = this
   var queryParams = util.parseQueryParams(location.search)
   var browserId = queryParams.id || util.generateId('manual-')
@@ -80,6 +80,7 @@ function Karma (socket, iframe, opener, navigator, location, document) {
 
   var childWindow = null
   function navigateContextTo (url) {
+    karmaNavigating = true
     if (self.config.useIframe === false) {
       // run in new window
       if (self.config.runInParent === false) {
@@ -89,9 +90,11 @@ function Karma (socket, iframe, opener, navigator, location, document) {
           childWindow.close()
         }
         childWindow = opener(url)
+        karmaNavigating = false
       // run context on parent element (client_with_context)
       // using window.__karma__.scriptUrls to get the html element strings and load them dynamically
       } else if (url !== 'about:blank') {
+        karmaNavigating = false
         var loadScript = function (idx) {
           if (idx < window.__karma__.scriptUrls.length) {
             var parser = new DOMParser()
@@ -123,20 +126,19 @@ function Karma (socket, iframe, opener, navigator, location, document) {
     // run in iframe
     } else {
       iframe.src = policy.createURL(url)
+      karmaNavigating = false
     }
   }
 
   this.onbeforeunload = function () {
-    if (!reloadingContext) {
+    if (!karmaNavigating) {
       // TODO(vojta): show what test (with explanation about jasmine.UPDATE_INTERVAL)
       self.error('Some of your tests did a full page reload!')
     }
-    reloadingContext = false
+    karmaNavigating = false
   }
 
   function clearContext () {
-    reloadingContext = true
-
     navigateContextTo('about:blank')
   }
 

--- a/test/client/karma.spec.js
+++ b/test/client/karma.spec.js
@@ -147,6 +147,29 @@ describe('Karma', function () {
   it('should error out if a script attempted to reload the browser after setup', function (done) {
     // Perform setup
     var config = ck.config = {
+      clearContext: false
+    }
+    socket.emit('execute', config)
+
+    setTimeout(function nextEventLoop () {
+      var mockWindow = {}
+      ck.setupContext(mockWindow)
+
+      // Spy on our error handler
+      sinon.spy(k, 'error')
+
+      // Emulate an unload event
+      mockWindow.onbeforeunload()
+
+      // Assert our spy was called
+      assert(k.error.calledWith('Some of your tests did a full page reload!'))
+      done()
+    })
+  })
+
+  it('should error out if a script attempted to reload the browser after setup with clearContext true', function (done) {
+    // Perform setup
+    var config = ck.config = {
       clearContext: true
     }
     socket.emit('execute', config)


### PR DESCRIPTION
Change the flag name to karmaNavigating and set it along all paths where
karma deliberately navigates. Other paths must be wrong.

Fixes #3560