### PR TITLE
feat(server): print stack of unhandledrejections

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -417,12 +417,12 @@ class Server extends KarmaEventEmitter {
     }
 
     processWrapper.on('unhandledRejection', (error) => {
-      this.log.error(`UnhandledRejection: ${error.message || String(error)}`)
+      this.log.error(`UnhandledRejection: ${error.stack || error.message || String(error)}`)
       reportError(error)
     })
 
     processWrapper.on('uncaughtException', (error) => {
-      this.log.error(`UncaughtException:: ${error.message || String(error)}`)
+      this.log.error(`UncaughtException:: ${error.stack || error.message || String(error)}`)
       reportError(error)
     })
   }


### PR DESCRIPTION
The v8 engine includes the error with the stack and most of the time we
need the stack also.