### PR TITLE
fix: update constants to remove deprecation warning from log4js

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -28,8 +28,8 @@ exports.LOG_PRIORITIES = [
 ]
 
 // Default patterns for the pattern layout.
-exports.COLOR_PATTERN = '%[%d{DATE}:%p [%c]: %]%m'
-exports.NO_COLOR_PATTERN = '%d{DATE}:%p [%c]: %m'
+exports.COLOR_PATTERN = '%[%d{DATETIME}:%p [%c]: %]%m'
+exports.NO_COLOR_PATTERN = '%d{DATETIME}:%p [%c]: %m'
 
 // Default console appender
 exports.CONSOLE_APPENDER = {


### PR DESCRIPTION
Closes: #3749

A simple fix to resolve the issue that was introduced from this change in Loj4js https://github.com/log4js-node/log4js-node/commit/3226b3de40da493c3a034ffa7694caa2aab1ef38#diff-ade4a5a1a21fa05e981597abfd6195ecf9459cc7681f8cbf873308ec0b0c4637