### PR TITLE
chore: remove unnecessary `init` scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,16 @@ jobs:
   include:
     - node_js: "10"
       script:
-        - npm run init
         - npm run test:unit
         - npm run test:e2e
 
     - node_js: "12"
       script:
-        - npm run init
         - npm run test:unit
         - npm run test:e2e
 
     - node_js: "14"
       script:
-        - npm run init
         - commitlint-travis
         - npm run lint
         - npm run build:check

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,6 @@ install:
   # Install our package dependencies
   - appveyor-retry npm install
 
-  # Install our current directory as a dependency of itself
-  - npm run init:windows
-
 test_script:
   - npm run test:unit
   - npm run test:client

--- a/docs/dev/02-making-changes.md
+++ b/docs/dev/02-making-changes.md
@@ -23,10 +23,6 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 * Install for development. Use a recent npm version, ignore peerdep warnings
   ```bash
   $ npm install
-  
-  $ npm run init
-  # or if you're on Windows
-  $ npm run init:windows
   ```
 
 ## Testing and Building

--- a/package.json
+++ b/package.json
@@ -503,10 +503,6 @@
     "build:check": "node scripts/client.js check",
     "build:watch": "node scripts/client.js watch",
     "test:integration": "./scripts/integration-tests.sh",
-    "link": "node --eval \"path=require('path'); require('fs').symlinkSync(path.resolve(__dirname), path.resolve(__dirname, 'node_modules', 'karma'), 'junction')\"",
-    "unlink": "node --eval \"require('fs').unlinkSync(require('path').resolve(__dirname, 'node_modules', 'karma'))\"",
-    "init": "rm -rf node_modules/karma && cd node_modules && ln -nsf ../ karma && cd ../",
-    "init:windows": "(IF EXIST node_modules\\karma (rmdir node_modules\\karma /S /q)) && npm run link",
     "semantic-release": "semantic-release"
   }
 }

--- a/test/client/karma.conf.js
+++ b/test/client/karma.conf.js
@@ -1,5 +1,3 @@
-const fs = require('fs')
-
 const TRAVIS_WITH_BS = !!process.env.BROWSER_STACK_ACCESS_KEY
 
 const launchers = {
@@ -44,28 +42,6 @@ const launchers = {
   //   os_version: '7'
   // }
 }
-
-// Verify the install. This will run async but that's ok we'll see the log.
-fs.lstat('node_modules/karma', (err, stats) => {
-  if (err) {
-    console.error('Cannot verify installation', err.stack || err)
-  }
-  if (stats && stats.isSymbolicLink()) {
-    return
-  }
-
-  console.log('**** Incorrect directory layout for karma self-tests ****')
-  console.log(`
-    $ npm install
-
-    $ npm run init
-    # or if you're on Windows
-    $ npm run init:windows
-
-    $ npm run build
-  `)
-  process.exit(1)
-})
 
 let browsers = ['Chrome']
 


### PR DESCRIPTION
These are not necessary anymore and can be safely cleaned up.