### PR TITLE
fix(commitlint): skip task on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ jobs:
     - node_js: "14"
       script:
         - npm run init
-        - commitlint-travis
+        - if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+            commitlint-travis;
+          fi;
         - npm run lint
         - npm run build:check
         - npm run test:unit


### PR DESCRIPTION
The rule between master and branch should be different to take the PR reference in consideration when merging.

---

This PR should be fixing the current build failure on master due to the latest commit message `fix: report launcher process error when exit event is not emitted (#3647)` being more than 72 characters (https://travis-ci.org/github/karma-runner/karma/jobs/757457475).

---

### Problem
The problem is that the same `header-max-length` rule is applied to master and the PR branches and when a PR branch is merged the commit message has the PR reference appended to it making the length longer and potentially breaking the `commitlint` on master

### Proposed Solution

Using different `header-max-length` rules for master and branches.

* `header-max-length` rule on master set to 80 characters to **temporary fix** the build on master and **then submit another PR to  set the header-max-length rule on master set to 72 characters.**
* `header-max-length` rule on branches set to 64 characters (72 - 8 characters for the PR reference)