### PR TITLE
Bug fix: Report launcher process error when the process exit event is not emitted

### DIFF
--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -93,6 +93,7 @@ function ProcessLauncher (spawn, tempDir, timer, processKillTimeout) {
       } else {
         errorOutput += err.toString()
       }
+      self._onProcessExit(-1, null, errorOutput)
     })
 
     self._process.stderr.on('data', function (errBuff) {
@@ -101,6 +102,10 @@ function ProcessLauncher (spawn, tempDir, timer, processKillTimeout) {
   }
 
   this._onProcessExit = function (code, signal, errorOutput) {
+    if (!self._process) {
+      // Both exit and error events trigger _onProcessExit(), but we only need one cleanup.
+      return
+    }
     log.debug(`Process ${self.name} exited with code ${code} and signal ${signal}`)
 
     let error = null


### PR DESCRIPTION
This PR is to ensure the launcher process error is reported in the logs when the process exit event is not emitted which can happen in some cases.

As per described on this page https://nodejs.org/api/child_process.html#child_process_event_error, "The 'exit' event may or may not fire after an error has occurred. When listening to both the 'exit' and 'error' events, guard against accidentally invoking handler functions multiple times."

**Without this fix**, if the browser binary file is missing, Karma will report the following **if only in Debug mode**:

```
DEBUG [launcher]: Process {{browser_name}} exited with code -1
```
This is not really helpful to the users and if debug log level is not set, they won't see this message.

**With this fix**, if the browser binary file is missing, Karma will **always** report the following:

```
ERROR [launcher]: Cannot start {{browser_name}}
        Can not find the binary {{path_to_binary}}
        Please set env variable {{env_cmd}}
```
This error is clear to the users and always visible