### PR TITLE
fix(client): do not reset karmaNavigating in onbeforeunload

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -135,7 +135,6 @@ function Karma (socket, iframe, opener, navigator, location, document) {
       // TODO(vojta): show what test (with explanation about jasmine.UPDATE_INTERVAL)
       self.error('Some of your tests did a full page reload!')
     }
-    karmaNavigating = false
   }
 
   function clearContext () {

--- a/static/karma.js
+++ b/static/karma.js
@@ -145,7 +145,6 @@ function Karma (socket, iframe, opener, navigator, location, document) {
       // TODO(vojta): show what test (with explanation about jasmine.UPDATE_INTERVAL)
       self.error('Some of your tests did a full page reload!')
     }
-    karmaNavigating = false
   }
 
   function clearContext () {


### PR DESCRIPTION
The unload handler itself does not know about navigation.
May fix #3482