### PR TITLE
fix: fix running tests in IE9

### DIFF
--- a/static/client.html
+++ b/static/client.html
@@ -109,7 +109,7 @@ It contains socket.io and all the communication logic.
 
   <iframe id="context" src="about:blank" width="100%" height="100%"></iframe>
 
-  <script src="socket.io/socket.io.js"></script>
+  <script src="socket.io/socket.io.min.js"></script>
   <script src="karma.js"></script>
 </body>
 </html>

--- a/static/client_with_context.html
+++ b/static/client_with_context.html
@@ -104,7 +104,7 @@ Is used for single-shot tests.
   <div id="banner" class="offline">
     <h1 id="title">Karma - starting</h1>
   </div>
-  <script src="socket.io/socket.io.js"></script>
+  <script src="socket.io/socket.io.min.js"></script>
   <script src="karma.js"></script>
   <script src="context.js"></script>
   <!-- The scripts need to be at the end of body, so that some test running frameworks

--- a/test/client/karma.conf.js
+++ b/test/client/karma.conf.js
@@ -27,6 +27,13 @@ const launchers = {
     browser_version: '11.0',
     os: 'Windows',
     os_version: '10'
+  },
+  bs_ie9: {
+    base: 'BrowserStack',
+    browser: 'IE',
+    browser_version: '9.0',
+    os: 'Windows',
+    os_version: '7'
   }
 }
 


### PR DESCRIPTION
So the symptom is that after Karma page is loaded in IE9 the tests don't run and Karma is stuck at the "starting" step. Reloading the page once or twice makes IE9 connect to the server and tests pass successfully.

After an "exciting" debugging session I figured out that the problem is that on the first load (and sometimes after the page reload) [`io` variable](https://github.com/karma-runner/karma/blob/026fff870913fb6cd2858dd962935dc74c92b725/client/main.js#L14), which should be set by the `socket.io.js` script is undefined. It looks like IE9 silently stops executing `socket.io.js` script somewhere midway and switches to the next script causing the `io` variable to be undefined. I assume it hits some limit or threshold or whatnot. Couldn't find much information on the Internet, besides people experiencing similar issues when loading e.g. unminified jQuery and their own code firing before the `$` variable is available. No good solutions found.

Checking the `socket.io.js` contents, I have noticed that v2 served the minified client script on that path, while v3 now serves the unminified code. Presumably the huge script size is what causing IE9 to choke. Switching back to the minified socket.io client bundle allows tests to pass in IE9.

With the fix, tests passed 5 times in a row, while without it they fail every time, so I assume it does resolve the problem.

Fixes #3665