### PR TITLE
ci: add behavior analysis of dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   main:
     name: Lint and Unit (Client and Server), E2E and Integration Test
@@ -15,6 +18,11 @@ jobs:
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -37,6 +45,11 @@ jobs:
       matrix:
         node: [10, 12]
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
@@ -52,6 +65,11 @@ jobs:
       matrix:
         node: [10, 12, 14]
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,6 @@ jobs:
       matrix:
         node: [10, 12, 14]
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@v1
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
This PR 
1. Adds [harden-runner](https://github.com/step-security/harden-runner) GitHub Action to the `test.yml` workflow.
2. Sets the token permission for the workflow to `contents: read`. This is a security best practice and gets you are higher [Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) score. 

[harden-runner](https://github.com/step-security/harden-runner) GitHub Action detects hijacked dependencies and compromised build tools. It correlates outbound traffic with each step of the workflow so you can see what processes are calling what endpoints. This is the analysis when run on a fork: https://app.stepsecurity.io/github/varunsh-coder/karma/actions/runs/1923349069

You can also restrict traffic to the allowed endpoints for future runs. You do not need to grant any permission or install any App to use this, and the action (and agent the action uses) are open source. 

Information on how harden-runner could have detected past package hijacks can be found here: https://github.com/step-security/supply-chain-goat. Do share feedback to improve the [harden-runner](https://github.com/step-security/harden-runner) GitHub Action developer experience. Thanks!