### PR TITLE
chore(test): adjust test to pass in Safari browser

### DIFF
--- a/test/client/karma.conf.js
+++ b/test/client/karma.conf.js
@@ -15,12 +15,12 @@ const launchers = {
     os: 'Windows',
     os_version: '10'
   },
-  // bs_safari: {
-  //   base: 'BrowserStack',
-  //   browser: 'Safari',
-  //   os: 'OS X',
-  //   os_version: 'Big Sur'
-  // },
+  bs_safari: {
+    base: 'BrowserStack',
+    browser: 'Safari',
+    os: 'OS X',
+    os_version: 'Big Sur'
+  },
   bs_ie: {
     base: 'BrowserStack',
     browser: 'IE',

--- a/test/client/stringify.spec.js
+++ b/test/client/stringify.spec.js
@@ -49,7 +49,9 @@ describe('stringify', function () {
   if (window.Proxy) {
     it('should serialize proxied functions', function () {
       var defProxy = new Proxy(function (d, e, f) { return 'whatever' }, {})
-      assert.deepStrictEqual(stringify(defProxy), 'function () { ... }')
+      // In Safari stringified Proxy object has ProxyObject as a name, but
+      // in other browsers it does not.
+      assert.deepStrictEqual(/^function (ProxyObject)?\(\) { ... }$/.test(stringify(defProxy)), true)
     })
   }
 


### PR DESCRIPTION
In Safari stringified Proxy object has ProxyObject as a name, but in other browsers it does not.

Enabled Safari tests on BrowserStack to prevent future regressions.