### PR TITLE
feat(plugins): add support wildcard config for scoped package plugin

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -36,13 +36,14 @@ function resolve (plugins, emitter) {
 
       log.debug(`Loading ${plugin} from ${pluginDirectory}`)
       fs.readdirSync(pluginDirectory)
-        .flatMap((e) => {
+        .map((e) => {
           const modulePath = path.join(pluginDirectory, e)
           if (e[0] === '@') {
             return fs.readdirSync(modulePath).map((e) => path.join(modulePath, e))
           }
           return modulePath
         })
+        .reduce((a, x) => a.concat(x), [])
         .map((modulePath) => path.relative(pluginDirectory, modulePath))
         .filter((moduleName) => !IGNORED_PACKAGES.includes(moduleName) && regexp.test(moduleName))
         .forEach((pluginName) => requirePlugin(path.join(pluginDirectory, pluginName)))

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -32,12 +32,20 @@ function resolve (plugins, emitter) {
         return
       }
       const pluginDirectory = path.normalize(path.join(__dirname, '/../..'))
-      const regexp = new RegExp(`^${plugin.replace('*', '.*')}`)
+      const regexp = new RegExp(`^${plugin.replace(/\*/g, '.*').replace(/\//g, '[/\\\\]')}`)
 
       log.debug(`Loading ${plugin} from ${pluginDirectory}`)
       fs.readdirSync(pluginDirectory)
-        .filter((pluginName) => !IGNORED_PACKAGES.includes(pluginName) && regexp.test(pluginName))
-        .forEach((pluginName) => requirePlugin(`${pluginDirectory}/${pluginName}`))
+        .flatMap((e) => {
+          const modulePath = path.join(pluginDirectory, e)
+          if (e[0] === '@') {
+            return fs.readdirSync(modulePath).map((e) => path.join(modulePath, e))
+          }
+          return modulePath
+        })
+        .map((modulePath) => path.relative(pluginDirectory, modulePath))
+        .filter((moduleName) => !IGNORED_PACKAGES.includes(moduleName) && regexp.test(moduleName))
+        .forEach((pluginName) => requirePlugin(path.join(pluginDirectory, pluginName)))
     } else if (helper.isObject(plugin)) {
       log.debug(`Loading inline plugin defining ${Object.keys(plugin).join(', ')}.`)
       modules.push(plugin)


### PR DESCRIPTION
If you wish load all scoped package plugins by `@*/karma-*` like `karma-*`, karma doesn't handle it.
It'll be modified to `RegExp("^@.*/karma-*")` internally, and karma doesn't care scoped package's sub directories.

In this PR, add features below.

- support plugin name with multiple `*` (replace ALL `*` to `.*`)
  - `@*/karma-*` is now valid
  - `karma-*` also work same as before
  - **however, if anyone already force using multiple `*` (such as `karma-*-foo-.*`), there is a risk of incompatibility**
- when finding plugin, get scoped package name now correctly (before: `@foo`, now: `@foo/bar`)

Fixes #3656