### PR TITLE
fix: ignore dollar replacement sequences in file paths

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -31,6 +31,11 @@ const FILE_TYPES = [
 ]
 
 function filePathToUrlPath (filePath, basePath, urlRoot, proxyPath) {
+  // Escape all dollar signs as it can be interpreted as replacement
+  // sequences ($&, $`, $', $n, $nn) when doing the final replacement
+  // at the end into the template.
+  filePath = filePath.replace(/\$/g, '$$$$')
+
   if (filePath.startsWith(basePath)) {
     return proxyPath + urlRoot.substr(1) + 'base' + filePath.substr(basePath.length)
   }

--- a/test/unit/middleware/karma.spec.js
+++ b/test/unit/middleware/karma.spec.js
@@ -388,6 +388,21 @@ describe('middleware.karma', () => {
     callHandlerWith('/__karma__/context.html')
   })
 
+  it('should ignore dollar replacement sequences in mappings with all served files', (done) => {
+    fsMock._touchFile('/karma/static/context.html', 0, '%MAPPINGS%')
+    servedFiles([
+      new MockFile('/some/abc/a$$b.js', 'sha_a'),
+      new MockFile('/base/path/ba.js', 'sha_b')
+    ])
+
+    response.once('end', () => {
+      expect(response).to.beServedAs(200, 'window.__karma__.files = {\n  \'/__proxy__/__karma__/absolute/some/abc/a$$b.js\': \'sha_a\',\n  \'/__proxy__/__karma__/base/ba.js\': \'sha_b\'\n};\n')
+      done()
+    })
+
+    callHandlerWith('/__karma__/context.html')
+  })
+
   it('should serve debug.html with replaced script tags without timestamps', (done) => {
     includedFiles([
       new MockFile('/first.js'),


### PR DESCRIPTION
When using `string.replace` as a templating engine, care must be taken to escape dollar signs as they can be interpreted as replacement patterns: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter

Note yarn uses a special `$$virtual` folder in [some circumstances](https://yarnpkg.com/configuration/yarnrc#virtualFolder), so this can break setups involving yarn.