### PR TITLE
fix(deps): pin colors package to 1.4.0 due to security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5211,7 +5211,7 @@
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
         "chokidar": "^3.5.1",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "connect": "^3.7.0",
         "di": "^0.0.1",
         "dom-serialize": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -420,11 +420,14 @@
     "chalkerx@gmail.com>",
     "weiran.zsd@outlook.com>"
   ],
+  "overrides": {
+    "colors": "1.4.0"
+  },
   "dependencies": {
     "body-parser": "^1.19.0",
     "braces": "^3.0.2",
     "chokidar": "^3.5.1",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "connect": "^3.7.0",
     "di": "^0.0.1",
     "dom-serialize": "^2.2.1",


### PR DESCRIPTION
Another one, hopefully contains all required changes :weary:

Pin `colors` package to `1.4.0` version due to security vulnerability. See details:
- [1.4.0...1.4.2 diff](https://diff.intrinsic.com/colors/1.4.0/1.4.2)
- https://github.com/Marak/colors.js/issues/285
- https://www.theverge.com/2022/1/9/22874949/developer-corrupts-open-source-libraries-projects-affected
- https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/