### PR TITLE
fix(client): clearContext after complete sent

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -236,13 +236,12 @@ function Karma (updater, socket, iframe, opener, navigator, location, document) 
     // to ensure the error from an incorrect navigate is processed.
     var config = this.config
     setTimeout(function () {
+      socket.emit('complete', result || {})
       if (config.clearContext) {
         navigateContextTo('about:blank')
+      } else {
+        self.updater.updateTestStatus('complete')
       }
-
-      socket.emit('complete', result || {})
-      self.updater.updateTestStatus('complete')
-
       if (returnUrl) {
         location.href = returnUrl
       }

--- a/static/karma.js
+++ b/static/karma.js
@@ -246,13 +246,12 @@ function Karma (updater, socket, iframe, opener, navigator, location, document) 
     // to ensure the error from an incorrect navigate is processed.
     var config = this.config
     setTimeout(function () {
+      socket.emit('complete', result || {})
       if (config.clearContext) {
         navigateContextTo('about:blank')
+      } else {
+        self.updater.updateTestStatus('complete')
       }
-
-      socket.emit('complete', result || {})
-      self.updater.updateTestStatus('complete')
-
       if (returnUrl) {
         location.href = returnUrl
       }


### PR DESCRIPTION
When useiframe false and clearContext true and IE11, the clearContext
blocks the complete event.