### PR TITLE
fix(security): remove XSS vulnerability in `returnUrl` query param

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -239,6 +239,9 @@ function Karma (updater, socket, iframe, opener, navigator, location, document) 
       self.updater.updateTestStatus('complete')
     }
     if (returnUrl) {
+      if (!/^https?:\/\//.test(returnUrl)) {
+        throw new Error(`Security: Navigation to ${returnUrl} was blocked to prevent malicious exploits.`)
+      }
       location.href = returnUrl
     }
   }

--- a/static/karma.js
+++ b/static/karma.js
@@ -249,6 +249,9 @@ function Karma (updater, socket, iframe, opener, navigator, location, document) 
       self.updater.updateTestStatus('complete')
     }
     if (returnUrl) {
+      if (!/^https?:\/\//.test(returnUrl)) {
+        throw new Error(`Security: Navigation to ${returnUrl} was blocked to prevent malicious exploits.`)
+      }
       location.href = returnUrl
     }
   }


### PR DESCRIPTION
The `returnUrl` query parameter can be used to execute malicious code. For
example, visiting
`http://localhost:9876/?return_url=javascript:alert(document.domain)` will
display an alert.