### PR TITLE
Fix link to Sauce Labs plugin

### DIFF
--- a/docs/config/03-browsers.md
+++ b/docs/config/03-browsers.md
@@ -16,7 +16,7 @@ Note: Most of the browser launchers need to be loaded as [plugins].
 - [JSDOM](https://www.npmjs.com/package/karma-jsdom-launcher)
 - [Opera](https://www.npmjs.com/package/karma-opera-launcher)
 - [Internet Explorer](https://www.npmjs.com/package/karma-ie-launcher)
-- [SauceLabs](https://www.npmjs.com/package/karma-saucelabs-launcher)
+- [SauceLabs](https://www.npmjs.com/package/karma-sauce-launcher)
 - [BrowserStack](https://www.npmjs.com/package/karma-browserstack-launcher)
 - [many more](https://www.npmjs.org/browse/keyword/karma-launcher)
 


### PR DESCRIPTION
The Sauce Labs plugin link goes to a module at version 0.0.0 that hasn't been published in 5 years. Update the link to point to the module that is at version 3.4.3 and was published two months ago. In addition, this module is within the karmar-runner GitHub org.