### PR TITLE
fix(middleware): catch errors when loading a module

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -191,7 +191,11 @@ function createKarmaMiddleware (
             } else {
               const scriptType = (SCRIPT_TYPE[fileType] || 'text/javascript')
               const crossOriginAttribute = includeCrossOriginAttribute ? 'crossorigin="anonymous"' : ''
-              scriptTags.push(`<script type="${scriptType}" src="${filePath}" ${crossOriginAttribute}></script>`)
+              if (fileType === 'module') {
+                scriptTags.push(`<script onerror="throw 'Error loading ${filePath}'" type="${scriptType}" src="${filePath}" ${crossOriginAttribute}></script>`)
+              } else {
+                scriptTags.push(`<script type="${scriptType}" src="${filePath}" ${crossOriginAttribute}></script>`)
+              }
             }
           }
 

--- a/test/e2e/error.feature
+++ b/test/e2e/error.feature
@@ -40,3 +40,19 @@ Feature: Error Display
       """
       SyntaxError: Unexpected token '}'
       """
+
+Scenario: Missing module Error in a test file
+    Given a configuration with:
+      """
+      files = [{pattern: 'error/import-something-from-somewhere.js', type: 'module'}];
+      browsers = ['ChromeHeadlessNoSandbox'];
+      plugins = [
+        'karma-jasmine',
+        'karma-chrome-launcher'
+      ];
+      """
+    When I start Karma
+    Then it fails with:
+      """
+      Uncaught Error loading error/import-something-from-somewhere.js
+      """

--- a/test/e2e/support/error/import-something-from-somewhere.js
+++ b/test/e2e/support/error/import-something-from-somewhere.js
@@ -1,0 +1,2 @@
+import { something } from './somewhere.js'
+console.log(something)


### PR DESCRIPTION
Fix #3572

Same as the fix by @jehon, but with a test.