### PR TITLE
fix: error only when karma is navigating

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -131,7 +131,7 @@ function Karma (socket, iframe, opener, navigator, location, document) {
   }
 
   this.onbeforeunload = function () {
-    if (!karmaNavigating) {
+    if (karmaNavigating) {
       // TODO(vojta): show what test (with explanation about jasmine.UPDATE_INTERVAL)
       self.error('Some of your tests did a full page reload!')
     }

--- a/static/karma.js
+++ b/static/karma.js
@@ -141,7 +141,7 @@ function Karma (socket, iframe, opener, navigator, location, document) {
   }
 
   this.onbeforeunload = function () {
-    if (!karmaNavigating) {
+    if (karmaNavigating) {
       // TODO(vojta): show what test (with explanation about jasmine.UPDATE_INTERVAL)
       self.error('Some of your tests did a full page reload!')
     }


### PR DESCRIPTION
This commit fixes a bug whereby Karma mistakenly errors out when it is
*not* navigating. This is because the variable was flipped from
`reloadingContext` to `karmaNavigating` in #3565, but the condition was
not negated.