### PR TITLE
fix(server): set maxHttpBufferSize to the socket.io v2 default

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -43,7 +43,9 @@ function createSocketIoServer (webServer, executor, config) {
     transports: config.transports,
     forceJSONP: config.forceJSONP,
     // Default is 5000 in socket.io v2.x and v3.x.
-    pingTimeout: config.pingTimeout || 5000
+    pingTimeout: config.pingTimeout || 5000,
+    // Default in v2 is 1e8 and coverage results can fail at 1e6
+    maxHttpBufferSize: 1e8
   })
 
   // hack to overcome circular dependency


### PR DESCRIPTION
Fixes #3621