### PR TITLE
fix: set socket.io closeOnBeforeunload option to true

### DIFF
--- a/static/karma.js
+++ b/static/karma.js
@@ -353,7 +353,8 @@ var socket = io(location.host, {
   timeout: BROWSER_SOCKET_TIMEOUT,
   path: KARMA_PROXY_PATH + KARMA_URL_ROOT.slice(1) + 'socket.io',
   'sync disconnect on unload': true,
-  useNativeTimers: true
+  useNativeTimers: true,
+  closeOnBeforeunload: true,
 })
 
 // instantiate the updater of the view


### PR DESCRIPTION
Since this change on socket.io-client: https://github.com/socketio/engine.io-client/commit/a63066bdc8ae9e6746c3113d06c2ead78f4a4851, the default value for closeOnBeforeunload option is now "false".

On Karma.js side, this can lead to error message: "Some of your tests did a full page reload!".

In order to keep the previous behaviour, this commit explicitly sets the closeOnBeforeunload option to "true".