### PR TITLE
fix(cve): update ua-parser-js to 0.7.23 to fix CVE-2020-7793

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15588,9 +15588,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.22",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
+      "version": "0.7.23",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
     },
     "uglify-js": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -425,7 +425,7 @@
     "socket.io": "^2.3.0",
     "source-map": "^0.6.1",
     "tmp": "0.2.1",
-    "ua-parser-js": "0.7.22",
+    "ua-parser-js": "^0.7.23",
     "yargs": "^15.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes: #3583