### PR TITLE
chore(ci/client/browserstack): reduce the `captureTimeout`

### DIFF
--- a/test/client/karma.conf.js
+++ b/test/client/karma.conf.js
@@ -101,7 +101,7 @@ module.exports = function (config) {
 
     // Recommeneded browserstack timeouts
     // https://github.com/karma-runner/karma-browserstack-launcher/issues/61
-    captureTimeout: 3e5,
+    captureTimeout: 6e4,
     browserDisconnectTolerance: 3,
     browserDisconnectTimeout: 6e4,
     browserSocketTimeout: 1.2e5,


### PR DESCRIPTION
This should've happened in
https://github.com/karma-runner/karma/commit/4b3b0721b38dfacfca9886c31686ffd97e75654e.