### PR TITLE
chore: prevent duplicate CI tasks on creating a PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches-ignore:
-      - master
   pull_request:
     branches:
       - master
@@ -38,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 10, 12 ]
+        node: [10, 12]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/test/client/karma.conf.js
+++ b/test/client/karma.conf.js
@@ -124,7 +124,7 @@ module.exports = function (config) {
       'karma-browserstack-launcher'
     ],
 
-    concurrency: 2,
+    concurrency: 1,
 
     forceJSONP: true,
 


### PR DESCRIPTION
BrowserStack can be flaky when there are multiple concurrent jobs running on
it. This commit makes sure that only 1 browser can run concurrently during the
`npm run test:client` jobs and that the "Test" GitHub Action workflow is only
trigerred once when creating a PR; having the `on: push` configuration made it
so that GH triggers two duplicate jobs when a PR is opened.