### PR TITLE
fix(server): error on unknown filetypes

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -58,6 +58,12 @@ function getXUACompatibleUrl (url) {
   return ''
 }
 
+function reportFileTypeError (fileType, path) {
+  log.error(`Invalid file type (${fileType}) for ${path}.\n` +
+  '  Specify a valid type in the configuration file.\n' +
+  '  See http://karma-runner.github.io/latest/config/files.html')
+}
+
 function createKarmaMiddleware (
   filesPromise,
   serveStaticFile,
@@ -163,15 +169,8 @@ function createKarmaMiddleware (
             const fileType = file.type || file.detectType()
 
             if (!FILE_TYPES.includes(fileType)) {
-              if (file.type == null) {
-                log.warn(
-                  'Unable to determine file type from the file extension, defaulting to js.\n' +
-                  `  To silence the warning specify a valid type for ${file.originalPath} in the configuration file.\n` +
-                  '  See http://karma-runner.github.io/latest/config/files.html'
-                )
-              } else {
-                log.warn(`Invalid file type (${file.type || 'empty string'}), defaulting to js.`)
-              }
+              reportFileTypeError(fileType.length ? fileType : '<empty>', file.originalPath)
+              continue
             }
 
             if (!file.isUrl) {

--- a/test/e2e/helpful-logs.feature
+++ b/test/e2e/helpful-logs.feature
@@ -18,7 +18,5 @@ Feature: Helpful warning and errors
     When I start Karma
     Then the stdout matches RegExp:
       """
-      WARN \[middleware:karma\]: Unable to determine file type from the file extension, defaulting to js.
-        To silence the warning specify a valid type for .+modules/minus.mjs in the configuration file.
-        See http://karma-runner.github.io/latest/config/files.html
+      ERROR \[middleware:karma\]: Invalid file type \(mjs\) for .+modules/minus.mjs\.
       """

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -329,11 +329,11 @@ describe('middleware.karma', () => {
 
   it('should not change urls', (done) => {
     includedFiles([
-      new Url('http://some.url.com/whatever')
+      new Url('http://some.url.com/whatever.js')
     ])
 
     response.once('end', () => {
-      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="http://some.url.com/whatever" crossorigin="anonymous"></script>')
+      expect(response).to.beServedAs(200, 'CONTEXT\n<script type="text/javascript" src="http://some.url.com/whatever.js" crossorigin="anonymous"></script>')
       done()
     })
 


### PR DESCRIPTION
BREAKING CHANGE:
  Previously file types that were not given in the config and could not be
  determined from the file extension were treated as .js.  That can lead
  to loading extra or incorrect files.
  Now we emit an ERROR and skip any files that cannot be classified.