### PR TITLE
Return exitCode from onExit exitCode setters

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -185,6 +185,7 @@ class Server extends KarmaEventEmitter {
         if (!--pending) {
           resolve()
         }
+        return code;
       })
 
       if (!pending) {


### PR DESCRIPTION
This allows a listener to get the exitCode as well.