### PR TITLE
bump vulnerable ua-parser-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6473,7 +6473,7 @@
         "socket.io": "^4.2.0",
         "source-map": "^0.6.1",
         "tmp": "^0.2.1",
-        "ua-parser-js": "^0.7.28",
+        "ua-parser-js": "^0.7.30",
         "yargs": "^16.1.1"
       }
     },
@@ -13216,9 +13216,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+      "version": "0.7.30",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.30.tgz",
+      "integrity": "sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg=="
     },
     "uglify-js": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -439,7 +439,7 @@
     "socket.io": "^4.2.0",
     "source-map": "^0.6.1",
     "tmp": "^0.2.1",
-    "ua-parser-js": "^0.7.28",
+    "ua-parser-js": "^0.7.30",
     "yargs": "^16.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
There's a malicious `ua-parser-js` NPM takeover, this PR bumps `ua-parser-js` version to the safe `0.7.30`.

Security advisory: https://github.com/advisories/GHSA-pjwm-rvh2-c87w
GH thread: https://github.com/faisalman/ua-parser-js/issues/536