### PR TITLE
fix: warn when `singleRun` and `autoWatch` are `false`

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -96,6 +96,10 @@ class Server extends KarmaEventEmitter {
 
     this.log.debug('Final config', util.inspect(config, false, /** depth **/ null))
 
+    if (!config.autoWatch && !config.singleRun) {
+      this.log.warn('`autowatch` and `singleRun` are both `false`. In order to execute tests use `karma run`.')
+    }
+
     let modules = [{
       helper: ['value', helper],
       logger: ['value', logger],


### PR DESCRIPTION
Setting `singleRun` and `autoWatch` to `false` will make the server remain idle
even when capturing a browser. It is a no-op combination. If it is detected,
fail and explain.