### PR TITLE
feat(server): remove deprecated static methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,18 +7,6 @@ const stopper = require('./stopper')
 const launcher = require('./launcher')
 const cfg = require('./config')
 
-// TODO: remove in 1.0
-const oldServer = {
-  start: function (cliOptions, done) {
-    console.error('WARN `start` method is deprecated since 0.13. It will be removed in 0.14. Please use \n' +
-      '  server = new Server(config, [done])\n' +
-      '  server.start()\n' +
-      'instead.')
-    const server = new Server(cliOptions, done)
-    server.start()
-  }
-}
-
 module.exports = {
   constants: constants,
   VERSION: constants.VERSION,
@@ -26,6 +14,5 @@ module.exports = {
   runner: runner,
   stopper: stopper,
   launcher: launcher,
-  config: { parseConfig: cfg.parseConfig }, // lets start with only opening up the `parseConfig` api
-  server: oldServer
+  config: { parseConfig: cfg.parseConfig } // lets start with only opening up the `parseConfig` api
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -450,11 +450,6 @@ class Server extends KarmaEventEmitter {
   stop () {
     return this.emitAsync('stop')
   }
-
-  static start (cliOptions, done) {
-    console.warn('Deprecated static method to be removed in v3.0')
-    return new Server(cliOptions, done).start()
-  }
 }
 
 Server.prototype._start.$inject = ['config', 'launcher', 'preprocess', 'fileList', 'capturedBrowsers', 'executor', 'done']


### PR DESCRIPTION
BREAKING CHANGE: Deprecated `require('karma').server.start()` and `require('karma').Server.start()` variants were removed from the public API. Instead use canonical form:

```
const { Server } = require('karma');
const server = new Server();
server.start();
```