### PR TITLE
docs: Fix a few typos

### DIFF
--- a/context/main.js
+++ b/context/main.js
@@ -12,7 +12,7 @@ var callParentKarmaMethod = ContextKarma.getDirectCallParentKarmaMethod(parentWi
 // DEV: We avoid using this in Internet Explorer as they only support strings
 //   https://caniuse.com/?search=postmessage
 var haveParentAccess = false
-try { haveParentAccess = !!parentWindow.window } catch (err) { /* Ignore errors (likely permisison errors) */ }
+try { haveParentAccess = !!parentWindow.window } catch (err) { /* Ignore errors (likely permission errors) */ }
 if (!haveParentAccess) {
   callParentKarmaMethod = ContextKarma.getPostMessageCallParentKarmaMethod(parentWindow)
 }

--- a/docs/dev/04-public-api.md
+++ b/docs/dev/04-public-api.md
@@ -288,7 +288,7 @@ const karmaConfig = cfg.parseConfig(
 ```
 
 The new behavior in the future will involve throwing exceptions instead of
-exiting the process and aynchronous config files will be supported through the
+exiting the process and asynchronous config files will be supported through the
 use of promises.
 
 ##### New Behavior

--- a/static/context.js
+++ b/static/context.js
@@ -312,7 +312,7 @@ var callParentKarmaMethod = ContextKarma.getDirectCallParentKarmaMethod(parentWi
 // DEV: We avoid using this in Internet Explorer as they only support strings
 //   https://caniuse.com/?search=postmessage
 var haveParentAccess = false
-try { haveParentAccess = !!parentWindow.window } catch (err) { /* Ignore errors (likely permisison errors) */ }
+try { haveParentAccess = !!parentWindow.window } catch (err) { /* Ignore errors (likely permission errors) */ }
 if (!haveParentAccess) {
   callParentKarmaMethod = ContextKarma.getPostMessageCallParentKarmaMethod(parentWindow)
 }


### PR DESCRIPTION
There are small typos in:
- context/main.js
- docs/dev/04-public-api.md
- static/context.js

Fixes:
- Should read `permission` rather than `permisison`.
- Should read `asynchronous` rather than `aynchronous`.