### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -15,7 +15,7 @@ var socket = io(location.host, {
   reconnectionDelay: 500,
   reconnectionDelayMax: Infinity,
   timeout: BROWSER_SOCKET_TIMEOUT,
-  path: KARMA_PROXY_PATH + KARMA_URL_ROOT.substr(1) + 'socket.io',
+  path: KARMA_PROXY_PATH + KARMA_URL_ROOT.slice(1) + 'socket.io',
   'sync disconnect on unload': true,
   useNativeTimers: true
 })

--- a/common/util.js
+++ b/common/util.js
@@ -20,7 +20,7 @@ exports.isDefined = function (value) {
 
 exports.parseQueryParams = function (locationSearch) {
   var params = {}
-  var pairs = locationSearch.substr(1).split('&')
+  var pairs = locationSearch.slice(1).split('&')
   var keyValue
 
   for (var i = 0; i < pairs.length; i++) {

--- a/lib/completion.js
+++ b/lib/completion.js
@@ -36,7 +36,7 @@ const options = {
 
 function opositeWord (word) {
   if (word.startsWith('-')) {
-    return word.startsWith('--no-') ? `--${word.substr(5)}` : `--no-${word.substr(2)}`
+    return word.startsWith('--no-') ? `--${word.slice(5)}` : `--no-${word.slice(2)}`
   } else {
     return null
   }

--- a/lib/events.js
+++ b/lib/events.js
@@ -35,7 +35,7 @@ class KarmaEventEmitter extends EventEmitter {
   bind (object) {
     for (const method in object) {
       if (method.startsWith('on') && helper.isFunction(object[method])) {
-        this.on(helper.camelToSnake(method.substr(2)), function () {
+        this.on(helper.camelToSnake(method.slice(2)), function () {
           // We do not use an arrow function here, to supply the caller as this.
           object[method].apply(object, Array.from(arguments).concat(this))
         })

--- a/lib/file.js
+++ b/lib/file.js
@@ -36,7 +36,7 @@ class File {
    * @returns {string} detected file type or empty string
    */
   detectType () {
-    return path.extname(this.path).substring(1)
+    return path.extname(this.path).slice(1)
   }
 
   toString () {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -30,15 +30,15 @@ const parser = (pattern, out) => {
       t = 'optional'
     }
     out[t]++
-    return parser(pattern.substring(1), out)
+    return parser(pattern.slice(1), out)
   }
   if (matches[2] !== undefined) {
     out.ext_glob++
     parser(matches[2], out)
-    return parser(pattern.substring(matches[0].length), out)
+    return parser(pattern.slice(matches[0].length), out)
   }
   out.range++
-  return parser(pattern.substring(matches[0].length), out)
+  return parser(pattern.slice(matches[0].length), out)
 }
 
 const gsParser = (pattern, out) => {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -96,7 +96,7 @@ exports.camelToSnake = (camelCase) => {
 }
 
 exports.ucFirst = (word) => {
-  return word.charAt(0).toUpperCase() + word.substr(1)
+  return word.charAt(0).toUpperCase() + word.slice(1)
 }
 
 exports.dashToCamel = (dash) => {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -60,7 +60,7 @@ class Launcher {
       protocol = upstreamProxy.protocol
       hostname = upstreamProxy.hostname
       port = upstreamProxy.port
-      urlRoot = upstreamProxy.path + urlRoot.substr(1)
+      urlRoot = upstreamProxy.path + urlRoot.slice(1)
     }
 
     return (name) => {

--- a/lib/launchers/process.js
+++ b/lib/launchers/process.js
@@ -44,7 +44,7 @@ function ProcessLauncher (spawn, tempDir, timer, processKillTimeout) {
   // Normalize the command, remove quotes (spawn does not like them).
   this._normalizeCommand = function (cmd) {
     if (cmd.charAt(0) === cmd.charAt(cmd.length - 1) && '\'`"'.includes(cmd.charAt(0))) {
-      cmd = cmd.substring(1, cmd.length - 1)
+      cmd = cmd.slice(1, -1)
       log.warn(`The path should not be quoted.\n  Normalized the path to ${cmd}`)
     }
 

--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -32,9 +32,9 @@ const FILE_TYPES = [
 
 function filePathToUrlPath (filePath, basePath, urlRoot, proxyPath) {
   if (filePath.startsWith(basePath)) {
-    return proxyPath + urlRoot.substr(1) + 'base' + filePath.substr(basePath.length)
+    return proxyPath + urlRoot.slice(1) + 'base' + filePath.slice(basePath.length)
   }
-  return proxyPath + urlRoot.substr(1) + 'absolute' + filePath
+  return proxyPath + urlRoot.slice(1) + 'absolute' + filePath
 }
 
 function getQuery (urlStr) {
@@ -85,8 +85,8 @@ function createKarmaMiddleware (
     const requestedRangeHeader = request.headers.range
 
     // redirect /__karma__ to /__karma__ (trailing slash)
-    if (requestUrl === urlRoot.substr(0, urlRoot.length - 1)) {
-      response.setHeader('Location', proxyPath + urlRoot.substr(1))
+    if (requestUrl === urlRoot.slice(0, -1)) {
+      response.setHeader('Location', proxyPath + urlRoot.slice(1))
       response.writeHead(301)
       return response.end('MOVED PERMANENTLY')
     }
@@ -97,7 +97,7 @@ function createKarmaMiddleware (
     }
 
     // remove urlRoot prefix
-    requestUrl = requestUrl.substr(urlRoot.length - 1)
+    requestUrl = requestUrl.slice(urlRoot.length - 1)
 
     // serve client.html
     if (requestUrl === '/') {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -18,9 +18,9 @@ function parseExitCode (buffer, defaultExitCode, failOnEmptyTestSuite) {
 
   const tail = buffer.slice(tailPos)
   const tailStr = tail.toString()
-  if (tailStr.substr(0, tailStr.length - 2) === constant.EXIT_CODE) {
-    const emptyInt = parseInt(tailStr.substr(-2, 1), 10)
-    let exitCode = parseInt(tailStr.substr(-1), 10)
+  if (tailStr.slice(0, -2) === constant.EXIT_CODE) {
+    const emptyInt = parseInt(tailStr.slice(-2, -1), 10)
+    let exitCode = parseInt(tailStr.slice(-1), 10)
     if (failOnEmptyTestSuite === false && emptyInt === 0) {
       log.warn('Test suite was empty.')
       exitCode = 0

--- a/lib/url.js
+++ b/lib/url.js
@@ -19,7 +19,7 @@ class Url {
    * @returns {string} detected file type or empty string
    */
   detectType () {
-    return path.extname(new URL(this.path).pathname).substring(1)
+    return path.extname(new URL(this.path).pathname).slice(1)
   }
 
   toString () {

--- a/static/context.js
+++ b/static/context.js
@@ -123,7 +123,7 @@ exports.isDefined = function (value) {
 
 exports.parseQueryParams = function (locationSearch) {
   var params = {}
-  var pairs = locationSearch.substr(1).split('&')
+  var pairs = locationSearch.slice(1).split('&')
   var keyValue
 
   for (var i = 0; i < pairs.length; i++) {

--- a/static/karma.js
+++ b/static/karma.js
@@ -348,7 +348,7 @@ var socket = io(location.host, {
   reconnectionDelay: 500,
   reconnectionDelayMax: Infinity,
   timeout: BROWSER_SOCKET_TIMEOUT,
-  path: KARMA_PROXY_PATH + KARMA_URL_ROOT.substr(1) + 'socket.io',
+  path: KARMA_PROXY_PATH + KARMA_URL_ROOT.slice(1) + 'socket.io',
   'sync disconnect on unload': true,
   useNativeTimers: true
 })
@@ -565,7 +565,7 @@ exports.isDefined = function (value) {
 
 exports.parseQueryParams = function (locationSearch) {
   var params = {}
-  var pairs = locationSearch.substr(1).split('&')
+  var pairs = locationSearch.slice(1).split('&')
   var keyValue
 
   for (var i = 0; i < pairs.length; i++) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated. While [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) isn't deprecated I replaced it with `slice()` as well.  `slice()` is generally a bit faster (and uses less bites as the name is shorter) and this way we don't have 2 functions which nearly do the same thing in the code.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.