### PR TITLE
fix(config): check extension before ts-node register

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -27,7 +27,7 @@ try {
 } catch (e) {}
 
 try {
-  require('ts-node').register()
+  require('ts-node')
   TYPE_SCRIPT_AVAILABLE = true
 } catch (e) {}
 
@@ -374,6 +374,9 @@ function parseConfig (configFilePath, cliOptions, parseOptions) {
   let configModule
   if (configFilePath) {
     try {
+      if (path.extname(configFilePath) === '.ts' && TYPE_SCRIPT_AVAILABLE) {
+        require('ts-node').register()
+      }
       configModule = require(configFilePath)
       if (typeof configModule === 'object' && typeof configModule.default !== 'undefined') {
         configModule = configModule.default


### PR DESCRIPTION
Call require('ts-node').register() after checking configFilePath has `.ts` extension

Fixes #3329

сс @devoto13 