### PR TITLE
docs: alternative for local `karma-cli` install

### DIFF
--- a/docs/intro/01-installation.md
+++ b/docs/intro/01-installation.md
@@ -40,6 +40,12 @@ $ npm install -g karma-cli
 
 Then, you can run Karma simply by `karma` from anywhere and it will always run the local version.
 
+Alternatively, you can install `karma-cli` for the current project only and use scripts. First add `"karma": "karma"` to your package.json.
+```bash
+$ npm install karma-cli --save-dev
+$ npm run karma start
+```
+
 
 [Node.js]: https://nodejs.org/
 [npm]: https://www.npmjs.com/package/karma


### PR DESCRIPTION
While installing `karma-cli` globally may commonly make some sense, another alternative is keeping it encapsulated within each individual repository which is also easy enough.