### PR TITLE
Update colors to maintained version

### DIFF
--- a/lib/reporters/base_color.js
+++ b/lib/reporters/base_color.js
@@ -1,4 +1,4 @@
-const { red, yellow, green, cyan } = require('colors/safe')
+const { red, yellow, green, cyan } = require('@colors/colors/safe')
 
 function BaseColorReporter () {
   this.USE_COLORS = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,11 @@
         }
       }
     },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
+    },
     "@commitlint/cli": {
       "version": "12.1.4",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-12.1.4.tgz",
@@ -2315,7 +2320,8 @@
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
     },
     "combine-source-map": {
       "version": "0.8.0",
@@ -5209,10 +5215,10 @@
       "version": "file:",
       "dev": true,
       "requires": {
+        "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
         "chokidar": "^3.5.1",
-        "colors": "1.4.0",
         "connect": "^3.7.0",
         "di": "^0.0.1",
         "dom-serialize": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -422,14 +422,11 @@
     "chalkerx@gmail.com>",
     "weiran.zsd@outlook.com>"
   ],
-  "overrides": {
-    "colors": "1.4.0"
-  },
   "dependencies": {
     "body-parser": "^1.19.0",
     "braces": "^3.0.2",
     "chokidar": "^3.5.1",
-    "colors": "1.4.0",
+    "@colors/colors": "1.5.0",
     "connect": "^3.7.0",
     "di": "^0.0.1",
     "dom-serialize": "^2.2.1",


### PR DESCRIPTION
Per https://github.com/Marak/colors.js/issues/340, the colors package on which `karma` depends has been migrated to @colors/colors. This PR performs the (very simple) migration. Thanks for your help with getting this into the next release, and let me know if you need any help with getting this fix out or other maintenance tasks.