### PR TITLE
Add support for Node.js 16 & 18

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
       - run: npm ci
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ env.GITHUB_TOKEN }}
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
       - run: npm ci
       - run: npm run build:check
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12]
+        node: [10, 12, 14, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -48,7 +48,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node: [10, 12, 14]
+        node: [10, 12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/docs/intro/01-installation.md
+++ b/docs/intro/01-installation.md
@@ -5,7 +5,7 @@ Karma runs on [Node.js] and is available as an [npm] package.
 On Mac or Linux we recommend using [NVM](https://github.com/creationix/nvm). On Windows, download Node.js
 from [the official site](https://nodejs.org/) or use the [NVM PowerShell Module](https://www.powershellgallery.com/packages/nvm).
 
-Note: Karma currently works on Node.js **6.x**, **8.x**, and **10.x**. See [FAQ] for more info.
+Karma works on all [LTS releases](https://nodejs.org/en/about/releases/) of Node.js.
 
 ## Installing Karma and plugins
 

--- a/docs/intro/04-faq.md
+++ b/docs/intro/04-faq.md
@@ -27,7 +27,7 @@ The latest stable version from npm (`npm install karma`). See [versioning] for m
 
 
 ### Which version of Node.js does Karma run with?
-Karma works on all active LTS versions of node as specified by the [Node.js Release Working Group](https://github.com/nodejs/Release/blob/master/README.md). The nodejs version numbers are set in the package.json. Older versions of karma work with older versions of nodejs, but are not maintained or updated.
+Karma works on all LTS versions of Node.js as specified by the [Node.js Release Working Group](https://github.com/nodejs/Release/blob/master/README.md). The Node.js version numbers are set in the package.json. Older versions of karma work with older versions of Node.js, but are not maintained or updated.
 
 [mailing list]: https://groups.google.com/d/forum/karma-users
 [karma-ng-scenario]: https://github.com/karma-runner/karma-ng-scenario

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -3,6 +3,7 @@ const { Agent: httpAgent } = require('http')
 const { Agent: httpsAgent } = require('https')
 const httpProxy = require('http-proxy')
 const _ = require('lodash')
+const { lookup } = require('../utils/dns-utils')
 
 const log = require('../logger').create('proxy')
 
@@ -41,7 +42,10 @@ function parseProxyConfig (proxies, config) {
     const port = proxyDetails.port || defaultPorts[proxyDetails.protocol] || config.port
     const changeOrigin = proxyConfiguration.changeOrigin || false
     const Agent = protocol === 'https:' ? httpsAgent : httpAgent
-    const agent = new Agent({ keepAlive: true })
+    const agent = new Agent({
+      keepAlive: true,
+      lookup
+    })
     const proxy = httpProxy.createProxyServer({
       target: { host: hostname, port, protocol },
       xfwd: true,

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -7,6 +7,7 @@ const EventEmitter = require('events').EventEmitter
 const helper = require('./helper')
 const cfg = require('./config')
 const logger = require('./logger')
+const { lookup } = require('./utils/dns-utils')
 const log = logger.create('runner')
 
 function parseExitCode (buffer, defaultExitCode, failOnEmptyTestSuite) {
@@ -74,7 +75,8 @@ function run (cliOptionsOrConfig, done) {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
-    }
+    },
+    lookup
   }
 
   const request = http.request(options, function (response) {

--- a/lib/stopper.js
+++ b/lib/stopper.js
@@ -2,6 +2,7 @@ const http = require('http')
 const cfg = require('./config')
 const logger = require('./logger')
 const helper = require('./helper')
+const { lookup } = require('./utils/dns-utils')
 
 exports.stop = function (cliOptionsOrConfig, done) {
   cliOptionsOrConfig = cliOptionsOrConfig || {}
@@ -42,7 +43,8 @@ exports.stop = function (cliOptionsOrConfig, done) {
     hostname: config.hostname,
     path: config.urlRoot + 'stop',
     port: config.port,
-    method: 'GET'
+    method: 'GET',
+    lookup
   })
 
   request.on('response', function (response) {

--- a/lib/utils/dns-utils.js
+++ b/lib/utils/dns-utils.js
@@ -1,0 +1,11 @@
+const dns = require('dns')
+
+// Node >=17 has different DNS resolution (see
+// https://github.com/nodejs/node/issues/40702), it resolves domains
+// according to the OS settings instead of IPv4-address first. The Karma server
+// only listens on IPv4 address (127.0.0.1) by default, but the requests are
+// sent to `localhost` in several places and `localhost` is resolved into IPv6
+// address (`::`). So the run/stop/proxy request is unable to reach the Karma
+// server and produces an error. To mitigate this issue karma force the
+// IPv4-address first approach in Node >=17 as well.
+module.exports.lookup = (hostname, options, callback) => dns.lookup(hostname, { ...options, verbatim: false }, callback)

--- a/test/e2e/support/proxy.js
+++ b/test/e2e/support/proxy.js
@@ -8,7 +8,7 @@ module.exports = class Proxy {
     this.proxyPathRegExp = null
 
     this.proxy = httpProxy.createProxyServer({
-      target: 'http://localhost:9876'
+      target: 'http://127.0.0.1:9876'
     })
 
     this.proxy.on('error', (err) => {


### PR DESCRIPTION
build: add Node 16 and 18 to the CI matrix

Update documentation, so that it does not become outdated whenever a new version of Node is released.

Test on the current version of Node, so we can spot problems early, but don't claim to support it as current release line sometimes introduces bugs, which are later fixed by Node itself.

Fixes #3728

---

fix: prefer IPv4 addresses when resolving domains

Node 17+ changed the DNS resolution (see https://github.com/nodejs/node/issues/40702), so now it resolves `localhost` according to the OS settings instead of IPv4-address first. The Karma server only listens on IPv4 address (127.0.0.1) by default, but the requests are sent to `localhost` in several places and `localhost` is resolved into IPv6 address (`::`) in Node 17+. So the run/stop/proxy request is unable to reach the Karma server and produces an error. This commit configures karma to use the IPv4-address first approach in newer Node version as well.

In the future major release, we may consider changing defaults to listen on IPv6 address instead, but IPv6 is not supported in Docker on macOS and Windows, so I think we should not rush such a change to make sure karma works there out of the box.

Fixes #3730