### PR TITLE
fix: ensure that Karma supports running tests on IE 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4297,31 +4297,31 @@
       }
     },
     "engine.io": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.0.5.tgz",
-      "integrity": "sha512-Ri+whTNr2PKklxQkfbGjwEo+kCBUM4Qxk4wtLqLrhH+b1up2NFL9g9pjYWiCV/oazwB0rArnvF/ZmZN2ab5Hpg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.0.tgz",
+      "integrity": "sha512-vW7EAtn0HDQ4MtT5QbmCHF17TaYLONv2/JwdYsq9USPRZVM4zG7WB3k0Nc321z8EuSOlhGokrYlYx4176QhD0A==",
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
-        "debug": "~4.1.0",
+        "debug": "~4.3.1",
         "engine.io-parser": "~4.0.0",
-        "ws": "^7.1.2"
+        "ws": "~7.4.2"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -12451,54 +12451,54 @@
       }
     },
     "socket.io": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.0.4.tgz",
-      "integrity": "sha512-Vj1jUoO75WGc9txWd311ZJJqS9Dr8QtNJJ7gk2r7dcM/yGe9sit7qOijQl3GAwhpBOz/W8CwkD7R6yob07nLbA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.0.tgz",
+      "integrity": "sha512-Aqg2dlRh6xSJvRYK31ksG65q4kmBOqU4g+1ukhPcoT6wNGYoIwSYPlCPuRwOO9pgLUajojGFztl6+V2opmKcww==",
       "requires": {
         "@types/cookie": "^0.4.0",
         "@types/cors": "^2.8.8",
-        "@types/node": "^14.14.7",
+        "@types/node": "^14.14.10",
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
-        "debug": "~4.1.0",
-        "engine.io": "~4.0.0",
-        "socket.io-adapter": "~2.0.3",
-        "socket.io-parser": "~4.0.1"
+        "debug": "~4.3.1",
+        "engine.io": "~4.1.0",
+        "socket.io-adapter": "~2.1.0",
+        "socket.io-parser": "~4.0.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.14.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.13.tgz",
-          "integrity": "sha512-vbxr0VZ8exFMMAjCW8rJwaya0dMCDyYW2ZRdTyjtrCvJoENMpdUHOT/eTzvgyA5ZnqRZ/sI0NwqAxNHKYokLJQ=="
+          "version": "14.14.22",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
+          "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
     "socket.io-adapter": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.0.3.tgz",
-      "integrity": "sha512-2wo4EXgxOGSFueqvHAdnmi5JLZzWqMArjuP4nqC26AtLh5PoCPsaRbRdah2xhcwTAMooZfjYiNVNkkmmSMaxOQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
+      "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg=="
     },
     "socket.io-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.2.tgz",
-      "integrity": "sha512-Bs3IYHDivwf+bAAuW/8xwJgIiBNtlvnjYRc4PbXgniLmcP1BrakBoq/QhO24rgtgW7VZ7uAaswRGxutUnlAK7g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
       "requires": {
         "@types/component-emitter": "^1.2.10",
         "component-emitter": "~1.3.0",
-        "debug": "~4.1.0"
+        "debug": "~4.3.1"
       },
       "dependencies": {
         "component-emitter": {
@@ -12507,17 +12507,17 @@
           "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -13812,9 +13812,9 @@
       }
     },
     "ws": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
-      "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ=="
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
     },
     "xmlbuilder": {
       "version": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -428,7 +428,7 @@
     "qjobs": "^1.2.0",
     "range-parser": "^1.2.1",
     "rimraf": "^3.0.2",
-    "socket.io": "^3.0.4",
+    "socket.io": "^3.1.0",
     "source-map": "^0.6.1",
     "tmp": "0.2.1",
     "ua-parser-js": "^0.7.23",

--- a/test/client/karma.conf.js
+++ b/test/client/karma.conf.js
@@ -14,35 +14,20 @@ const launchers = {
     browser: 'firefox',
     os: 'Windows',
     os_version: '10'
-  }
+  },
   // bs_safari: {
   //   base: 'BrowserStack',
-  //   browser: 'safari',
-  //   browser_version: '9.0',
-  //   os_version: 'El Capitan',
-  //   os: 'OS X'
+  //   browser: 'Safari',
+  //   os: 'OS X',
+  //   os_version: 'Big Sur'
   // },
-  // bs_ie_11: {
-  //   base: 'BrowserStack',
-  //   browser: 'ie',
-  //   browser_version: '11.0',
-  //   os: 'Windows',
-  //   os_version: '10'
-  // },
-  // bs_ie_10: {
-  //   base: 'BrowserStack',
-  //   browser: 'ie',
-  //   browser_version: '10.0',
-  //   os: 'Windows',
-  //   os_version: '8'
-  // },
-  // bs_ie_9: {
-  //   base: 'BrowserStack',
-  //   browser: 'ie',
-  //   browser_version: '9.0',
-  //   os: 'Windows',
-  //   os_version: '7'
-  // }
+  bs_ie: {
+    base: 'BrowserStack',
+    browser: 'IE',
+    browser_version: '11.0',
+    os: 'Windows',
+    os_version: '10'
+  }
 }
 
 // Verify the install. This will run async but that's ok we'll see the log.

--- a/test/client/karma.spec.js
+++ b/test/client/karma.spec.js
@@ -17,7 +17,7 @@ describe('Karma', function () {
   beforeEach(function () {
     mockTestStatus = ''
     updater = {
-      updateTestStatus: (s) => {
+      updateTestStatus: function (s) {
         mockTestStatus = s
       }
     }
@@ -454,7 +454,7 @@ describe('Karma', function () {
       clock.tick(500)
 
       ck.complete()
-      setTimeout(() => {
+      setTimeout(function () {
         assert(windowLocation.href === 'http://return.com')
         done()
       }, 5)


### PR DESCRIPTION
They were failing because of unsupported arrow function syntax in two places:
- in karma.spec.js file (only affecting Karma's own tests)
- in socket.io.js file installed from NPM, hence the dependency update (this affected Karma consumers)

Enabled BrowserStack tests on IE 11 to prevent regressions.