### PR TITLE
test: fix version regex in the CLI test case

### DIFF
--- a/test/e2e/cli.feature
+++ b/test/e2e/cli.feature
@@ -30,7 +30,7 @@ Feature: CLI
     When I execute Karma with arguments: "--version"
     Then the stdout matches RegExp:
       """
-      ^\d\.\d\.\d$
+      ^\d+\.\d+\.\d+$
       """
 
   Scenario: Error when command is unknown


### PR DESCRIPTION
\d no longer matches since 6.3.10 because of two-digit number.