### PR TITLE
chore: replace `init` scripts with a dependency on itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,16 @@ jobs:
   include:
     - node_js: "10"
       script:
-        - npm run init
         - npm run test:unit
         - npm run test:e2e
 
     - node_js: "12"
       script:
-        - npm run init
         - npm run test:unit
         - npm run test:e2e
 
     - node_js: "14"
       script:
-        - npm run init
         - if [[ "$TRAVIS_BRANCH" != "master" ]]; then
             commitlint-travis;
           fi;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,6 @@ install:
   # Install our package dependencies
   - appveyor-retry npm install
 
-  # Install our current directory as a dependency of itself
-  - npm run init:windows
-
 test_script:
   - npm run test:unit
   - npm run test:client

--- a/docs/dev/02-making-changes.md
+++ b/docs/dev/02-making-changes.md
@@ -20,13 +20,9 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
   $ git clone https://github.com/<your-username>/karma.git
   $ cd karma
   ```
-* Install for development. Use a recent npm version, ignore peerdep warnings
+* Install for development
   ```bash
   $ npm install
-  
-  $ npm run init
-  # or if you're on Windows
-  $ npm run init:windows
   ```
 
 ## Testing and Building

--- a/package-lock.json
+++ b/package-lock.json
@@ -6493,6 +6493,35 @@
       "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
       "dev": true
     },
+    "karma": {
+      "version": "file:",
+      "dev": true,
+      "requires": {
+        "body-parser": "^1.19.0",
+        "braces": "^3.0.2",
+        "chokidar": "^3.4.2",
+        "colors": "^1.4.0",
+        "connect": "^3.7.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.1",
+        "glob": "^7.1.6",
+        "graceful-fs": "^4.2.4",
+        "http-proxy": "^1.18.1",
+        "isbinaryfile": "^4.0.6",
+        "lodash": "^4.17.19",
+        "log4js": "^6.2.1",
+        "mime": "^2.4.5",
+        "minimatch": "^3.0.4",
+        "qjobs": "^1.2.0",
+        "range-parser": "^1.2.1",
+        "rimraf": "^3.0.2",
+        "socket.io": "^3.1.0",
+        "source-map": "^0.6.1",
+        "tmp": "0.2.1",
+        "ua-parser-js": "^0.7.23",
+        "yargs": "^16.1.1"
+      }
+    },
     "karma-browserify": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -460,6 +460,7 @@
     "http2": "^3.3.6",
     "husky": "^4.2.5",
     "jasmine-core": "^3.6.0",
+    "karma": ".",
     "karma-browserify": "^7.0.0",
     "karma-browserstack-launcher": "^1.6.0",
     "karma-chai": "^0.1.0",
@@ -509,10 +510,6 @@
     "build:check": "node scripts/client.js check",
     "build:watch": "node scripts/client.js watch",
     "test:integration": "./scripts/integration-tests.sh",
-    "link": "node --eval \"path=require('path'); require('fs').symlinkSync(path.resolve(__dirname), path.resolve(__dirname, 'node_modules', 'karma'), 'junction')\"",
-    "unlink": "node --eval \"require('fs').unlinkSync(require('path').resolve(__dirname, 'node_modules', 'karma'))\"",
-    "init": "rm -rf node_modules/karma && cd node_modules && ln -nsf ../ karma && cd ../",
-    "init:windows": "(IF EXIST node_modules\\karma (rmdir node_modules\\karma /S /q)) && npm run link",
     "semantic-release": "semantic-release"
   }
 }

--- a/test/client/karma.conf.js
+++ b/test/client/karma.conf.js
@@ -1,5 +1,3 @@
-const fs = require('fs')
-
 const TRAVIS_WITH_BS = !!process.env.BROWSER_STACK_ACCESS_KEY
 
 const launchers = {
@@ -36,28 +34,6 @@ const launchers = {
     os_version: '7'
   }
 }
-
-// Verify the install. This will run async but that's ok we'll see the log.
-fs.lstat('node_modules/karma', (err, stats) => {
-  if (err) {
-    console.error('Cannot verify installation', err.stack || err)
-  }
-  if (stats && stats.isSymbolicLink()) {
-    return
-  }
-
-  console.log('**** Incorrect directory layout for karma self-tests ****')
-  console.log(`
-    $ npm install
-
-    $ npm run init
-    # or if you're on Windows
-    $ npm run init:windows
-
-    $ npm run build
-  `)
-  process.exit(1)
-})
 
 let browsers = ['Chrome']
 


### PR DESCRIPTION
This has the same result (symlink to the `karma` in the node_modules), but has two benefits:

- karma developers don't need to run extra command
- no peer dependency warnings when `npm install` is run