### PR TITLE
fix(cli): temporarily disable strict parameters validation

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -153,7 +153,7 @@ function describeRoot () {
     .command('stop [configFile]', 'Stop the server.', describeStop)
     .command('completion', 'Shell completion for karma.', describeCompletion)
     .demandCommand(1, 'Command not specified.')
-    .strict()
+    .strictCommands()
     .describe('help', 'Print usage and options.')
     .describe('version', 'Print current version.')
 }
@@ -164,6 +164,7 @@ function describeInit (yargs) {
       'INIT - Initialize a config file.\n\n' +
       'Usage:\n' +
       '  $0 init [configFile]')
+    .strictCommands(false)
     .version(false)
     .positional('configFile', {
       describe: 'Name of the generated Karma configuration file',
@@ -215,6 +216,7 @@ function describeRun (yargs) {
       'RUN - Run the tests (requires running server).\n\n' +
       'Usage:\n' +
       '  $0 run [configFile] [-- <clientArgs>]')
+    .strictCommands(false)
     .version(false)
     .positional('configFile', {
       describe: 'Path to the Karma configuration file',
@@ -247,6 +249,7 @@ function describeStop (yargs) {
       'STOP - Stop the server (requires running server).\n\n' +
       'Usage:\n' +
       '  $0 stop [configFile]')
+    .strictCommands(false)
     .version(false)
     .positional('configFile', {
       describe: 'Path to the Karma configuration file',

--- a/test/e2e/cli.feature
+++ b/test/e2e/cli.feature
@@ -55,52 +55,24 @@ Feature: CLI
         --help     Print usage and options.                                  [boolean]
         --version  Print current version.                                    [boolean]
 
-      Unknown argument: strat
+      Unknown command: strat
       """
 
-  Scenario: Error when option is unknown
-    When I execute Karma with arguments: "start --invalid-option"
-    Then the stderr is exactly:
+  Scenario: No error when unknown option and argument are passed in
+    Given a configuration with:
       """
-      Karma - Spectacular Test Runner for JavaScript.
-
-      START - Start the server / do a single run.
-
-      Usage:
-        karma start [configFile]
-
-      Positionals:
-        configFile  Path to the Karma configuration file                      [string]
-
-      Options:
-        --help                           Print usage and options.            [boolean]
-        --port                           <integer> Port where the server is running.
-        --auto-watch                     Auto watch source files and run on change.
-        --detached                       Detach the server.
-        --no-auto-watch                  Do not watch source files.
-        --log-level                      <disable | error | warn | info | debug> Level
-                                         of logging.
-        --colors                         Use colors when reporting and printing logs.
-        --no-colors                      Do not use colors when reporting or printing
-                                         logs.
-        --reporters                      List of reporters (available: dots, progress,
-                                         junit, growl, coverage).
-        --browsers                       List of browsers to start (eg. --browsers
-                                         Chrome,ChromeCanary,Firefox).
-        --capture-timeout                <integer> Kill browser if does not capture in
-                                         given time [ms].
-        --single-run                     Run the test when browsers captured and exit.
-        --no-single-run                  Disable single-run.
-        --report-slower-than             <integer> Report tests that are slower than
-                                         given time [ms].
-        --fail-on-empty-test-suite       Fail on empty test suite.
-        --no-fail-on-empty-test-suite    Do not fail on empty test suite.
-        --fail-on-failing-test-suite     Fail on failing test suite.
-        --no-fail-on-failing-test-suite  Do not fail on failing test suite.
-        --format-error                   A path to a file that exports the format
-                                         function.                            [string]
-
-      Unknown arguments: invalid-option, invalidOption
+      files = ['basic/plus.js', 'basic/test.js'];
+      browsers = ['ChromeHeadlessNoSandbox'];
+      plugins = [
+        'karma-jasmine',
+        'karma-chrome-launcher'
+      ];
+      """
+    When I execute Karma with arguments: "start sandbox/karma.conf.js unknown-argument --unknown-option"
+    Then it passes with:
+      """
+      ..
+      Chrome Headless
       """
 
   Scenario: Init command help


### PR DESCRIPTION
As discussed in #3625 there are multiple cases, where Karma users rely on the possibility to pass arbitrary options/arguments to the karma CLI. These arguments are either handled in a `karma.conf.js` file or are consumed by Karma plugins. Given the disruptive effect of the strict parameters validation and the lack of the feasible workarounds, the feature is reverted until we have better understanding of the custom options/arguments use cases and can implement a solution which works for everybody.