### PR TITLE
Simplify lib/middleware/karma.js

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -18,10 +18,6 @@ const stripHost = require('./strip_host').stripHost
 const common = require('./common')
 
 const VERSION = require('../constants').VERSION
-const SCRIPT_TYPE = {
-  js: 'text/javascript',
-  module: 'module'
-}
 const FILE_TYPES = [
   'css',
   'html',
@@ -185,17 +181,16 @@ function createKarmaMiddleware (
             const integrityAttribute = file.integrity ? ` integrity="${file.integrity}"` : ''
             const crossOriginAttribute = includeCrossOriginAttribute ? ' crossorigin="anonymous"' : ''
             if (fileType === 'css') {
-              scriptTags.push(`<link type="text/css" href="${filePath}" rel="stylesheet"${integrityAttribute}${crossOriginAttribute}>`)
+              scriptTags.push(`<link href="${filePath}" rel="stylesheet"${integrityAttribute}${crossOriginAttribute}>`)
             } else if (fileType === 'dom') {
               scriptTags.push(file.content)
             } else if (fileType === 'html') {
               scriptTags.push(`<link href="${filePath}" rel="import"${integrityAttribute}${crossOriginAttribute}>`)
             } else {
-              const scriptType = (SCRIPT_TYPE[fileType] || 'text/javascript')
               if (fileType === 'module') {
-                scriptTags.push(`<script onerror="throw 'Error loading ${filePath}'" type="${scriptType}" src="${filePath}"${integrityAttribute}${crossOriginAttribute}></script>`)
+                scriptTags.push(`<script onerror="throw 'Error loading ${filePath}'" type="module" src="${filePath}"${integrityAttribute}${crossOriginAttribute}></script>`)
               } else {
-                scriptTags.push(`<script type="${scriptType}" src="${filePath}"${integrityAttribute}${crossOriginAttribute}></script>`)
+                scriptTags.push(`<script src="${filePath}"${integrityAttribute}${crossOriginAttribute}></script>`)
               }
             }
           }


### PR DESCRIPTION
`<script>` defaults to `type="text/javascript"`, so there is no need to specify it in the HTML.

Similarly, `type="text/css"` is the default for `<link rel="stylesheet">` so including it in the HTML is redundant.

This simplifies the code a bit.

https://mathiasbynens.be/notes/html5-levels#type-attributes