### PR TITLE
fix(tests): verify the executed success for the reconnection test.

### DIFF
--- a/test/e2e/reconnecting.feature
+++ b/test/e2e/reconnecting.feature
@@ -19,8 +19,7 @@ Feature: Passing Options
       };
       """
     When I start Karma
-    Then it passes with:
+    Then it passes with regexp:
       """
-      .....
-      Chrome Headless
+      Chrome Headless.*Executed.*SUCCESS
       """


### PR DESCRIPTION
This tests fails local testing in some combinations of node and chrome. The match to the string fails.
By switching to a regexp we allow text on the end of the line. 