### PR TITLE
fix: replace `colors` with `ansi-colors`

### DIFF
--- a/lib/reporters/base_color.js
+++ b/lib/reporters/base_color.js
@@ -1,4 +1,4 @@
-const { red, yellow, green, cyan } = require('colors/safe')
+const { red, yellow, green, cyan } = require('ansi-colors')
 
 function BaseColorReporter () {
   this.USE_COLORS = true

--- a/package.json
+++ b/package.json
@@ -421,10 +421,10 @@
     "weiran.zsd@outlook.com>"
   ],
   "dependencies": {
+    "ansi-colors": "^4.1.1",
     "body-parser": "^1.19.0",
     "braces": "^3.0.2",
     "chokidar": "^3.5.1",
-    "colors": "^1.4.0",
     "connect": "^3.7.0",
     "di": "^0.0.1",
     "dom-serialize": "^2.2.1",


### PR DESCRIPTION
The author of the colors package purpose broke this package.

See: https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/ and https://github.com/Marak/colors.js/issues/285

Closes #3738