### PR TITLE
fix(client): error out when opening a new tab fails

### DIFF
--- a/client/karma.js
+++ b/client/karma.js
@@ -94,6 +94,9 @@ function Karma (updater, socket, iframe, opener, navigator, location, document) 
           childWindow.close()
         }
         childWindow = opener(url)
+        if (childWindow === null) {
+          self.error('Opening a new tab/window failed, probably because pop-ups are blocked.')
+        }
       // run context on parent element (client_with_context)
       // using window.__karma__.scriptUrls to get the html element strings and load them dynamically
       } else if (url !== 'about:blank') {

--- a/static/karma.js
+++ b/static/karma.js
@@ -104,6 +104,9 @@ function Karma (updater, socket, iframe, opener, navigator, location, document) 
           childWindow.close()
         }
         childWindow = opener(url)
+        if (childWindow === null) {
+          self.error('Opening a new tab/window failed, probably because pop-ups are blocked.')
+        }
       // run context on parent element (client_with_context)
       // using window.__karma__.scriptUrls to get the html element strings and load them dynamically
       } else if (url !== 'about:blank') {


### PR DESCRIPTION
Safari in iOS fails opening a new tab with the `window.open` API. This makes it explicit that that is the culprit, in the right case. Also, it suggests a workaround: enabling pop ups.