### PR TITLE
fix(context): do not error when karma is navigating in iframe

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -128,8 +128,10 @@ function Karma (updater, socket, iframe, opener, navigator, location, document) 
       }
     // run in iframe
     } else {
+      iframe.onload = () => {
+        karmaNavigating = false
+      }
       iframe.src = policy.createURL(url)
-      karmaNavigating = false
     }
   }
 

--- a/static/karma.js
+++ b/static/karma.js
@@ -138,8 +138,10 @@ function Karma (updater, socket, iframe, opener, navigator, location, document) 
       }
     // run in iframe
     } else {
+      iframe.onload = () => {
+        karmaNavigating = false
+      }
       iframe.src = policy.createURL(url)
-      karmaNavigating = false
     }
   }
 

--- a/test/client/karma.spec.js
+++ b/test/client/karma.spec.js
@@ -184,15 +184,17 @@ describe('Karma', function () {
       var mockWindow = {}
       ck.setupContext(mockWindow)
 
-      // Spy on our error handler
-      sinon.spy(k, 'error')
+      setTimeout(() => {
+        // Spy on our error handler
+        sinon.spy(k, 'error')
 
-      // Emulate an unload event
-      mockWindow.onbeforeunload()
+        // Emulate an unload event
+        mockWindow.onbeforeunload()
 
-      // Assert our spy was called
-      assert(k.error.calledWith('Some of your tests did a full page reload!'))
-      done()
+        // Assert our spy was called
+        assert(k.error.calledWith('Some of your tests did a full page reload!'))
+        done()
+      })
     })
   })
 


### PR DESCRIPTION
reset karmaNavigating flag only after iframe is loaded. otherwise we run in to a race condition where the flag is reset before URL changes and onbeforeunload is called afterwards making the handler think the navigation was not part of context change.