### PR TITLE
feat: support asynchronous `config.set()` call in karma.conf.js

### DIFF
--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -192,19 +192,6 @@ use of promises.
 const cfg = require('karma').config;
 const path = require('path');
 // Read karma.conf.js, but override port with 1337
-const karmaConfig = cfg.parseConfig(
-  path.resolve('./karma.conf.js'),
-  { port: 1337 },
-  { throwErrors: true }
-)
-```
-
-##### New Behavior with Promise Support
-
-```javascript
-const cfg = require('karma').config;
-const path = require('path');
-// Read karma.conf.js, but override port with 1337
 cfg.parseConfig(
   path.resolve('./karma.conf.js'),
   { port: 1337 },

--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -401,7 +401,7 @@ then `parseOptions.throwErrors = true` allows the promise to be rejected
 instead of exiting the process.
 
 
-## `constants`
+## `karma.constants`
 
 ### `constants.VERSION`
 

--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -4,7 +4,7 @@ You can, however, call Karma programmatically from your node module. Here is the
 
 ## karma.Server(options, [callback=process.exit])
 
-### Constructor
+### `constructor`
 
 -   **Returns:** `Server` instance.
 
@@ -48,7 +48,7 @@ parseConfig(
 );
 ```
 
-### **server.start()**
+### `server.start()`
 
 Equivalent of `karma start`.
 
@@ -56,7 +56,7 @@ Equivalent of `karma start`.
 server.start()
 ```
 
-### **server.refreshFiles()**
+### `server.refreshFiles()`
 
 Trigger a file list refresh. Returns a promise.
 
@@ -64,7 +64,7 @@ Trigger a file list refresh. Returns a promise.
 server.refreshFiles()
 ```
 
-### **server.refreshFile(path)**
+### `server.refreshFile(path)`
 
 Trigger a file refresh. Returns a promise.
 
@@ -148,7 +148,7 @@ This event gets triggered whenever all the browsers, which belong to a test run,
 
 ## karma.runner
 
-### **runner.run(options, [callback=process.exit])**
+### `runner.run(options, [callback=process.exit])`
 
 -   **Returns:** `EventEmitter`
 
@@ -211,7 +211,7 @@ runner.run({port: 9876}).on('progress', function(data) {
 
 ## karma.stopper
 
-### **stopper.stop(options, [callback=process.exit])**
+### `stopper.stop(options, [callback=process.exit])`
 
 This function will signal a running server to stop. The equivalent of
 `karma stop`.
@@ -264,7 +264,7 @@ the error callback.
 
 ## karma.config
 
-### config.parseConfig([configFilePath], [cliOptions], [parseOptions])
+### `config.parseConfig([configFilePath], [cliOptions], [parseOptions])`
 
 This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
@@ -401,60 +401,60 @@ then `parseOptions.throwErrors = true` allows the promise to be rejected
 instead of exiting the process.
 
 
-## karma.constants
+## `constants`
 
-### **constants.VERSION**
+### `constants.VERSION`
 
 The current version of karma
 
-### **constants.DEFAULT_PORT**
+### `constants.DEFAULT_PORT`
 
 The default port used for the karma server
 
-### **constants.DEFAULT_HOSTNAME**
+### `constants.DEFAULT_HOSTNAME`
 
 The default hostname used for the karma server
 
-### **constants.DEFAULT_LISTEN_ADDR**
+### `constants.DEFAULT_LISTEN_ADDR`
 
 The default address use for the karma server to listen on
 
-### **constants.LOG_DISABLE**
+### `constants.LOG_DISABLE`
 
 The value for disabling logs
 
-### **constants.LOG_ERROR**
+### `constants.LOG_ERROR`
 
 The value for the log `error` level
 
-### **constants.LOG_WARN**
+### `constants.LOG_WARN`
 
 The value for the log `warn` level
 
-### **constants.LOG_INFO**
+### `constants.LOG_INFO`
 
 The value for the log `info` level
 
-### **constants.LOG_DEBUG**
+### `constants.LOG_DEBUG`
 
 The value for the log `debug` level
 
-### **constants.LOG_PRIORITIES**
+### `constants.LOG_PRIORITIES`
 
 An array of log levels in descending order, i.e. `LOG_DISABLE`, `LOG_ERROR`, `LOG_WARN`, `LOG_INFO`, and `LOG_DEBUG`
 
-### **constants.COLOR_PATTERN**
+### `constants.COLOR_PATTERN`
 
 The default color pattern for log output
 
-### **constants.NO_COLOR_PATTERN**
+### `constants.NO_COLOR_PATTERN`
 
 The default pattern for log output without color
 
-### **constants.CONSOLE_APPENDER**
+### `constants.CONSOLE_APPENDER`
 
 The default console appender
 
-### **constants.EXIT_CODE**
+### `constants.EXIT_CODE`
 
 The exit code

--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -6,6 +6,17 @@ You can, however, call Karma programmatically from your node module. Here is the
 
 ### Constructor
 
+-   **Returns:** `Server` instance.
+
+#### Usage
+
+Notice the capital 'S' on  `require('karma').Server`.
+
+##### Deprecated Behavior
+
+The following still works, but the way it behaves is deprecated and will be
+changed in a future major version.
+
 ```javascript
 var Server = require('karma').Server
 var karmaConfig = {port: 9876}
@@ -15,7 +26,27 @@ var server = new Server(karmaConfig, function(exitCode) {
 })
 ```
 
-Notice the capital 'S' on  `require('karma').Server`.
+##### New Behavior
+
+```javascript
+const karma = require('karma')
+const parseConfig = karma.config.parseConfig
+const Server = karma.Server
+
+parseConfig(
+  null,
+  { port: 9876 },
+  { promiseConfig: true, throwErrors: true }
+).then(
+  (karmaConfig) => {
+    const server = new Server(karmaConfig, function doneCallback(exitCode) {
+      console.log('Karma has exited with ' + exitCode)
+      process.exit(exitCode)
+    })
+  },
+  (rejectReason) => { /* respond to the rejection reason error */ }
+);
+```
 
 ### **server.start()**
 

--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -162,8 +162,7 @@ stopper.stop({port: 9876}, function(exitCode) {
 
 This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
-the karma config while honoring the karma defaults. For example, the [stryker-karma-runner](https://github.com/stryker-mutator/stryker-karma-runner)
-uses this to load your karma configuration and use that in the stryker configuration.
+the karma config while honoring the karma defaults.
 
 #### Usage
 

--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -150,7 +150,16 @@ This event gets triggered whenever all the browsers, which belong to a test run,
 
 ### **runner.run(options, [callback=process.exit])**
 
+-   **Returns:** `EventEmitter`
+
 The equivalent of `karma run`.
+
+#### Usage
+
+##### Deprecated Behavior
+
+The following still works, but the way it behaves is deprecated and will be
+changed in a future major version.
 
 ```javascript
 var runner = require('karma').runner
@@ -159,6 +168,35 @@ runner.run({port: 9876}, function(exitCode) {
   process.exit(exitCode)
 })
 ```
+
+##### New Behavior
+
+```javascript
+const karma = require('karma')
+
+karma.config.parseConfig(
+  null,
+  { port: 9876 },
+  { promiseConfig: true, throwErrors: true }
+).then(
+  (karmaConfig) => {
+    karma.runner.run(karmaConfig, function doneCallback(exitCode, possibleErrorCode) {
+      console.log('Karma has exited with ' + exitCode)
+      process.exit(exitCode)
+    })
+  },
+  (rejectReason) => { /* respond to the rejection reason error */ }
+);
+```
+
+#### `callback` argument
+
+The callback receives the exit code as the first argument.
+
+If there is an error, the error code will be provided as the second parameter to
+the error callback.
+
+#### runner Events
 
 `runner.run()` returns an `EventEmitter` which emits a `progress` event passing
 the reporter output as a `Buffer` object.
@@ -175,7 +213,15 @@ runner.run({port: 9876}).on('progress', function(data) {
 
 ### **stopper.stop(options, [callback=process.exit])**
 
-This function will signal a running server to stop.  The equivalent of `karma stop`.  
+This function will signal a running server to stop. The equivalent of
+`karma stop`.
+
+#### Usage
+
+##### Deprecated Behavior
+
+The following still works, but the way it behaves is deprecated and will be
+changed in a future major version.
 
 ```javascript
 var stopper = require('karma').stopper
@@ -186,6 +232,35 @@ stopper.stop({port: 9876}, function(exitCode) {
   process.exit(exitCode)
 })
 ```
+
+##### New Behavior
+
+```javascript
+const karma = require('karma')
+
+karma.config.parseConfig(
+  null,
+  { port: 9876 },
+  { promiseConfig: true, throwErrors: true }
+).then(
+  (karmaConfig) => {
+    karma.stopper.stop(karmaConfig, function doneCallback(exitCode, possibleErrorCode) {
+      if (exitCode === 0) {
+        console.log('Server stop as initiated')
+      }
+      process.exit(exitCode)
+    })
+  },
+  (rejectReason) => { /* respond to the rejection reason error */ }
+);
+```
+
+#### `callback` argument
+
+The callback receives the exit code as the first argument.
+
+If there is an error, the error code will be provided as the second parameter to
+the error callback.
 
 ## karma.config
 
@@ -383,7 +458,3 @@ The default console appender
 ### **constants.EXIT_CODE**
 
 The exit code
-
-## Callback function notes
-
-- If there is an error, the error code will be provided as the second parameter to the error callback.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -304,8 +304,9 @@ exports.run = () => {
           require('./stopper').stop(config)
           break
       }
-    }, function onKarmaConfigRejected (reason) {
-      console.error(reason) // TODO: configure a CLI Logger?
+    }, function onKarmaConfigRejected (/* ignoredReason */) {
+      // The reject reason isn't used to log a message since parseConfig already
+      // calls a configured logger method with an almost identical message.
 
       // The `run` function is a private application, not a public API. We don't
       // need to worry about process.exit vs throw vs promise rejection here.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,6 +7,7 @@ const fs = require('graceful-fs')
 const Server = require('./server')
 const helper = require('./helper')
 const constant = require('./constants')
+const cfg = require('./config')
 
 function processArgs (argv, options, fs, path) {
   Object.getOwnPropertyNames(argv).forEach(function (name) {
@@ -278,26 +279,36 @@ exports.process = () => {
 }
 
 exports.run = () => {
-  const config = exports.process()
-
-  switch (config.cmd) {
-    case 'start':
-      new Server(config).start()
-      break
-    case 'run':
-      require('./runner')
-        .run(config)
-        .on('progress', printRunnerProgress)
-      break
-    case 'stop':
-      require('./stopper').stop(config)
-      break
-    case 'init':
-      require('./init').init(config)
-      break
-    case 'completion':
-      require('./completion').completion(config)
-      break
+  const cliOptions = exports.process()
+  const cmd = cliOptions.cmd // prevent config from changing the command
+  const cmdSupportsConfigPromise =
+    cmd === 'start' || cmd === 'run' || cmd === 'stop'
+  if (!cmdSupportsConfigPromise) {
+    switch (cmd) {
+      case 'init':
+        require('./init').init(cliOptions)
+        break
+      case 'completion':
+        require('./completion').completion(cliOptions)
+        break
+    }
+  } else {
+    cfg.parseConfig(cliOptions.configFile, cliOptions, { promiseConfig: true })
+      .then(function onKarmaConfigFulfilled (config) {
+        switch (cmd) {
+          case 'start':
+            new Server(config).start()
+            break
+          case 'run':
+            require('./runner')
+              .run(config)
+              .on('progress', printRunnerProgress)
+            break
+          case 'stop':
+            require('./stopper').stop(config)
+            break
+        }
+      })
   }
 }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -278,66 +278,51 @@ exports.process = () => {
   return processArgs(argv, { cmd: argv._.shift() }, fs, path)
 }
 
-exports.run = () => {
+exports.run = async () => {
   const cliOptions = exports.process()
   const cmd = cliOptions.cmd // prevent config from changing the command
   const cmdNeedsConfig = cmd === 'start' || cmd === 'run' || cmd === 'stop'
-  let runPromise
   if (cmdNeedsConfig) {
-    runPromise = cfg.parseConfig(
-      cliOptions.configFile,
-      cliOptions,
-      {
-        promiseConfig: true,
-        throwErrors: true
-      }
-    ).then(function onKarmaConfigFulfilled (config) {
-      let fulfillmentValue
-      switch (cmd) {
-        case 'start': {
-          const server = new Server(config)
-          fulfillmentValue = server.start().then(() => server)
-          break
+    let config
+    try {
+      config = await cfg.parseConfig(
+        cliOptions.configFile,
+        cliOptions,
+        {
+          promiseConfig: true,
+          throwErrors: true
         }
-        case 'run':
-          fulfillmentValue = require('./runner')
-            .run(config)
-            .on('progress', printRunnerProgress)
-          break
-        case 'stop':
-          fulfillmentValue = require('./stopper').stop(config)
-          break
-      }
-      return fulfillmentValue
-    }, function onKarmaConfigRejected (/* ignoredReason */) {
-      // The reject reason isn't used to log a message since parseConfig already
-      // calls a configured logger method with an almost identical message.
+      )
+    } catch (karmaConfigException) {
+      // The reject reason/exception isn't used to log a message since
+      // parseConfig already calls a configured logger method with an almost
+      // identical message.
 
       // The `run` function is a private application, not a public API. We don't
       // need to worry about process.exit vs throw vs promise rejection here.
       process.exit(1)
-    })
-  } else {
-    try {
-      let fulfillmentValue
-      switch (cmd) {
-        case 'init':
-          fulfillmentValue = require('./init').init(cliOptions)
-          break
-        case 'completion':
-          fulfillmentValue = require('./completion').completion(cliOptions)
-          break
+    }
+    switch (cmd) {
+      case 'start': {
+        const server = new Server(config)
+        await server.start()
+        return server
       }
-      runPromise = Promise.resolve(fulfillmentValue)
-    } catch (ex) {
-      runPromise = Promise.reject(ex)
+      case 'run':
+        return require('./runner')
+          .run(config)
+          .on('progress', printRunnerProgress)
+      case 'stop':
+        return require('./stopper').stop(config)
+    }
+  } else {
+    switch (cmd) {
+      case 'init':
+        return require('./init').init(cliOptions)
+      case 'completion':
+        return require('./completion').completion(cliOptions)
     }
   }
-
-  // Always return a promise for ease of testing. We want to know when it is
-  // safe to start making assertions. Without the promise, it would be difficult
-  // to test the asynchronous branches.
-  return runPromise
 }
 
 // just for testing

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -283,22 +283,34 @@ exports.run = () => {
   const cmd = cliOptions.cmd // prevent config from changing the command
   const cmdNeedsConfig = cmd === 'start' || cmd === 'run' || cmd === 'stop'
   if (cmdNeedsConfig) {
-    cfg.parseConfig(cliOptions.configFile, cliOptions, { promiseConfig: true })
-      .then(function onKarmaConfigFulfilled (config) {
-        switch (cmd) {
-          case 'start':
-            new Server(config).start()
-            break
-          case 'run':
-            require('./runner')
-              .run(config)
-              .on('progress', printRunnerProgress)
-            break
-          case 'stop':
-            require('./stopper').stop(config)
-            break
-        }
-      })
+    cfg.parseConfig(
+      cliOptions.configFile,
+      cliOptions,
+      {
+        promiseConfig: true,
+        throwErrors: true
+      }
+    ).then(function onKarmaConfigFulfilled (config) {
+      switch (cmd) {
+        case 'start':
+          new Server(config).start()
+          break
+        case 'run':
+          require('./runner')
+            .run(config)
+            .on('progress', printRunnerProgress)
+          break
+        case 'stop':
+          require('./stopper').stop(config)
+          break
+      }
+    }, function onKarmaConfigRejected (reason) {
+      console.error(reason) // TODO: configure a CLI Logger?
+
+      // The `run` function is a private application, not a public API. We don't
+      // need to worry about process.exit vs throw vs promise rejection here.
+      process.exit(1)
+    })
   } else {
     switch (cmd) {
       case 'init':

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -281,18 +281,8 @@ exports.process = () => {
 exports.run = () => {
   const cliOptions = exports.process()
   const cmd = cliOptions.cmd // prevent config from changing the command
-  const cmdSupportsConfigPromise =
-    cmd === 'start' || cmd === 'run' || cmd === 'stop'
-  if (!cmdSupportsConfigPromise) {
-    switch (cmd) {
-      case 'init':
-        require('./init').init(cliOptions)
-        break
-      case 'completion':
-        require('./completion').completion(cliOptions)
-        break
-    }
-  } else {
+  const cmdNeedsConfig = cmd === 'start' || cmd === 'run' || cmd === 'stop'
+  if (cmdNeedsConfig) {
     cfg.parseConfig(cliOptions.configFile, cliOptions, { promiseConfig: true })
       .then(function onKarmaConfigFulfilled (config) {
         switch (cmd) {
@@ -309,6 +299,15 @@ exports.run = () => {
             break
         }
       })
+  } else {
+    switch (cmd) {
+      case 'init':
+        require('./init').init(cliOptions)
+        break
+      case 'completion':
+        require('./completion').completion(cliOptions)
+        break
+    }
   }
 }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -282,8 +282,9 @@ exports.run = () => {
   const cliOptions = exports.process()
   const cmd = cliOptions.cmd // prevent config from changing the command
   const cmdNeedsConfig = cmd === 'start' || cmd === 'run' || cmd === 'stop'
+  let runPromise
   if (cmdNeedsConfig) {
-    cfg.parseConfig(
+    runPromise = cfg.parseConfig(
       cliOptions.configFile,
       cliOptions,
       {
@@ -291,19 +292,23 @@ exports.run = () => {
         throwErrors: true
       }
     ).then(function onKarmaConfigFulfilled (config) {
+      let fulfillmentValue
       switch (cmd) {
-        case 'start':
-          new Server(config).start()
+        case 'start': {
+          const server = new Server(config)
+          fulfillmentValue = server.start().then(() => server)
           break
+        }
         case 'run':
-          require('./runner')
+          fulfillmentValue = require('./runner')
             .run(config)
             .on('progress', printRunnerProgress)
           break
         case 'stop':
-          require('./stopper').stop(config)
+          fulfillmentValue = require('./stopper').stop(config)
           break
       }
+      return fulfillmentValue
     }, function onKarmaConfigRejected (/* ignoredReason */) {
       // The reject reason isn't used to log a message since parseConfig already
       // calls a configured logger method with an almost identical message.
@@ -313,15 +318,26 @@ exports.run = () => {
       process.exit(1)
     })
   } else {
-    switch (cmd) {
-      case 'init':
-        require('./init').init(cliOptions)
-        break
-      case 'completion':
-        require('./completion').completion(cliOptions)
-        break
+    try {
+      let fulfillmentValue
+      switch (cmd) {
+        case 'init':
+          fulfillmentValue = require('./init').init(cliOptions)
+          break
+        case 'completion':
+          fulfillmentValue = require('./completion').completion(cliOptions)
+          break
+      }
+      runPromise = Promise.resolve(fulfillmentValue)
+    } catch (ex) {
+      runPromise = Promise.reject(ex)
     }
   }
+
+  // Always return a promise for ease of testing. We want to know when it is
+  // safe to start making assertions. Without the promise, it would be difficult
+  // to test the asynchronous branches.
+  return runPromise
 }
 
 // just for testing

--- a/lib/config.js
+++ b/lib/config.js
@@ -352,11 +352,16 @@ const CONFIG_SYNTAX_HELP = '  module.exports = function(config) {\n' +
   '  };\n'
 
 function parseConfig (configFilePath, cliOptions, parseOptions) {
+  const promiseConfig = parseOptions && parseOptions.promiseConfig === true
   function fail () {
     log.error(...arguments)
     if (parseOptions && parseOptions.throwErrors === true) {
       const errorMessage = Array.from(arguments).join(' ')
-      throw new Error(errorMessage)
+      const err = new Error(errorMessage)
+      if (promiseConfig) {
+        return Promise.reject(err)
+      }
+      throw err
     } else {
       const warningMessage =
         'The `parseConfig()` function historically called `process.exit(1)`' +
@@ -442,7 +447,6 @@ function parseConfig (configFilePath, cliOptions, parseOptions) {
     return normalizeConfig(config, configFilePath)
   }
   const returnIsThenable = configModuleReturn != null && typeof configModuleReturn === 'object' && typeof configModuleReturn.then === 'function'
-  const promiseConfig = parseOptions && parseOptions.promiseConfig === true
   if (returnIsThenable) {
     if (promiseConfig !== true) {
       const errorMessage =

--- a/lib/config.js
+++ b/lib/config.js
@@ -356,7 +356,7 @@ function parseConfig (configFilePath, cliOptions, parseOptions) {
   const throwErrors = parseOptions && parseOptions.throwErrors === true
   function fail () {
     log.error(...arguments)
-    if (throwErrors === true || promiseConfig === true) {
+    if (throwErrors) {
       const errorMessage = Array.from(arguments).join(' ')
       const err = new Error(errorMessage)
       if (promiseConfig) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -454,7 +454,19 @@ function parseConfig (configFilePath, cliOptions, parseOptions) {
 
     return normalizeConfig(config, configFilePath)
   }
-  const returnIsThenable = configModuleReturn != null && typeof configModuleReturn === 'object' && typeof configModuleReturn.then === 'function'
+
+  /**
+   * Return value is a function or (non-null) object that has a `then` method.
+   *
+   * @type {boolean}
+   * @see {@link https://promisesaplus.com/}
+   */
+  const returnIsThenable = (
+    (
+      (configModuleReturn != null && typeof configModuleReturn === 'object') ||
+      typeof configModuleReturn === 'function'
+    ) && typeof configModuleReturn.then === 'function'
+  )
   if (returnIsThenable) {
     if (promiseConfig !== true) {
       const errorMessage =

--- a/lib/config.js
+++ b/lib/config.js
@@ -268,6 +268,9 @@ function normalizeConfig (config, configFilePath) {
   return config
 }
 
+/**
+ * @class
+ */
 class Config {
   constructor () {
     this.LOG_DISABLE = constant.LOG_DISABLE
@@ -351,6 +354,42 @@ const CONFIG_SYNTAX_HELP = '  module.exports = function(config) {\n' +
   '    });\n' +
   '  };\n'
 
+/**
+ * Retrieve a parsed and finalized Karma `Config` instance. This `karmaConfig`
+ * object may be used to configure public API methods such a `Server`,
+ * `runner.run`, and `stopper.stop`.
+ *
+ * @param {?string} [configFilePath=null]
+ *     A string representing a file system path pointing to the config file
+ *     whose default export is a function that will be used to set Karma
+ *     configuration options. This function will be passed an instance of the
+ *     `Config` class as its first argument. If this option is not provided,
+ *     then only the options provided by the `cliOptions` argument will be
+ *     set.
+ * @param {Object} cliOptions
+ *     An object whose values will take priority over options set in the
+ *     config file. The config object passed to function exported by the
+ *     config file will already have these options applied. Any changes the
+ *     config file makes to these options will effectively be ignored in the
+ *     final configuration.
+ *
+ *     `cliOptions` all the same options as the config file and is applied
+ *     using the same `config.set()` method.
+ * @param {Object} parseOptions
+ * @param {boolean} [parseOptions.promiseConfig=false]
+ *     When `true`, a promise that resolves to a `Config` object will be
+ *     returned. This also allows the function exported by config files (if
+ *     provided) to be asynchronous by returning a promise. Resolving this
+ *     promise indicates that all async activity has completed. The resolution
+ *     value itself is ignored, all configuration must be done with
+ *     `config.set`.
+ * @param {boolean} [parseOptions.throwErrors=false]
+ *     When `true`, process exiting on critical failures will be disabled. In
+ *     The error will be thrown as an exception. If
+ *     `parseOptions.promiseConfig` is also `true`, then the error will
+ *     instead be used as the promise's reject reason.
+ * @returns {Config|Promise<Config>}
+ */
 function parseConfig (configFilePath, cliOptions, parseOptions) {
   const promiseConfig = parseOptions && parseOptions.promiseConfig === true
   const throwErrors = parseOptions && parseOptions.throwErrors === true

--- a/lib/config.js
+++ b/lib/config.js
@@ -354,6 +354,13 @@ const CONFIG_SYNTAX_HELP = '  module.exports = function(config) {\n' +
 function parseConfig (configFilePath, cliOptions, parseOptions) {
   const promiseConfig = parseOptions && parseOptions.promiseConfig === true
   const throwErrors = parseOptions && parseOptions.throwErrors === true
+  const shouldSetupLoggerEarly = promiseConfig
+  if (shouldSetupLoggerEarly) {
+    // `setupFromConfig` provides defaults for `colors` and `logLevel`.
+    // `setup` provides defaults for `appenders`
+    // The first argument MUST BE an object
+    logger.setupFromConfig({})
+  }
   function fail () {
     log.error(...arguments)
     if (throwErrors) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -456,9 +456,14 @@ function parseConfig (configFilePath, cliOptions, parseOptions) {
         'Example: `parseConfig(path, cliOptions, { promiseConfig: true })`'
       return fail(errorMessage)
     }
-    return configModuleReturn.then(function onKarmaConfigModuleFulfilled (/* ignoredResolutionValue */) {
-      return finalizeConfig(config)
-    })
+    return configModuleReturn.then(
+      function onKarmaConfigModuleFulfilled (/* ignoredResolutionValue */) {
+        return finalizeConfig(config)
+      },
+      function onKarmaConfigModuleRejected (reason) {
+        return fail('Error in config file!\n', reason)
+      }
+    )
   } else {
     if (promiseConfig) {
       try {

--- a/lib/config.js
+++ b/lib/config.js
@@ -353,9 +353,10 @@ const CONFIG_SYNTAX_HELP = '  module.exports = function(config) {\n' +
 
 function parseConfig (configFilePath, cliOptions, parseOptions) {
   const promiseConfig = parseOptions && parseOptions.promiseConfig === true
+  const throwErrors = parseOptions && parseOptions.throwErrors === true
   function fail () {
     log.error(...arguments)
-    if (parseOptions && parseOptions.throwErrors === true) {
+    if (throwErrors === true || promiseConfig === true) {
       const errorMessage = Array.from(arguments).join(' ')
       const err = new Error(errorMessage)
       if (promiseConfig) {
@@ -451,7 +452,8 @@ function parseConfig (configFilePath, cliOptions, parseOptions) {
     if (promiseConfig !== true) {
       const errorMessage =
         'The `parseOptions.promiseConfig` option must be set to `true` to ' +
-        'enable promise return values from configuration files.'
+        'enable promise return values from configuration files. ' +
+        'Example: `parseConfig(path, cliOptions, { promiseConfig: true })`'
       return fail(errorMessage)
     }
     return configModuleReturn.then(function onKarmaConfigModuleFulfilled (/* ignoredResolutionValue */) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -411,34 +411,59 @@ function parseConfig (configFilePath, cliOptions, parseOptions) {
   // add the user's configuration in
   config.set(cliOptions)
 
+  let configModuleReturn
   try {
-    configModule(config)
+    configModuleReturn = configModule(config)
   } catch (e) {
     return fail('Error in config file!\n', e)
   }
+  function finalizeConfig (config) {
+    // merge the config from config file and cliOptions (precedence)
+    config.set(cliOptions)
 
-  // merge the config from config file and cliOptions (precedence)
-  config.set(cliOptions)
-
-  // if the user changed listenAddress, but didn't set a hostname, warn them
-  if (config.hostname === null && config.listenAddress !== null) {
-    log.warn(`ListenAddress was set to ${config.listenAddress} but hostname was left as the default: ` +
+    // if the user changed listenAddress, but didn't set a hostname, warn them
+    if (config.hostname === null && config.listenAddress !== null) {
+      log.warn(`ListenAddress was set to ${config.listenAddress} but hostname was left as the default: ` +
       `${defaultHostname}. If your browsers fail to connect, consider changing the hostname option.`)
-  }
-  // restore values that weren't overwritten by the user
-  if (config.hostname === null) {
-    config.hostname = defaultHostname
-  }
-  if (config.listenAddress === null) {
-    config.listenAddress = defaultListenAddress
-  }
+    }
+    // restore values that weren't overwritten by the user
+    if (config.hostname === null) {
+      config.hostname = defaultHostname
+    }
+    if (config.listenAddress === null) {
+      config.listenAddress = defaultListenAddress
+    }
 
-  // configure the logger as soon as we can
-  logger.setup(config.logLevel, config.colors, config.loggers)
+    // configure the logger as soon as we can
+    logger.setup(config.logLevel, config.colors, config.loggers)
 
-  log.debug(configFilePath ? `Loading config ${configFilePath}` : 'No config file specified.')
+    log.debug(configFilePath ? `Loading config ${configFilePath}` : 'No config file specified.')
 
-  return normalizeConfig(config, configFilePath)
+    return normalizeConfig(config, configFilePath)
+  }
+  const returnIsThenable = configModuleReturn != null && typeof configModuleReturn === 'object' && typeof configModuleReturn.then === 'function'
+  const promiseConfig = parseOptions && parseOptions.promiseConfig === true
+  if (returnIsThenable) {
+    if (promiseConfig !== true) {
+      const errorMessage =
+        'The `parseOptions.promiseConfig` option must be set to `true` to ' +
+        'enable promise return values from configuration files.'
+      return fail(errorMessage)
+    }
+    return configModuleReturn.then(function onKarmaConfigModuleFulfilled (/* ignoredResolutionValue */) {
+      return finalizeConfig(config)
+    })
+  } else {
+    if (promiseConfig) {
+      try {
+        return Promise.resolve(finalizeConfig(config))
+      } catch (exception) {
+        return Promise.reject(exception)
+      }
+    } else {
+      return finalizeConfig(config)
+    }
+  }
 }
 
 // PUBLIC API

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -35,6 +35,9 @@ function parseExitCode (buffer, defaultExitCode, failOnEmptyTestSuite) {
 function run (cliOptionsOrConfig, done) {
   cliOptionsOrConfig = cliOptionsOrConfig || {}
 
+  // TODO: Should `const log = logger.create('runner')` be moved into the
+  //     : function for consistency with server.js and stopper.js? or the
+  //     : reverse (make server and stopper consistent with runner?)
   logger.setupFromConfig({
     colors: cliOptionsOrConfig.colors,
     logLevel: cliOptionsOrConfig.logLevel
@@ -46,6 +49,12 @@ function run (cliOptionsOrConfig, done) {
   if (cliOptionsOrConfig instanceof cfg.Config) {
     config = cliOptionsOrConfig
   } else {
+    const deprecatedCliOptionsMessage =
+      'Passing raw CLI options to `runner(config, done)` is deprecated. Use ' +
+      '`parseConfig(configFilePath, cliOptions, {promiseConfig: true, throwErrors: true})` ' +
+      'to prepare a processed `Config` instance and pass that as the ' +
+      '`config` argument instead.'
+    log.warn(deprecatedCliOptionsMessage)
     try {
       config = cfg.parseConfig(
         cliOptionsOrConfig.configFile,

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -40,9 +40,6 @@ function run (cliOptionsOrConfig, done) {
   if (cliOptionsOrConfig instanceof cfg.Config) {
     config = cliOptionsOrConfig
   } else {
-    // TODO: Should `const log = logger.create('runner')` be moved into the
-    //     : function for consistency with server.js and stopper.js? or the
-    //     : reverse (make server and stopper consistent with runner?)
     logger.setupFromConfig({
       colors: cliOptionsOrConfig.colors,
       logLevel: cliOptionsOrConfig.logLevel

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -34,21 +34,19 @@ function parseExitCode (buffer, defaultExitCode, failOnEmptyTestSuite) {
 // TODO(vojta): read config file (port, host, urlRoot)
 function run (cliOptionsOrConfig, done) {
   cliOptionsOrConfig = cliOptionsOrConfig || {}
-
-  // TODO: Should `const log = logger.create('runner')` be moved into the
-  //     : function for consistency with server.js and stopper.js? or the
-  //     : reverse (make server and stopper consistent with runner?)
-  logger.setupFromConfig({
-    colors: cliOptionsOrConfig.colors,
-    logLevel: cliOptionsOrConfig.logLevel
-  })
-
   done = helper.isFunction(done) ? done : process.exit
 
   let config
   if (cliOptionsOrConfig instanceof cfg.Config) {
     config = cliOptionsOrConfig
   } else {
+    // TODO: Should `const log = logger.create('runner')` be moved into the
+    //     : function for consistency with server.js and stopper.js? or the
+    //     : reverse (make server and stopper consistent with runner?)
+    logger.setupFromConfig({
+      colors: cliOptionsOrConfig.colors,
+      logLevel: cliOptionsOrConfig.logLevel
+    })
     const deprecatedCliOptionsMessage =
       'Passing raw CLI options to `runner(config, done)` is deprecated. Use ' +
       '`parseConfig(configFilePath, cliOptions, {promiseConfig: true, throwErrors: true})` ' +

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -32,14 +32,35 @@ function parseExitCode (buffer, defaultExitCode, failOnEmptyTestSuite) {
 }
 
 // TODO(vojta): read config file (port, host, urlRoot)
-function run (config, done) {
-  config = config || {}
+function run (cliOptionsOrConfig, done) {
+  cliOptionsOrConfig = cliOptionsOrConfig || {}
 
-  logger.setupFromConfig(config)
+  logger.setupFromConfig({
+    colors: cliOptionsOrConfig.colors,
+    logLevel: cliOptionsOrConfig.logLevel
+  })
 
   done = helper.isFunction(done) ? done : process.exit
-  config = cfg.parseConfig(config.configFile, config)
 
+  let config
+  if (cliOptionsOrConfig instanceof cfg.Config) {
+    config = cliOptionsOrConfig
+  } else {
+    try {
+      config = cfg.parseConfig(
+        cliOptionsOrConfig.configFile,
+        cliOptionsOrConfig,
+        {
+          promiseConfig: false,
+          throwErrors: true
+        }
+      )
+    } catch (parseConfigError) {
+      // TODO: change how `done` falls back to exit in next major version
+      //  SEE: https://github.com/karma-runner/karma/pull/3635#discussion_r565399378
+      done(1)
+    }
+  }
   let exitCode = 1
   const emitter = new EventEmitter()
   const options = {

--- a/lib/server.js
+++ b/lib/server.js
@@ -70,6 +70,13 @@ class Server extends KarmaEventEmitter {
     if (cliOptionsOrConfig instanceof cfg.Config) {
       config = cliOptionsOrConfig
     } else {
+      const deprecatedCliOptionsMessage =
+        'Passing raw CLI options to `new Server(config, done)` is ' +
+        'deprecated. Use ' +
+        '`parseConfig(configFilePath, cliOptions, {promiseConfig: true, throwErrors: true})` ' +
+        'to prepare a processed `Config` instance and pass that as the ' +
+        '`config` argument instead.'
+      this.log.warn(deprecatedCliOptionsMessage)
       try {
         config = cfg.parseConfig(
           cliOptionsOrConfig.configFile,

--- a/lib/server.js
+++ b/lib/server.js
@@ -55,22 +55,36 @@ function createSocketIoServer (webServer, executor, config) {
 }
 
 class Server extends KarmaEventEmitter {
-  constructor (cliOptions, done) {
+  constructor (cliOptionsOrConfig, done) {
     super()
-    logger.setupFromConfig(cliOptions)
+    logger.setupFromConfig({
+      colors: cliOptionsOrConfig.colors,
+      logLevel: cliOptionsOrConfig.logLevel
+    })
 
     this.log = logger.create('karma-server')
 
     this.loadErrors = []
 
     let config
-    try {
-      config = cfg.parseConfig(cliOptions.configFile, cliOptions, { throwErrors: true })
-    } catch (parseConfigError) {
-      // TODO: change how `done` falls back to exit in next major version
-      //  SEE: https://github.com/karma-runner/karma/pull/3635#discussion_r565399378
-      (done || process.exit)(1)
-      return
+    if (cliOptionsOrConfig instanceof cfg.Config) {
+      config = cliOptionsOrConfig
+    } else {
+      try {
+        config = cfg.parseConfig(
+          cliOptionsOrConfig.configFile,
+          cliOptionsOrConfig,
+          {
+            promiseConfig: false,
+            throwErrors: true
+          }
+        )
+      } catch (parseConfigError) {
+        // TODO: change how `done` falls back to exit in next major version
+        //  SEE: https://github.com/karma-runner/karma/pull/3635#discussion_r565399378
+        (done || process.exit)(1)
+        return
+      }
     }
 
     this.log.debug('Final config', util.inspect(config, false, /** depth **/ null))

--- a/lib/server.js
+++ b/lib/server.js
@@ -57,13 +57,13 @@ function createSocketIoServer (webServer, executor, config) {
 class Server extends KarmaEventEmitter {
   constructor (cliOptionsOrConfig, done) {
     super()
+    cliOptionsOrConfig = cliOptionsOrConfig || {}
     logger.setupFromConfig({
       colors: cliOptionsOrConfig.colors,
       logLevel: cliOptionsOrConfig.logLevel
     })
-
     this.log = logger.create('karma-server')
-
+    done = helper.isFunction(done) ? done : process.exit
     this.loadErrors = []
 
     let config
@@ -82,7 +82,7 @@ class Server extends KarmaEventEmitter {
       } catch (parseConfigError) {
         // TODO: change how `done` falls back to exit in next major version
         //  SEE: https://github.com/karma-runner/karma/pull/3635#discussion_r565399378
-        (done || process.exit)(1)
+        done(1)
         return
       }
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -58,10 +58,6 @@ class Server extends KarmaEventEmitter {
   constructor (cliOptionsOrConfig, done) {
     super()
     cliOptionsOrConfig = cliOptionsOrConfig || {}
-    logger.setupFromConfig({
-      colors: cliOptionsOrConfig.colors,
-      logLevel: cliOptionsOrConfig.logLevel
-    })
     this.log = logger.create('karma-server')
     done = helper.isFunction(done) ? done : process.exit
     this.loadErrors = []
@@ -70,6 +66,10 @@ class Server extends KarmaEventEmitter {
     if (cliOptionsOrConfig instanceof cfg.Config) {
       config = cliOptionsOrConfig
     } else {
+      logger.setupFromConfig({
+        colors: cliOptionsOrConfig.colors,
+        logLevel: cliOptionsOrConfig.logLevel
+      })
       const deprecatedCliOptionsMessage =
         'Passing raw CLI options to `new Server(config, done)` is ' +
         'deprecated. Use ' +

--- a/lib/stopper.js
+++ b/lib/stopper.js
@@ -3,11 +3,34 @@ const cfg = require('./config')
 const logger = require('./logger')
 const helper = require('./helper')
 
-exports.stop = function (config, done) {
-  config = config || {}
-  logger.setupFromConfig(config)
+exports.stop = function (cliOptionsOrConfig, done) {
+  cliOptionsOrConfig = cliOptionsOrConfig || {}
+  logger.setupFromConfig({
+    colors: cliOptionsOrConfig.colors,
+    logLevel: cliOptionsOrConfig.logLevel
+  })
   const log = logger.create('stopper')
   done = helper.isFunction(done) ? done : process.exit
+
+  let config
+  if (cliOptionsOrConfig instanceof cfg.Config) {
+    config = cliOptionsOrConfig
+  } else {
+    try {
+      config = cfg.parseConfig(
+        cliOptionsOrConfig.configFile,
+        cliOptionsOrConfig,
+        {
+          promiseConfig: false,
+          throwErrors: true
+        }
+      )
+    } catch (parseConfigError) {
+      // TODO: change how `done` falls back to exit in next major version
+      //  SEE: https://github.com/karma-runner/karma/pull/3635#discussion_r565399378
+      done(1)
+    }
+  }
   config = cfg.parseConfig(config.configFile, config)
 
   const request = http.request({

--- a/lib/stopper.js
+++ b/lib/stopper.js
@@ -5,10 +5,6 @@ const helper = require('./helper')
 
 exports.stop = function (cliOptionsOrConfig, done) {
   cliOptionsOrConfig = cliOptionsOrConfig || {}
-  logger.setupFromConfig({
-    colors: cliOptionsOrConfig.colors,
-    logLevel: cliOptionsOrConfig.logLevel
-  })
   const log = logger.create('stopper')
   done = helper.isFunction(done) ? done : process.exit
 
@@ -16,6 +12,10 @@ exports.stop = function (cliOptionsOrConfig, done) {
   if (cliOptionsOrConfig instanceof cfg.Config) {
     config = cliOptionsOrConfig
   } else {
+    logger.setupFromConfig({
+      colors: cliOptionsOrConfig.colors,
+      logLevel: cliOptionsOrConfig.logLevel
+    })
     const deprecatedCliOptionsMessage =
       'Passing raw CLI options to `stopper(config, done)` is deprecated. Use ' +
       '`parseConfig(configFilePath, cliOptions, {promiseConfig: true, throwErrors: true})` ' +

--- a/lib/stopper.js
+++ b/lib/stopper.js
@@ -16,6 +16,12 @@ exports.stop = function (cliOptionsOrConfig, done) {
   if (cliOptionsOrConfig instanceof cfg.Config) {
     config = cliOptionsOrConfig
   } else {
+    const deprecatedCliOptionsMessage =
+      'Passing raw CLI options to `stopper(config, done)` is deprecated. Use ' +
+      '`parseConfig(configFilePath, cliOptions, {promiseConfig: true, throwErrors: true})` ' +
+      'to prepare a processed `Config` instance and pass that as the ' +
+      '`config` argument instead.'
+    log.warn(deprecatedCliOptionsMessage)
     try {
       config = cfg.parseConfig(
         cliOptionsOrConfig.configFile,

--- a/lib/stopper.js
+++ b/lib/stopper.js
@@ -37,7 +37,6 @@ exports.stop = function (cliOptionsOrConfig, done) {
       done(1)
     }
   }
-  config = cfg.parseConfig(config.configFile, config)
 
   const request = http.request({
     hostname: config.hostname,

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -48,20 +48,8 @@ describe('config', () => {
   const wrapCfg = function (cfg) {
     return (config) => config.set(cfg)
   }
-  function wrapCfgResolvedPromise (cfg) {
-    return (config) => {
-      return new Promise((resolve, reject) => {
-        const delayMs = 50
-        setTimeout(() => {
-          try {
-            config.set(cfg)
-            resolve()
-          } catch (configSetException) {
-            reject(configSetException)
-          }
-        }, delayMs)
-      })
-    }
+  const wrapAsyncCfg = function (cfg) {
+    return async (config) => config.set(cfg)
   }
 
   beforeEach(() => {
@@ -87,7 +75,7 @@ describe('config', () => {
       '/conf/coffee.coffee': wrapCfg({ files: ['one.js', 'two.js'] }),
       '/conf/default-export.js': { default: wrapCfg({ files: ['one.js', 'two.js'] }) },
       '/conf/default-config': function noOperations () {},
-      '/conf/returns-promise-that-resolves.js': wrapCfgResolvedPromise({ foo: 'bar' }),
+      '/conf/returns-promise-that-resolves.js': wrapAsyncCfg({ foo: 'bar' }),
       '/conf/returns-promise-that-rejects.js': () => {
         return Promise.reject(new Error('Unexpected Error'))
       }

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -5,24 +5,6 @@ const loadFile = require('mocks').loadFile
 const helper = require('../../lib/helper')
 const logger = require('../../lib/logger.js')
 
-/**
- * If an object is "thenable", then it is considered to be a promise
- * implementation. It does not have to be an instance of ECMAScript's own
- * `Promise` class to be considered a promise.
- *
- * @param {*} value
- * @returns {boolean}
- *
- * @see {@link https://promisesaplus.com/}
- */
-function isPromiseLike (value) {
-  const valueType = typeof value
-  return (
-    ((value != null && valueType === 'object') || valueType === 'function') &&
-    typeof value.then === 'function'
-  )
-}
-
 describe('config', () => {
   let m
   let e
@@ -86,6 +68,7 @@ describe('config', () => {
       global: {},
       process: mocks.process,
       Error: Error, // Without this, chai's `.throw()` assertion won't correctly check against constructors.
+      Promise: Promise,
       require (path) {
         if (mockConfigs[path]) {
           return mockConfigs[path]
@@ -248,18 +231,18 @@ describe('config', () => {
           { promiseConfig: true }
         )
 
-        expect(
-          isPromiseLike(noConfigFilePromise),
+        expect(noConfigFilePromise).to.be.an.instanceof(
+          Promise,
           'Expected parseConfig to return a promise when no config file path is provided.'
-        ).to.be.true
-        expect(
-          isPromiseLike(syncConfigPromise),
+        )
+        expect(syncConfigPromise).to.be.an.instanceof(
+          Promise,
           'Expected parseConfig to return a promise when the config file DOES NOT return a promise.'
-        ).to.be.true
-        expect(
-          isPromiseLike(asyncConfigPromise),
+        )
+        expect(asyncConfigPromise).to.be.an.instanceof(
+          Promise,
           'Expected parseConfig to return a promise when the config file returns a promise.'
-        ).to.be.true
+        )
       })
 
       it('should log an error and exit if invalid file', () => {

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -5,6 +5,24 @@ const loadFile = require('mocks').loadFile
 const helper = require('../../lib/helper')
 const logger = require('../../lib/logger.js')
 
+/**
+ * If an object is "thenable", then it is considered to be a promise
+ * implementation. It does not have to be an instance of ECMAScript's own
+ * `Promise` class to be considered a promise.
+ *
+ * @param {*} value
+ * @returns {boolean}
+ *
+ * @see {@link https://promisesaplus.com/}
+ */
+function isPromiseLike (value) {
+  const valueType = typeof value
+  return (
+    ((value != null && valueType === 'object') || valueType === 'function') &&
+    typeof value.then === 'function'
+  )
+}
+
 describe('config', () => {
   let m
   let e
@@ -30,6 +48,21 @@ describe('config', () => {
   const wrapCfg = function (cfg) {
     return (config) => config.set(cfg)
   }
+  function wrapCfgResolvedPromise (cfg) {
+    return (config) => {
+      return new Promise((resolve, reject) => {
+        const delayMs = 50
+        setTimeout(() => {
+          try {
+            config.set(cfg)
+            resolve()
+          } catch (configSetException) {
+            reject(configSetException)
+          }
+        }, delayMs)
+      })
+    }
+  }
 
   beforeEach(() => {
     mocks = {}
@@ -52,7 +85,12 @@ describe('config', () => {
       '/conf/absolute.js': wrapCfg({ files: ['http://some.com', 'https://more.org/file.js'] }),
       '/conf/both.js': wrapCfg({ files: ['one.js', 'two.js'], exclude: ['third.js'] }),
       '/conf/coffee.coffee': wrapCfg({ files: ['one.js', 'two.js'] }),
-      '/conf/default-export.js': { default: wrapCfg({ files: ['one.js', 'two.js'] }) }
+      '/conf/default-export.js': { default: wrapCfg({ files: ['one.js', 'two.js'] }) },
+      '/conf/default-config': function noOperations () {},
+      '/conf/returns-promise-that-resolves.js': wrapCfgResolvedPromise({ foo: 'bar' }),
+      '/conf/returns-promise-that-rejects.js': () => {
+        return Promise.reject(new Error('Unexpected Error'))
+      }
     }
 
     // load file under test
@@ -75,10 +113,22 @@ describe('config', () => {
   })
 
   describe('parseConfig', () => {
-    let logSpy
+    let logErrorStub
+    let logWarnStub
+    let processExitStub
 
     beforeEach(() => {
-      logSpy = sinon.spy(logger.create('config'), 'error')
+      const log = logger.create('config')
+      // Silence and monitor logged errors and warnings, regardless of the
+      // `logLevel` option.
+      logErrorStub = sinon.stub(log, 'error')
+      logWarnStub = sinon.stub(log, 'warn')
+      processExitStub = sinon.stub(process, 'exit')
+    })
+    afterEach(() => {
+      logErrorStub.restore()
+      logWarnStub.restore()
+      processExitStub.restore()
     })
 
     it('should resolve relative basePath to config directory', () => {
@@ -116,24 +166,24 @@ describe('config', () => {
       expect(config.exclude).to.deep.equal(actual)
     })
 
-    it('should log error and exit if file does not exist', () => {
+    it('should log an error and exit if file does not exist', () => {
       e.parseConfig('/conf/not-exist.js', {})
 
-      expect(logSpy).to.have.been.called
-      const event = logSpy.lastCall.args
+      expect(logErrorStub).to.have.been.called
+      const event = logErrorStub.lastCall.args
       expect(event.toString().split('\n').slice(0, 2)).to.be.deep.equal(
         ['Error in config file!', '  Error: Cannot find module \'/conf/not-exist.js\''])
       expect(mocks.process.exit).to.have.been.calledWith(1)
     })
 
-    it('should log error and throw if file does not exist AND throwErrors is true', () => {
+    it('should log an error and throw if file does not exist AND throwErrors is true', () => {
       function parseConfig () {
         e.parseConfig('/conf/not-exist.js', {}, { throwErrors: true })
       }
 
       expect(parseConfig).to.throw(Error, 'Error in config file!\n  Error: Cannot find module \'/conf/not-exist.js\'')
-      expect(logSpy).to.have.been.called
-      const event = logSpy.lastCall.args
+      expect(logErrorStub).to.have.been.called
+      const event = logErrorStub.lastCall.args
       expect(event.toString().split('\n').slice(0, 2)).to.be.deep.equal(
         ['Error in config file!', '  Error: Cannot find module \'/conf/not-exist.js\''])
       expect(mocks.process.exit).not.to.have.been.called
@@ -142,8 +192,8 @@ describe('config', () => {
     it('should log an error and exit if invalid file', () => {
       e.parseConfig('/conf/invalid.js', {})
 
-      expect(logSpy).to.have.been.called
-      const event = logSpy.lastCall.args
+      expect(logErrorStub).to.have.been.called
+      const event = logErrorStub.lastCall.args
       expect(event[0]).to.eql('Error in config file!\n')
       expect(event[1].message).to.eql('Unexpected token =')
       expect(mocks.process.exit).to.have.been.calledWith(1)
@@ -155,8 +205,8 @@ describe('config', () => {
       }
 
       expect(parseConfig).to.throw(Error, 'Error in config file!\n SyntaxError: Unexpected token =')
-      expect(logSpy).to.have.been.called
-      const event = logSpy.lastCall.args
+      expect(logErrorStub).to.have.been.called
+      const event = logErrorStub.lastCall.args
       expect(event[0]).to.eql('Error in config file!\n')
       expect(event[1].message).to.eql('Unexpected token =')
       expect(mocks.process.exit).not.to.have.been.called
@@ -168,11 +218,95 @@ describe('config', () => {
       }
 
       expect(parseConfig).to.throw(Error, 'Config file must export a function!\n')
-      expect(logSpy).to.have.been.called
-      const event = logSpy.lastCall.args
+      expect(logErrorStub).to.have.been.called
+      const event = logErrorStub.lastCall.args
       expect(event.toString().split('\n').slice(0, 1)).to.be.deep.equal(
         ['Config file must export a function!'])
       expect(mocks.process.exit).not.to.have.been.called
+    })
+
+    it('should log an error and fail when the config file\'s function returns a promise, but `parseOptions.promiseConfig` is not true', () => {
+      function parseConfig () {
+        e.parseConfig(
+          '/conf/returns-promise-that-resolves.js', {}, { throwErrors: true }
+        )
+      }
+      const expectedErrorMessage =
+        'The `parseOptions.promiseConfig` option must be set to `true` to ' +
+        'enable promise return values from configuration files. ' +
+        'Example: `parseConfig(path, cliOptions, { promiseConfig: true })`'
+
+      expect(parseConfig).to.throw(Error, expectedErrorMessage)
+      expect(logErrorStub).to.have.been.called
+      const event = logErrorStub.lastCall.args
+      expect(event[0]).to.be.eql(expectedErrorMessage)
+      expect(mocks.process.exit).not.to.have.been.called
+    })
+
+    describe('when `parseOptions.promiseConfig` is true', () => {
+      it('should return a promise when promiseConfig is true', () => {
+        // Return value should always be a promise, regardless of whether or not
+        // the config file itself is synchronous or asynchronous and when no
+        // config file path is provided at all.
+        const noConfigFilePromise = e.parseConfig(
+          null, null, { promiseConfig: true }
+        )
+        const syncConfigPromise = e.parseConfig(
+          '/conf/default-config', null, { promiseConfig: true }
+        )
+        const asyncConfigPromise = e.parseConfig(
+          '/conf/returns-promise-that-resolves.js',
+          null,
+          { promiseConfig: true }
+        )
+
+        expect(
+          isPromiseLike(noConfigFilePromise),
+          'Expected parseConfig to return a promise when no config file path is provided.'
+        ).to.be.true
+        expect(
+          isPromiseLike(syncConfigPromise),
+          'Expected parseConfig to return a promise when the config file DOES NOT return a promise.'
+        ).to.be.true
+        expect(
+          isPromiseLike(asyncConfigPromise),
+          'Expected parseConfig to return a promise when the config file returns a promise.'
+        ).to.be.true
+      })
+
+      it('should log an error and exit if invalid file', () => {
+        e.parseConfig('/conf/invalid.js', {}, { promiseConfig: true })
+
+        expect(logErrorStub).to.have.been.called
+        const event = logErrorStub.lastCall.args
+        expect(event[0]).to.eql('Error in config file!\n')
+        expect(event[1].message).to.eql('Unexpected token =')
+        expect(mocks.process.exit).to.have.been.calledWith(1)
+      })
+
+      it('should log an error and reject the promise if the config file rejects the promise returned by its function AND throwErrors is true', async () => {
+        const configThatRejects = e.parseConfig('/conf/returns-promise-that-rejects.js', {}, { promiseConfig: true, throwErrors: true }).catch((reason) => {
+          expect(logErrorStub).to.have.been.called
+          const event = logErrorStub.lastCall.args
+          expect(event[0]).to.eql('Error in config file!\n')
+          expect(event[1].message).to.eql('Unexpected Error')
+          expect(reason.message).to.eql('Error in config file!\n Error: Unexpected Error')
+          expect(reason).to.be.an.instanceof(Error)
+        })
+        return configThatRejects
+      })
+
+      it('should log an error and reject the promise if invalid file AND throwErrors is true', async () => {
+        const configThatThrows = e.parseConfig('/conf/invalid.js', {}, { promiseConfig: true, throwErrors: true }).catch((reason) => {
+          expect(logErrorStub).to.have.been.called
+          const event = logErrorStub.lastCall.args
+          expect(event[0]).to.eql('Error in config file!\n')
+          expect(event[1].message).to.eql('Unexpected token =')
+          expect(reason.message).to.eql('Error in config file!\n SyntaxError: Unexpected token =')
+          expect(reason).to.be.an.instanceof(Error)
+        })
+        return configThatThrows
+      })
     })
 
     it('should override config with given cli options', () => {
@@ -288,7 +422,7 @@ describe('config', () => {
     it('should not read config file, when null', () => {
       const config = e.parseConfig(null, { basePath: '/some' })
 
-      expect(logSpy).not.to.have.been.called
+      expect(logErrorStub).not.to.have.been.called
       expect(config.basePath).to.equal(resolveWinPath('/some')) // overridden by CLI
       expect(config.urlRoot).to.equal('/')
     }) // default value
@@ -296,7 +430,7 @@ describe('config', () => {
     it('should not read config file, when null but still resolve cli basePath', () => {
       const config = e.parseConfig(null, { basePath: './some' })
 
-      expect(logSpy).not.to.have.been.called
+      expect(logErrorStub).not.to.have.been.called
       expect(config.basePath).to.equal(resolveWinPath('./some'))
       expect(config.urlRoot).to.equal('/')
     }) // default value


### PR DESCRIPTION
With this change, Karma allows to return a `Promise` from a configuration function directly or make such function `async` and thus allows to perform some asynchronous initialization/fetch configuration from somewhere. When the configuration function returns a Promise, Karma will wait until the promise is resolved before it proceeds with the next steps.

Example usage:

```js
module.exports = async (config) => {
  const karmaConfig = await getKarmaConfig("dev");
  
  config.set({
    ...karmaConfig
  });
};
```

For Karma's end-users the change is fully backward compatible. For Karma's programmatic users the change is backward compatible, but the current behavior of `parseConfig()`, `Server`, `runner`, and `stopper` is deprecated and will change in the next major release. New behavior (which supports asynchronous configuration function) can be enabled with a flag. Please refer to the [public API documentation](http://karma-runner.github.io/latest/dev/public-api.html) for more details.

Fixes #1259