### PR TITLE
pin colors to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -418,13 +418,14 @@
     "toran billups <toranb@gmail.com>",
     "xel23 <sawqe1@yandex.ru>",
     "chalkerx@gmail.com>",
-    "weiran.zsd@outlook.com>"
+    "weiran.zsd@outlook.com>",
+    "mannyluvstacos <mannyis@typingona.computer>"
   ],
   "dependencies": {
     "body-parser": "^1.19.0",
     "braces": "^3.0.2",
     "chokidar": "^3.5.1",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "connect": "^3.7.0",
     "di": "^0.0.1",
     "dom-serialize": "^2.2.1",


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR pins the color package to `1.4.0` as advised on the [snyk page](https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what/)