### PR TITLE
fix: restartOnFileChange option not restarting the test run

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -232,20 +232,15 @@ function Karma (updater, socket, iframe, opener, navigator, location, document) 
       resultsBuffer = []
     }
 
-    // A test could have incorrectly issued a navigate. Wait one turn
-    // to ensure the error from an incorrect navigate is processed.
-    var config = this.config
-    setTimeout(function () {
-      socket.emit('complete', result || {})
-      if (config.clearContext) {
-        navigateContextTo('about:blank')
-      } else {
-        self.updater.updateTestStatus('complete')
-      }
-      if (returnUrl) {
-        location.href = returnUrl
-      }
-    })
+    socket.emit('complete', result || {})
+    if (this.config.clearContext) {
+      navigateContextTo('about:blank')
+    } else {
+      self.updater.updateTestStatus('complete')
+    }
+    if (returnUrl) {
+      location.href = returnUrl
+    }
   }
 
   this.info = function (info) {

--- a/static/karma.js
+++ b/static/karma.js
@@ -242,20 +242,15 @@ function Karma (updater, socket, iframe, opener, navigator, location, document) 
       resultsBuffer = []
     }
 
-    // A test could have incorrectly issued a navigate. Wait one turn
-    // to ensure the error from an incorrect navigate is processed.
-    var config = this.config
-    setTimeout(function () {
-      socket.emit('complete', result || {})
-      if (config.clearContext) {
-        navigateContextTo('about:blank')
-      } else {
-        self.updater.updateTestStatus('complete')
-      }
-      if (returnUrl) {
-        location.href = returnUrl
-      }
-    })
+    socket.emit('complete', result || {})
+    if (this.config.clearContext) {
+      navigateContextTo('about:blank')
+    } else {
+      self.updater.updateTestStatus('complete')
+    }
+    if (returnUrl) {
+      location.href = returnUrl
+    }
   }
 
   this.info = function (info) {

--- a/test/e2e/restart-on-change.feature
+++ b/test/e2e/restart-on-change.feature
@@ -1,0 +1,28 @@
+Feature: Restart on file change
+  In order to use Karma
+  As a person who wants to write great tests
+  I want Karma to re-run tests whenever file changes.
+
+  Scenario: Re-run tests when file changes
+    Given a configuration with:
+      """
+      files = ['basic/plus.js', 'basic/test.js'];
+      browsers = ['ChromeHeadlessNoSandbox'];
+      plugins = [
+        'karma-jasmine',
+        'karma-chrome-launcher'
+      ];
+      restartOnFileChange = true;
+      singleRun = false;
+      """
+    When I start a server in background
+    And I wait until server output contains:
+      """
+      ..
+      Chrome Headless
+      """
+    When I touch file: "basic/test.js"
+    Then the background stdout matches RegExp:
+      """
+      Executed 2 of 2 SUCCESS[\s\S]+Executed 2 of 2 SUCCESS
+      """


### PR DESCRIPTION
The problem was caused by a race condition in the client JS implementation. When the `restartOnFileChange` option is enabled, the server would send [two commands](https://github.com/karma-runner/karma/blob/b153355de7e05559d877a625c9b0c5d23a3548bd/lib/server.js#L377) to the browser: `stop` and `execute`. Both of these commands navigate the context. `stop` navigates to the blank page, while `execute` navigate to the `context.html` thus triggering a test run. The `execute` command would trigger the navigation synchronously, but the `stop` command would trigger it on the next event loop tick. As a result, if both commands arrive almost at the same time, their order is effectively reversed: first schedule new execution and then immediately stop it. The bug is resolved by handling both commands synchronously thus ensuring correct order.

The setTimeout() call in question was introduced in 15d80f4 to solve #27 and was retained over time. It's not completely clear why the timeout was added, but it does not seem to be relevant.

With `clearContext: true`, karma will reset the context and thus cancel any scheduled navigations as soon as the test framework has reported the `complete` event. As navigations are canceled they don't affect karma and thus karma does not care about them. It's true that the user may have a test with race conditions (e.g. missing `done` callback), but it is up to them to investigate and fix it.

With `clearContext: false`, the same logic applies, that karma does not care about navigations after `complete` event as long as they don't break karma itself. Here it gets a bit tricky:

- Navigation within the same origin is undesired, but it doesn't break karma and the next execution can proceed normally.
- Navigation to a different origin however is a problem as after such navigation the iframe becomes cross-origin and karma client will not be able to navigate it to the `context.html` or interact with it at all for that matter until the page reload (see [this SO answer](https://stackoverflow.com/q/25098021/1377864)). This will break the watch mode, but IMO we can let it be given that the case is quite uncommon, the user will see the browser window displaying something unexpected and the error in the CLI output. The changes in this commit don't make this case any worse and it does not seem to be possible to prevent such problematic navigations with the current state of browsers per https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload:

> To combat unwanted pop-ups, some browsers don't display prompts created in beforeunload event handlers unless the page has been interacted with. Moreover, some don't display them at all.

Fixes #3724